### PR TITLE
Do not quote or unquote + if not a query string.

### DIFF
--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -148,6 +148,7 @@ def test_quoting_space(quote):
 
 
 def test_quoting_plus(quote):
+    assert quote('alpha+beta gamma', qs=False) == 'alpha+beta%20gamma'
     assert quote('alpha+beta gamma', qs=True) == 'alpha%2Bbeta+gamma'
     assert quote('alpha+beta gamma', safe='+', qs=True) == 'alpha+beta+gamma'
 
@@ -330,6 +331,10 @@ def test_quote_sub_delims(quote):
 
 def test_requote_sub_delims(quote):
     assert quote("%21%24%26%27%28%29%2A%2B%2C%3B%3D") == "!$&'()*+,;="
+
+
+def test_unquoting_plus(unquote):
+    assert unquote('a+b', qs=False) == 'a+b'
 
 
 def test_unquote_plus_to_space(unquote):

--- a/yarl/_quoting.pyx
+++ b/yarl/_quoting.pyx
@@ -219,7 +219,7 @@ cdef str _do_unquote(str val, str unsafe='', bint qs=False):
             last_pct = ''
 
         if ch == '+':
-            if ch in unsafe:
+            if not qs or ch in unsafe:
                 ret.append('+')
             else:
                 ret.append(' ')

--- a/yarl/quoting.py
+++ b/yarl/quoting.py
@@ -134,7 +134,7 @@ def _py_unquote(val, *, unsafe='', qs=False):
             last_pct = ''
 
         if ch == '+':
-            if ch in unsafe:
+            if not qs or ch in unsafe:
                 ret.append('+')
             else:
                 ret.append(' ')


### PR DESCRIPTION
"+" is entirely legal in URL paths.  Unfortunately unquote() does the wrong thing.  This patch fixes that.  It also adds a test for quote(qs=False) for "+", to be sure it continues to do the right thing.