### PR TITLE
Percent-encoding for userinfo in _make_netloc classmethod

### DIFF
--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -597,6 +597,8 @@ class URL:
         if password:
             if not user:
                 user = ''
+            user = _quote(user, safe=':', qs=True)
+            password = _quote(user, qs=True)
             user = user + ':' + password
         if user:
             ret = user + '@' + ret


### PR DESCRIPTION
According to [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.2.1) (percent-encoding) and [RFC 2617](https://tools.ietf.org/html/rfc2617#section-2) (colon is safe only for username).