### PR TITLE
Issue#168: give friendlier error when port cant be converted to int

### DIFF
--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -164,10 +164,17 @@ class URL:
                 if host is None:
                     raise ValueError(
                         "Invalid URL: host is required for abolute urls.")
+
+                try:
+                    port = val.port
+                except ValueError:
+                    raise ValueError(
+                        "Invalid URL: port can't be converted to integer")
+
                 netloc = cls._make_netloc(val.username,
                                           val.password,
                                           host,
-                                          val.port,
+                                          port,
                                           encode=True)
             path = cls._PATH_QUOTER(val[2])
             if netloc:


### PR DESCRIPTION
Fixes #168 

Few tests for bad port scenario are already present in `test_url_parsing.py`, they already cover current situation. 