### PR TITLE
Drop explicit py3.8 Travis rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
   include:
   - python: 3.7
     <<: *_xenial
-  - python: nightly
+  - python: 3.8-dev
     <<: *_xenial
   - stage: Deploy
     name: Publishing a source dist to PyPI

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ jobs:
   fast_finish: true
   allow_failures:
   - python: 3.8-dev
-  - python: nightly
   include:
   - python: 3.7
     <<: *_xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ jobs:
   include:
   - python: 3.7
     <<: *_xenial
-  - python: 3.8-dev
-    <<: *_xenial
   - python: nightly
     <<: *_xenial
   - stage: Deploy


### PR DESCRIPTION
Now nightly is essentially the same as 3.8, and will be until Python 3.8 beta.

Let's drop redundant duplication.