### PR TITLE
Fix double cython requirement

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,2 @@
 -r requirements-ci.txt
 pytest-sugar==0.7.1
-cython==0.25.1


### PR DESCRIPTION
Otherwise you have error when pip install requirements-dev

```
pip install -r requirements-dev.txt
Double requirement given: cython==0.25.1 (from -r requirements-dev.txt
(line 3)) (already in cython==0.25.1 (from -r requirements-wheel.txt
(line 1)), name='cython')
```