### PR TITLE
Unsafe encoding for QS fixed. Encode `;` char in value param

### DIFF
--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -113,10 +113,10 @@ def test_with_multidict_with_spaces_and_non_ascii():
 
 def test_with_query_multidict_with_unsafe():
     url = URL('http://example.com/path')
-    url2 = url.with_query({'a+b': '?=+&'})
-    assert url2.raw_query_string == 'a%2Bb=?%3D%2B%26'
-    assert url2.query_string == 'a%2Bb=?%3D%2B%26'
-    assert url2.query == {'a+b': '?=+&'}
+    url2 = url.with_query({'a+b': '?=+&;'})
+    assert url2.raw_query_string == 'a%2Bb=?%3D%2B%26%3B'
+    assert url2.query_string == 'a%2Bb=?%3D%2B%26%3B'
+    assert url2.query == {'a+b': '?=+&;'}
 
 
 def test_with_query_None():

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -760,7 +760,7 @@ class URL:
                 else:
                     raise TypeError("Invalid variable type: mapping value "
                                     "should be str or int, got {!r}".format(v))
-                lst.append(quoter(k, safe='/?:@')+'='+quoter(v, safe='/?:@;'))
+                lst.append(quoter(k, safe='/?:@')+'='+quoter(v, safe='/?:@'))
                 query = '&'.join(lst)
         elif isinstance(query, str):
             query = _quote(query, safe='/?:@',


### PR DESCRIPTION
Current behaviour of YARL does not encode the `;` parameter when it is present in the QS param value. The `;` is not a safe parameter and has to be encoded [1].

The following snippet shows the error (raised via aiohttp):

```python
from yarl import URL
url = URL("http://www.google.com").with_fragment(None)
params = {'foo': 'a;b'}
url2 = url.with_query(params)
url2.query
```

This snippet gets as an output an "invalid" MultiDict

```
<MultiDictProxy('foo': 'a', 'b': '')>
``` 

[1] https://tools.ietf.org/html/rfc3986#section-2.2