### PR TITLE
Minor fixes in test_quoting.py

### DIFF
--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -57,9 +57,9 @@ def test_never_quote(quoter):
     do_not_quote = '' .join(["ABCDEFGHIJKLMNOPQRSTUVWXYZ",
                              "abcdefghijklmnopqrstuvwxyz",
                              "0123456789",
-                             "_.-"])
+                             "_.-~"])
     assert quoter()(do_not_quote) == do_not_quote
-    quoter(qs=True)(do_not_quote) == do_not_quote
+    assert quoter(qs=True)(do_not_quote) == do_not_quote
 
 
 def test_safe(quoter):
@@ -72,7 +72,7 @@ def test_safe(quoter):
 
 
 _SHOULD_QUOTE = [chr(num) for num in range(32)]
-_SHOULD_QUOTE.append('<>#"{}|\^[]`')
+_SHOULD_QUOTE.append(r'<>#"{}|\^[]`')
 _SHOULD_QUOTE.append(chr(127))  # For 0x7F
 SHOULD_QUOTE = ''.join(_SHOULD_QUOTE)
 


### PR DESCRIPTION
**What has been done:**
1. Add raw string identifier - to fix "DeprecationWarning: invalid escape sequence \^"
(SHOULD_QUOTE remains the same)
2. `~` was missing from unquoted chars
3. I think `quoter(qs=True)(do_not_quote) == do_not_quote` without assert was unintended.

It could be the wrong place to ask, but... 
**Some questions**
4. `SHOULD_QUOTE` and `do_not_quote` - why not import from `quoting.py`, it has vars with the same meaning.
5. `test_quoting.py` has one todo item: `# TODO: should it encode percent?`
According to `rfc3986` it has to be encoded. 
Maybe the main concern is to do it's encoding/decoding only once? In that case it deserves its own issue.
6. does `assert s1 is s2` from `def test_quote_fastpath_safe():` has to be `is` instead of `==`?
I read this note about [cython limitations ](http://docs.cython.org/en/latest/src/userguide/limitations.html#identity-vs-equality-for-inferred-literals) , but question remains 