### PR TITLE
Prevent double unquoting

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1,7 +1,7 @@
 import sys
 import pickle
 import pytest
-from urllib.parse import SplitResult
+from urllib.parse import SplitResult, urlencode
 from multidict import MultiDict, MultiDictProxy
 
 from yarl import URL
@@ -235,6 +235,15 @@ def test_query_repeated_args():
 def test_query_empty_arg():
     url = URL('http://example.com?a')
     assert url.query == MultiDict([('a', '')])
+
+
+def test_query_dont_unqoute_twice():
+    sample_url = 'http://base.place?' + urlencode({'a': '/////'})
+    query = urlencode({'url': sample_url})
+    full_url = 'http://test_url.aha?' + query
+
+    url = URL(full_url)
+    assert url.query['url'] == sample_url
 
 
 def test_raw_fragment_empty():

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -464,7 +464,7 @@ class URL:
         Empty value if URL has no query part.
 
         """
-        ret = MultiDict(parse_qsl(self.query_string, keep_blank_values=True))
+        ret = MultiDict(parse_qsl(self.raw_query_string, keep_blank_values=True))
         return MultiDictProxy(ret)
 
     @property


### PR DESCRIPTION
In current version of yarl we have problem with query args unquoted twice. So If you will pass URL as argument, it will be broken. This PR fixes the problem.