### PR TITLE
URL::build(): Accept host-only URLs

### DIFF
--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -16,15 +16,27 @@ def test_build_simple():
     assert str(u) == 'http://127.0.0.1'
 
 
-def test_build_scheme_and_host():
-    with pytest.raises(ValueError):
-        URL.build(host='127.0.0.1')
-
+def test_build_with_scheme():
     with pytest.raises(ValueError):
         URL.build(scheme='http')
 
 
+def test_build_with_host():
+    u = URL.build(host='127.0.0.1')
+    assert str(u) == '//127.0.0.1'
+    assert u == URL('//127.0.0.1')
+
+
+def test_build_with_scheme_and_host():
+    u = URL.build(scheme='http', host='127.0.0.1')
+    assert str(u) == 'http://127.0.0.1'
+    assert u == URL('http://127.0.0.1')
+
+
 def test_build_with_port():
+    with pytest.raises(ValueError):
+        URL.build(port=8000)
+
     u = URL.build(scheme='http', host='127.0.0.1', port=8000)
     assert str(u) == 'http://127.0.0.1:8000'
 

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -188,12 +188,12 @@ class URL:
               encoded=False):
         """Creates and returns a new URL"""
 
-        if host and not scheme:
-            raise ValueError(
-                'Can\'t build URL with "host" but without "scheme".')
         if not host and scheme:
             raise ValueError(
                 'Can\'t build URL with "scheme" but without "host".')
+        if port and not host:
+            raise ValueError(
+                'Can\'t build URL with "port" but without "host".')
         if query and query_string:
             raise ValueError(
                 "Only one of \"query\" or \"query_string\" should be passed")


### PR DESCRIPTION
Accept host-only URLs, which are buildable using the parsing method as
`//host-name'.

Also, add check for setting port without a host, along-side test case
for it.