### PR TITLE
Fix reference to method in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,7 +66,7 @@ getting *encoded* strings:
    >>> url.raw_path
    '/%D0%BF%D1%83%D1%82%D1%8C'
 
-Human readable representation of URL is available as `~yarl.URL..human_repr()`:
+Human readable representation of URL is available as :meth:`~yarl.URL.human_repr()`:
 
    >>> url.human_repr()
    'https://www.python.org/путь'


### PR DESCRIPTION
This looks wrong (at http://yarl.readthedocs.io/en/latest/):
![ekrano nuotrauka is 2016-09-17 10-12-22](https://cloud.githubusercontent.com/assets/159967/18606677/4248e9bc-7cbf-11e6-95d1-6931a8f592f7.png)
and I hope I got the Sphinx syntax right to fix it.