### PR TITLE
Disallow passing NoneType to URL.build

### DIFF
--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -163,7 +163,18 @@ def test_build_with_authority_with_empty_path():
     u = URL.build(scheme="http", host="example.com", path="")
     assert str(u) == "http://example.com"
 
-
 def test_build_with_authority_with_path_without_leading_slash():
     with pytest.raises(ValueError):
         URL.build(scheme="http", host="example.com", path="path_without_leading_slash")
+
+def test_build_with_none_path():
+    with pytest.raises(TypeError):
+        URL.build(scheme="http", host="example.com", path=None)
+
+def test_build_with_none_query_string():
+    with pytest.raises(TypeError):
+        URL.build(scheme="http", host="example.com", query_string=None)
+
+def test_build_with_none_fragment():
+    with pytest.raises(TypeError):
+        URL.build(scheme="http", host="example.com", fragment=None)

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -204,6 +204,8 @@ class URL:
             raise ValueError('Can\'t build URL with "port" but without "host".')
         if query and query_string:
             raise ValueError('Only one of "query" or "query_string" should be passed')
+        if path is None or query_string is None or fragment is None:
+            raise TypeError('NoneType not accepted. Use "".')
 
         if not user and not password and not host and not port:
             netloc = ""

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -205,7 +205,8 @@ class URL:
         if query and query_string:
             raise ValueError('Only one of "query" or "query_string" should be passed')
         if path is None or query_string is None or fragment is None:
-            raise TypeError('NoneType is illegal for "path", "query_string" and "fragment args, use string values instead.')
+            raise TypeError('NoneType is illegal for "path", "query_string" and '
+                            '"fragment" args, use string values instead.')
 
         if not user and not password and not host and not port:
             netloc = ""

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -205,7 +205,7 @@ class URL:
         if query and query_string:
             raise ValueError('Only one of "query" or "query_string" should be passed')
         if path is None or query_string is None or fragment is None:
-            raise TypeError('NoneType not accepted. Use "".')
+            raise TypeError('NoneType is illegal for "path", "query_string" and "fragment args, use string values instead.')
 
         if not user and not password and not host and not port:
             netloc = ""


### PR DESCRIPTION
Unsupported and results in strange behavior of equality operator. See
issue #275.