### PR TITLE
Forbid inheritance, replace __init__ with __new__

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -5,6 +5,8 @@ from urllib.parse import SplitResult
 from yarl import URL
 
 
+@pytest.skipif(sys.version < (3, 6),
+               reason="The feature requires Python 3.6+")
 def test_inheritance():
     with pytest.raises(TypeError):
         class MyURL(URL):

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -8,9 +8,13 @@ from yarl import URL
 @pytest.mark.skipif(sys.version_info < (3, 6),
                     reason="The feature requires Python 3.6+")
 def test_inheritance():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as ctx:
         class MyURL(URL):
             pass
+
+    assert ("Inheritance a class "
+            "<class 'test_url.test_inheritance.<locals>.MyURL'> "
+            "from URL is forbidden" == str(ctx.value))
 
 
 def test_is():

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -5,8 +5,8 @@ from urllib.parse import SplitResult
 from yarl import URL
 
 
-@pytest.skipif(sys.version < (3, 6),
-               reason="The feature requires Python 3.6+")
+@pytest.mark.skipif(sys.version_info < (3, 6),
+                    reason="The feature requires Python 3.6+")
 def test_inheritance():
     with pytest.raises(TypeError):
         class MyURL(URL):

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -5,6 +5,18 @@ from urllib.parse import SplitResult
 from yarl import URL
 
 
+def test_inheritance():
+    with pytest.raises(TypeError):
+        class MyURL(URL):
+            pass
+
+
+def test_is():
+    u1 = URL('http://example.com')
+    u2 = URL(u1)
+    assert u1 is u2
+
+
 def test_absolute_url_without_host():
     with pytest.raises(ValueError):
         URL('http://:8080/')

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -226,8 +226,8 @@ class URL:
             return url
 
     def __init_subclass__(cls):
-        raise TypeError("Inheritance a class {} from URL "
-                        "is forbidden")
+        raise TypeError("Inheritance a class {!r} from URL "
+                        "is forbidden".format(cls))
 
     def __str__(self):
         val = self._val


### PR DESCRIPTION
yarl.URL was always considered as **final** class.