### PR TITLE
[test_url_query] Add failing test for str()

### DIFF
--- a/tests/test_url_query.py
+++ b/tests/test_url_query.py
@@ -1,3 +1,5 @@
+import pytest
+
 from urllib.parse import urlencode
 
 from multidict import MultiDict, MultiDictProxy
@@ -70,3 +72,23 @@ def test_semicolon_as_value():
     u = URL('http://127.0.0.1/?a=1%3Bb=2')
     assert len(u.query) == 1
     assert u.query['a'] == '1;b=2'
+
+
+@pytest.mark.xfail
+# FIXME: Converting a well-encoded URL with embedded URL should return a
+# well-encoded URL again.
+def test_embedded_url():
+    original_url_str = (
+        "https://example.com/something?"
+        "embedded=http%3A%2F%2Ftarget.test%2Fan%2520action%3F"
+        "foo%2520bar%3Dabc%2Bdef%23a%2520fragment"
+        "#pointing"
+    )
+    u = URL(original_url_str)
+
+    assert len(u.query) == 1
+    assert u.query['embedded'] == (
+        'http://target.test/an%20action?'
+        'foo%20bar=abc+def#a%20fragment'
+    )
+    assert str(u) == original_url_str


### PR DESCRIPTION
Add failing test for `URL.__str__()` on an instance with embedded URL
as query value.