### PR TITLE
Share `update_query()` implementation with `with_query()`

### DIFF
--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -16,6 +16,7 @@ def test_with_query():
 def test_update_query():
     url = URL('http://example.com/')
     assert str(url.update_query({'a': '1'})) == 'http://example.com/?a=1'
+    assert str(URL('test').update_query(a=1)) == 'test?a=1'
 
     url = URL('http://example.com/?foo=bar')
     expected_url = URL('http://example.com/?foo=bar&baz=foo')


### PR DESCRIPTION
Close issue https://github.com/aio-libs/yarl/issues/87:
- share implementation
- fixed `TypeError` (`URL('test').update_query(a=1)`)

Benchmark at `master`:
```
Cython quote: 1.361 sec
Python quote: 4.641 sec
Cython unquote: 0.520 sec
Python unquote: 1.682 sec
```

Benchmark at my branch:
```
Cython quote: 1.340 sec
Python quote: 4.428 sec
Cython unquote: 0.495 sec
Python unquote: 1.626 sec
```