### PR TITLE
Workaround for missing str.isascii() in Python 3.6

### DIFF
--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -683,13 +683,18 @@ class URL:
             return host
 
     else:
-        # the same bug without isascii check
+        # work around for missing str.isascii() in Python <= 3.6
         @classmethod
         def _encode_host(cls, host):
             try:
                 ip, sep, zone = host.partition("%")
                 ip = ip_address(ip)
             except ValueError:
+                for char in host:
+                    if ord(char) > 127:
+                        break
+                else:
+                    return host
                 try:
                     host = idna.encode(host, uts46=True).decode("ascii")
                 except UnicodeError:

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -691,7 +691,7 @@ class URL:
                 ip = ip_address(ip)
             except ValueError:
                 for char in host:
-                    if ord(char) > 127:
+                    if char > "\x7f":
                         break
                 else:
                     return host


### PR DESCRIPTION
## What do these changes do?

This would allow for checking if `host` contains only ASCII characters with Python 3.6 and 3.5. 

## Are there changes in behavior for the user?

Performance tests with `%timeit` in `ipython` on Python 3.6 show that this check takes about 0.18 μs, if the first character in `host` is non-ASCII. 0.87 μs if the 10th character is the first non-ASCII character and 1.46 μs if the 20th character is non-ASCII. The times are about the same, if `host` is purely ASCII and 1, 10 or 20 characters long, respectively. 

While this is quite a bit slower than `str.isascii()` on Python 3.8 on the same machine (about 0.038 μs, independ of length or position of the characters) it is about 25 times faster than running IDNA encoding needlessly: for 20 characters `idna.encode(host, uts46=True).decode("ascii")` takes about 40 μs if `host` is ASCII.

If some unicode character is found, the added time is negligible in comparison to the time needed for encoding: on 20 characters it takes 64 μs if one character is Unicode and about 85 - 150 μs if it contains only Unicode characters (There seems to be quite a spread depending on the characters used). So about 0.1 - 2.3 % more time, depending on where the first Unicode character is placed and how many there ares.

## Related issue number

#388 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (Tested by existing tests)
- [x] Documentation reflects the changes (No effect on user facing documentation)