### PR TITLE
No new if fragment unchanged

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -662,6 +662,18 @@ def test_with_fragment_None():
     assert str(url2) == "http://example.com/path"
 
 
+def test_with_fragment_None_matching():
+    url = URL("http://example.com/path")
+    url2 = url.with_fragment(None)
+    assert url is url2
+
+
+def test_with_fragment_matching():
+    url = URL("http://example.com/path#frag")
+    url2 = url.with_fragment("frag")
+    assert url is url2
+
+
 def test_with_fragment_bad_type():
     url = URL("http://example.com")
     with pytest.raises(TypeError):

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -912,6 +912,8 @@ class URL:
             fragment = ""
         elif not isinstance(fragment, str):
             raise TypeError("Invalid fragment type")
+        if self.fragment == fragment:
+            return self
         return URL(
             self._val._replace(fragment=self._FRAGMENT_QUOTER(fragment)), encoded=True
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Prevent yarl from creating a new `URL` in `with_fragment` if fragment is unchanged

This is a micro-optimization, but one that might bring some benefit to eg a server that makes a lot of requests

While profiling an application i noticed that it had become much more expensive to create request/response objects in recent versions of aiohttp. Some of the overhead is in yarl, and this goes some way to mitigate it.

In my limited perf testing, this change speeds up *creation* of aiohttp `ClientRequest`/`ClientResponse` objects by around 10-20%

Other fields in `URL` may benefit from similar code, but `with_fragment` is called a lot by req/resp

If you are happy to accep the PR i can add info required below

BEFORE:

```
tests/test_comparison.py::test_response_comparison 

> 10000x client RESPONSE created: 0.09966135025024414
> 10000x client RESPONSE (WITH FRAGMENT) created: 0.10220742225646973
> 10000x client RESPONSE (WITH PATH) created: 0.09807991981506348
PASSED
tests/test_comparison.py::test_request_comparison 

> 10000x client REQUEST created: 0.3886384963989258
> 10000x client REQUEST (WITH FRAGMENT) created: 0.39107656478881836
> 10000x client REQUEST (WITH PATH) created: 0.3992602825164795
PASSED



```

AFTER

```


tests/test_comparison.py::test_response_comparison 

> 10000x client RESPONSE created: 0.07283973693847656
> 10000x client RESPONSE (WITH FRAGMENT) created: 0.06992530822753906
> 10000x client RESPONSE (WITH PATH) created: 0.0684511661529541
PASSED
tests/test_comparison.py::test_request_comparison 

> 10000x client REQUEST created: 0.33188772201538086
> 10000x client REQUEST (WITH FRAGMENT) created: 0.3259406089782715
> 10000x client REQUEST (WITH PATH) created: 0.3326609134674072
PASSED




```



<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

I dont believe so

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
