### PR TITLE
Allow user=None in URL.build and sync .pyi with source.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ CHANGES
 ------------------
 
 * Distinguish an empty password in URL from a password not provided at all (#262)
+* Fixed annotations for optional parameters of ``URL.build`` (#309)
 
 1.3.0 (2018-12-11)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ CHANGES
 
 * Distinguish an empty password in URL from a password not provided at all (#262)
 * Fixed annotations for optional parameters of ``URL.build`` (#309)
+* Use None as default value of ``user`` parameter of ``URL.build`` (#309)
 
 1.3.0 (2018-12-11)
 ------------------

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -186,7 +186,7 @@ class URL:
         cls,
         *,
         scheme="",
-        user="",
+        user=None,
         password=None,
         host="",
         port=None,

--- a/yarl/__init__.pyi
+++ b/yarl/__init__.pyi
@@ -38,11 +38,11 @@ class URL:
         *,
         scheme: str = ...,
         user: str = ...,
-        password: str = ...,
+        password: Optional[str] = ...,
         host: str = ...,
         port: Optional[int] = ...,
         path: str = ...,
-        query: Query = ...,
+        query: Optional[Query] = ...,
         query_string: str = ...,
         fragment: str = ...,
         encoded: bool = ...

--- a/yarl/__init__.pyi
+++ b/yarl/__init__.pyi
@@ -37,7 +37,7 @@ class URL:
         cls,
         *,
         scheme: str = ...,
-        user: str = ...,
+        user: Optional[str] = ...,
         password: Optional[str] = ...,
         host: str = ...,
         port: Optional[int] = ...,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix type-check warnings when passing `Optional` arguments to URL.build.

## Are there changes in behavior for the user?

Changes related only to static type checking.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
