### PR TITLE
Load pytest-runner only if mandatory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import pathlib
+import sys
 import re
 
 from setuptools import setup, Extension
@@ -58,6 +59,12 @@ with fname.open(encoding='utf8') as fp:
 
 install_requires = ['multidict>=2.0']
 
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+if needs_pytest:
+    setup_requires = ['pytest-runner']
+else:
+    setup_requires = []
+
 
 def read(name):
     fname = here / name
@@ -86,7 +93,7 @@ args = dict(
     packages=['yarl'],
     install_requires=install_requires,
     include_package_data=True,
-    setup_requires=['pytest-runner'],
+    setup_requires=setup_requires,
     tests_require=['pytest'],
     ext_modules=extensions,
     cmdclass=dict(build_ext=ve_build_ext))


### PR DESCRIPTION
This PR load pytest runner only if need. Without that you need an internet access to execute setup.py install even if the dependencies are already installed.

The code for detecting if require is from section Conditional Requirement:
https://pypi.python.org/pypi/pytest-runner