### PR TITLE
Make port argument to URL.build optional in stub

### DIFF
--- a/yarl/__init__.pyi
+++ b/yarl/__init__.pyi
@@ -32,7 +32,7 @@ class URL:
 
     @classmethod
     def build(cls, *, scheme: str=..., user: str=..., password: str=...,
-              host: str=..., port: int=..., path: str=...,
+              host: str=..., port: Optional[int]=..., path: str=...,
               query: Mapping[str, str]=..., query_string: str=...,
               fragment: str=..., strict: bool=...) -> URL: ...
 


### PR DESCRIPTION
I have code like this to avoid having ports being redundantly part of my base urls:

```python
        port = None if (req.port in _DEFAULT_PORTS) else req.port

        req.base_url = URL.build(
            host=req.forwarded_host, scheme=req.forwarded_scheme, port=port
        )
```

and that currently gives me an `error: Argument "port" to "build" of "URL" has incompatible type "Optional[Any]"; expected "int"` although None is perfectly valid and also defined as optional on the class.

(this is Falcon in case you wondered)