### PR TITLE
Fix with_path leading slash.

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -506,11 +506,6 @@ def test_with_path_empty():
     assert str(url.with_path('')) == 'http://example.com'
 
 
-def test_with_path_slash():
-    url = URL('http://example.com/test')
-    assert str(url.with_path('/')) == 'http://example.com/'
-
-
 def test_with_path_leading_slash():
     url = URL('http://example.com')
     assert url.with_path('test').path == '/test'

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -501,6 +501,21 @@ def test_with_path_fragment():
     assert str(url.with_path('/test')) == 'http://example.com/test'
 
 
+def test_with_path_empty():
+    url = URL('http://example.com/test')
+    assert str(url.with_path('')) == 'http://example.com'
+
+
+def test_with_path_slash():
+    url = URL('http://example.com/test')
+    assert str(url.with_path('/')) == 'http://example.com/'
+
+
+def test_with_path_leading_slash():
+    url = URL('http://example.com')
+    assert url.with_path('test').path == '/test'
+
+
 # with_query
 
 def test_with_query():

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -718,6 +718,8 @@ class URL:
             path = _quote(path, safe='@:', protected='/', strict=self._strict)
             if self.is_absolute():
                 path = _normalize_path(path)
+        if len(path) > 0 and path[0] != '/':
+            path = '/' + path
         return URL(self._val._replace(path=path, query='', fragment=''),
                    encoded=True)
 


### PR DESCRIPTION
This pull request solves the bug of leading slash in URL path.

**How to reproduce?**
```
>>> from yarl import URL
>>> u = URL('http://example.com/path').with_path('new/path')
>>> str(u)
'http://example.com/new/path'
>>> u.path
'new/path'
```
Expecting result is: ``` u.path == '/new/path'```

**Why does this matter?**
This creates a side effect for other methods:
```
>>> u.parts
('/', 'ew', 'path')
>>> u.with_name('name')
URL('http://example.com/ew/name')
```
This creates an incorrect HTTP request header:
```
import asyncio
from aiohttp import ClientSession

from yarl import URL

u = URL('http://bbc.com/news').with_path('sport')

async def main():
    async with ClientSession() as session:
        async with session.get(u):
            pass

asyncio.get_event_loop().run_until_complete(main())
```
```
Traceback (most recent call last):
   ...
aiohttp.client_exceptions.ClientConnectorError: [Errno -2] Cannot connect to host www.bbc.comsport:80 ssl:False [Name or service not known]
```