### PR TITLE
Fix typos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,7 +60,7 @@ CHANGES
 0.5.1 (2016-11-02)
 ------------------
 
-* Make URL counstruction faster by removing extra classmethod calls
+* Make URL construction faster by removing extra classmethod calls
 
 0.5.0 (2016-11-02)
 ------------------
@@ -96,7 +96,7 @@ CHANGES
 0.3.1 (2016-09-26)
 ------------------
 
-* Support sequience of pairs as with_query() parameter
+* Support sequence of pairs as with_query() parameter
 
 0.3.0 (2016-09-26)
 ------------------
@@ -135,7 +135,7 @@ CHANGES
 0.1.1 (2016-09-06)
 ------------------
 
-* Update REAMDE, old version used obsolete AIP
+* Update README, old version used obsolete API
 
 0.1.0 (2016-09-06)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Url is constructed from ``str``::
    >>> url
    URL('https://www.python.org/~guido?arg=1#frag')
 
-All url parts: *scheme*, *user*, *passsword*, *host*, *port*, *path*,
+All url parts: *scheme*, *user*, *password*, *host*, *port*, *path*,
 *query* and *fragment* are accessible by properties::
 
    >>> url.scheme
@@ -101,11 +101,11 @@ Comparison with other URL libraries
 
 * furl (https://pypi.python.org/pypi/furl)
 
-  The libray has a rich functionality but ``furl`` object is mutable.
+  The library has a rich functionality but ``furl`` object is mutable.
 
   I afraid to pass this object into foreign code: who knows if the
-  code will modifiy my url in a terrible way while I just want to send URL
-  with handy helpers for accessing URL properies.
+  code will modify my url in a terrible way while I just want to send URL
+  with handy helpers for accessing URL properties.
 
   ``furl`` has other non obvious tricky things but the main objection
   is mutability.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,7 +42,7 @@ The library assumes all data uses *UTF-8* for *percent-encoded* tokens.
 
 Unless URL contain the only *ascii* characters there is no differences.
 
-But for *non-ascii* case *encoding* is applyed.
+But for *non-ascii* case *encoding* is applied.
 
 .. doctest::
 
@@ -329,9 +329,9 @@ For *path* and *query* *yarl* supports additional helpers:
 Absolute and relative URLs
 --------------------------
 
-The module supports both absolute an relative URLs.
+The module supports both absolute and relative URLs.
 
-Absulute URL should start from either *scheme* or ``'//'``.
+Absolute URL should start from either *scheme* or ``'//'``.
 
 
 .. method:: URL.is_absolute()
@@ -353,8 +353,8 @@ Absulute URL should start from either *scheme* or ``'//'``.
       False
 
 
-New URL generaion
------------------
+New URL generation
+------------------
 
 URL is an immutable object, every operation described in the
 section generates a new *URL* instance.
@@ -642,7 +642,7 @@ possible.
       Document describing non-ascii domain name encoding.
 
    :rfc:`3987` - Internationalized Resource Identifiers
-      This specifies convertion rules for non-ascii characters in URL.
+      This specifies conversion rules for non-ascii characters in URL.
 
    :rfc:`3986` - Uniform Resource Identifiers
       This is the current standard (STD66). Any changes to :mod:`yarl` module

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Url is constructed from :class:`str`:
    >>> url
    URL('https://www.python.org/~guido?arg=1#frag')
 
-All url parts: *scheme*, *user*, *passsword*, *host*, *port*, *path*,
+All url parts: *scheme*, *user*, *password*, *host*, *port*, *path*,
 *query* and *fragment* are accessible by properties:
 
 .. doctest::
@@ -105,11 +105,11 @@ Comparison with other URL libraries
 
 * furl (https://pypi.python.org/pypi/furl)
 
-  The libray has a rich functionality but ``furl`` object is mutable.
+  The library has a rich functionality but ``furl`` object is mutable.
 
   I afraid to pass this object into foreign code: who knows if the
-  code will modifiy my url in a terrible way while I just want to send URL
-  with handy helpers for accessing URL properies.
+  code will modify my url in a terrible way while I just want to send URL
+  with handy helpers for accessing URL properties.
 
   ``furl`` has other non obvious tricky things but the main objection
   is mutability.
@@ -120,7 +120,7 @@ Comparison with other URL libraries
 
   Every URL change generates a new URL object.
 
-  But the library doesn't any decode/encode transormations leaving end
+  But the library doesn't any decode/encode transformations leaving end
   user to cope with these gory details.
 
 


### PR DESCRIPTION
Found using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).