### PR TITLE
Support empty password in URL

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -134,7 +134,14 @@ def test_password_non_ascii():
 
 def test_password_without_user():
     url = URL("http://:password@example.com")
+    assert url.user is None
     assert "password" == url.password
+
+
+def test_user_empty_password():
+    url = URL("http://user:@example.com")
+    assert "user" == url.user
+    assert "" == url.password
 
 
 def test_raw_host():

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -187,7 +187,7 @@ class URL:
         *,
         scheme="",
         user="",
-        password="",
+        password=None,
         host="",
         port=None,
         path="",
@@ -673,7 +673,7 @@ class URL:
             ret = host
         if port:
             ret = ret + ":" + str(port)
-        if password:
+        if password is not None:
             if not user:
                 user = ""
             else:


### PR DESCRIPTION
Unlike `urllib.parse.urlsplit`, `yarl.URL` currently does not distinguish `http://user@localhost` and `http://user:@localhost`, returning `None` as `url.password` in both cases. I think that these cases are different and should be handled similar to `urllib.parse.urlsplit` function.