### PR TITLE
URL: Add explicit_port instance property

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -211,7 +211,7 @@ There are two kinds of properties: *decoded* and *encoded* (with
       True
 
 
-.. attribute:: URL.port
+.. attribute:: URL.explicit_port
 
    *explicit_port* part of URL, without scheme-based fallback.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -195,7 +195,7 @@ There are two kinds of properties: *decoded* and *encoded* (with
 
 .. attribute:: URL.port
 
-   *port* part of URL.
+   *port* part of URL, with scheme-based fallback.
 
    ``None`` for relative URLs (:ref:`yarl-api-relative-urls`) or for
    URLs without explicit port and :attr:`URL.scheme` without
@@ -208,6 +208,23 @@ There are two kinds of properties: *decoded* and *encoded* (with
       >>> URL('http://example.com').port
       80
       >>> URL('page.html').port is None
+      True
+
+
+.. attribute:: URL.port
+
+   *explicit_port* part of URL, without scheme-based fallback.
+
+   ``None`` for relative URLs (:ref:`yarl-api-relative-urls`) or for
+   URLs without explicit port.
+
+   .. doctest::
+
+      >>> URL('http://example.com:8080').explicit_port
+      8080
+      >>> URL('http://example.com').explicit_port is None
+      True
+      >>> URL('page.html').explicit_port is None
       True
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -227,6 +227,7 @@ There are two kinds of properties: *decoded* and *encoded* (with
       >>> URL('page.html').explicit_port is None
       True
 
+   .. versionadded:: 1.3
 
 .. attribute:: URL.path
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -203,12 +203,12 @@ def test_ipv4_zone():
     assert url.host == url.raw_host
 
 
-def test_explicit_port():
+def test_port_for_explicit_port():
     url = URL('http://example.com:8888')
     assert 8888 == url.port
 
 
-def test_implicit_port():
+def test_port_for_implicit_port():
     url = URL('http://example.com')
     assert 80 == url.port
 
@@ -221,6 +221,26 @@ def test_port_for_relative_url():
 def test_port_for_unknown_scheme():
     url = URL('unknown://example.com')
     assert url.port is None
+
+
+def test_explicit_port_for_explicit_port():
+    url = URL('http://example.com:8888')
+    assert 8888 == url.explicit_port
+
+
+def test_explicit_port_for_implicit_port():
+    url = URL('http://example.com')
+    assert url.explicit_port is None
+
+
+def test_explicit_port_for_relative_url():
+    url = URL('/path/to')
+    assert url.explicit_port is None
+
+
+def test_explicit_port_for_unknown_scheme():
+    url = URL('unknown://example.com')
+    assert url.explicit_port is None
 
 
 def test_raw_path_string_empty():

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -448,13 +448,22 @@ class URL:
 
     @property
     def port(self):
-        """Port part of URL.
+        """Port part of URL, with scheme-based fallback.
 
         None for relative URLs or URLs without explicit port and
         scheme without default port substitution.
 
         """
         return self._val.port or DEFAULT_PORTS.get(self._val.scheme)
+
+    @property
+    def explicit_port(self):
+        """Port part of URL, without scheme-based fallback.
+
+        None for relative URLs or URLs without explicit port.
+
+        """
+        return self._val.port
 
     @property
     def raw_path(self):


### PR DESCRIPTION
Having access to `explicit_port` makes it easier for working with the
URL instance as a data model, like when building mutable class on top of
`yarl.URL`.

On the other hand, the existing behavior of `port` property is better
for the applications. Therefore, it's better that we keep it the way it
is.