### PR TITLE
Fixed import in test_quoting.py

### DIFF
--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -1,14 +1,14 @@
 import pytest
 
-from yarl.quoting import _py_quote, _py_unquote, _quote, _unquote
+from yarl.quoting import _py_quote, _py_unquote, quote, unquote
 
 
-@pytest.fixture(params=[_py_quote, _quote], ids=['py_quote', 'c_quote'])
+@pytest.fixture(params=[_py_quote, quote], ids=['py_quote', 'c_quote'])
 def quote(request):
     return request.param
 
 
-@pytest.fixture(params=[_py_unquote, _unquote],
+@pytest.fixture(params=[_py_unquote, unquote],
                 ids=['py_unquote', 'c_unquote'])
 def unquote(request):
     return request.param

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -747,9 +747,7 @@ class URL:
             quoter = partial(_quote, qs=True, strict=self._strict)
             lst = []
             for k, v in query.items():
-                if isinstance(v, str):
-                    pass
-                elif type(v) == int:  # no subclasses like bool
+                if isinstance(v, (str, int)):  # no subclasses like bool
                     v = str(v)
                 else:
                     raise TypeError("Invalid variable type: mapping value "

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -46,7 +46,7 @@ class cached_property:
         self.wrapped = wrapped
         try:
             self.__doc__ = wrapped.__doc__
-        except:  # pragma: no cover
+        except AttributeError:  # pragma: no cover
             self.__doc__ = ""
         self.name = wrapped.__name__
 
@@ -167,7 +167,7 @@ class URL:
                 else:
                     try:
                         ip = ip_address(netloc)
-                    except:
+                    except ValueError:
                         pass
                     else:
                         if ip.version == 6:
@@ -684,7 +684,7 @@ class URL:
             raise ValueError("host removing is not allowed")
         try:
             ip = ip_address(host)
-        except:
+        except ValueError:
             host = host.encode('idna').decode('ascii')
         else:
             if ip.version == 6:


### PR DESCRIPTION
Tests failed when running on local machine from fresh fork.

Seems like error handing is being done in `quoting.py`:

    try:
        from ._quoting import _quote, _unquote
        quote = _quote
        unquote = _unquote
    except ImportError:  # pragma: no cover
        quote = _py_quote
        unquote = _py_unquote

In order to present a uniform import. Though the test didn't reflect this error handling

CI failed upon first pull request. Due to bare excepts. Added errors in commit

Added fix for issue  https://github.com/aio-libs/yarl/issues/129
   
