### PR TITLE
Add extra chars to avoid unquoting

### DIFF
--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -132,7 +132,7 @@ class URL:
     __slots__ = ('_cache', '_val')
 
     _QUOTER = _Quoter()
-    _PATH_QUOTER = _Quoter(safe='@:', protected='/+')
+    _PATH_QUOTER = _Quoter(safe='@:', protected='/+&,;')
     _QUERY_QUOTER = _Quoter(safe='?/:@', protected='=+&;', qs=True)
     _QUERY_PART_QUOTER = _Quoter(safe='?/:@', qs=True)
     _FRAGMENT_QUOTER = _Quoter(safe='?/:@')


### PR DESCRIPTION
In some cases when we have already quoted chars: ``&(%26),(%2C);(%3B)`` into path, yarl unquote it to standard representation: ``&,;` this behavior is wrong because server send redirection message with quoted url, but we again unquote it

Fixes #223