### PR TITLE
Update build badges and CI references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 yarl
 ====
 
-.. image:: https://travis-ci.com/aio-libs/yarl.svg?branch=master
-  :target:  https://travis-ci.com/aio-libs/yarl
+.. image:: https://dev.azure.com/aio-libs/yarl/_apis/build/status/CI?branchName=master
+  :target: https://dev.azure.com/aio-libs/yarl/_build/latest?definitionId=7&branchName=master
   :align: right
 
 .. image:: https://codecov.io/gh/aio-libs/yarl/branch/master/graph/badge.svg
@@ -132,7 +132,7 @@ Please file an issue on the `bug tracker
 <https://github.com/aio-libs/yarl/issues>`_ if you have found a bug
 or have some suggestion in order to improve the library.
 
-The library uses `Travis <https://travis-ci.org/aio-libs/yarl>`_ for
+The library uses `Azure Pipelines <https://dev.azure.com/aio-libs/yarl>`_ for
 Continuous Integration.
 
 Discussion list

--- a/docs/_templates/about.html
+++ b/docs/_templates/about.html
@@ -1,0 +1,8 @@
+{%- include "alabaster/about.html" %}
+
+<p>
+    <a class="badge" href="https://dev.azure.com/aio-libs/yarl">
+        <img alt="https://dev.azure.com/aio-libs/yarl/_apis/build/status/CI?branchName=master"
+            src="https://dev.azure.com/aio-libs/yarl/_apis/build/status/CI?branchName=master" />
+    </a>
+</p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -166,7 +166,6 @@ html_theme_options = {
     'github_button': True,
     'github_type': 'star',
     'github_banner': True,
-    'travis_button': True,
     'codecov_button': True,
     'pre_bg': '#FFF6E5',
     'note_bg': '#E5ECD1',

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -133,7 +133,7 @@ Please file an issue on the `bug tracker
 <https://github.com/aio-libs/yarl/issues>`_ if you have found a bug
 or have some suggestion in order to improve the library.
 
-The library uses `Travis <https://travis-ci.org/aio-libs/yarl>`_ for
+The library uses `Azure Pipelines <https://dev.azure.com/aio-libs/yarl>`_ for
 Continuous Integration.
 
 Discussion list

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -1,2 +1,2 @@
 -r doc.txt
-sphinxcontrib-spelling==4.3.0; platform_system!="Windows"  # We only use it in Travis CI
+sphinxcontrib-spelling==4.3.0; platform_system!="Windows"  # We only use it in Azure CI

--- a/tools/build-wheels.sh
+++ b/tools/build-wheels.sh
@@ -87,5 +87,3 @@ for PYTHON in ${PYTHON_VERSIONS}; do
     /opt/python/${PYTHON}/bin/pip install "$package_name" --no-index -f "file://${WHEELHOUSE_DIR}"
     /opt/python/${PYTHON}/bin/py.test ${WORKDIR_PATH}/tests
 done
-
-chown -R --reference="${WORKDIR_PATH}/.travis.yml" "${WORKDIR_PATH}"


### PR DESCRIPTION
## What do these changes do?

Badge on the README and readthedocs currently says the build is failing. However, it's pointing to travis, which was obviously replaced with azure pipelines.
This PR replaces travis references and badges with azure pipelines.

## Are there changes in behavior for the user?

Nope.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written (**N/A**)
- [x] Unit tests for the changes exist (**N/A**)
- [x] Documentation reflects the changes (**That's all there is XD**)
- [x] Add a new news fragment into the `CHANGES` folder (**Don't think this applies**)
