### PR TITLE
Makefile: Set all to all steps running on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 script:
   - make cov
   - make doc
-  - python setup.py check -rms
+  - make check
   - make mypy
 
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: test
+all: test doc check mypy
 
 
 .install-deps: $(shell find requirements -type f)
@@ -13,6 +13,10 @@ all: test
 
 flake: .develop
 	flake8 yarl tests setup.py
+
+
+check: flake
+	python setup.py check -rms
 
 
 test: flake


### PR DESCRIPTION
To be able to cover all the test running on CI, including unit tests,
type hint checks, and doctest, setting the `make all` behavior to
include everything, to be able to catch problems locally as much as
possible.