### PR TITLE
Include annotation for URL._val

### DIFF
--- a/yarl/__init__.pyi
+++ b/yarl/__init__.pyi
@@ -1,3 +1,5 @@
+from urllib.parse import SplitResult
+
 from typing import overload, Any, Tuple, Optional, Mapping, Union, Sequence, Type
 import multidict
 
@@ -29,6 +31,7 @@ class URL:
     raw_parts: Tuple[str, ...]
     parts: Tuple[str, ...]
     parent: URL
+    _val: SplitResult  # undocumented
     def __init__(
         self, val: Union[str, "URL"] = ..., *, encoded: bool = ...
     ) -> None: ...


### PR DESCRIPTION
I propose adding a type annotation for `URL._val`.  Even though it is a quasi-private attribute, a developer may choose to use it "at their own risk," and this change prevents a mypy error if it is used.

This is a follow-up to a question that I asked here:

> https://stackoverflow.com/q/57975352/7954504

From ["what to include"](https://github.com/python/typeshed/blob/master/CONTRIBUTING.md#what-to-include) portion of the typeshed documentation:

> We accept such undocumented objects because omitting objects can confuse users. Users who see an error like "module X has no attribute Y" will not know whether the error appeared because their code had a bug or because the stub is wrong. Although it may also be helpful for a type checker to point out usage of private objects, we usually prefer false negatives (no errors for wrong code) over false positives (type errors for correct code). In addition, even for private objects a type checker can be helpful in pointing out that an incorrect type was used.