### PR TITLE
Fix Python 3.6 builds in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
   - make cov
   - make doctest
   - python setup.py check -rm
-  - if python -c "import sys; sys.exit(sys.version_info < (3,5))"; then
+  - if python -c "import sys; sys.exit(sys.version_info < (3,6))"; then
         python setup.py check -s;
     fi
   - mypy yarl --silent-imports

--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-PYTHON_VERSIONS="cp34-cp34m cp35-cp35m"
+PYTHON_VERSIONS="cp34-cp34m cp35-cp35m cp36-cp36m"
 
 echo "Compile wheels"
 for PYTHON in ${PYTHON_VERSIONS}; do


### PR DESCRIPTION
This should fix everything to deal with Python 3.6 wheel building on linux.