### PR TITLE
Support for boolean parameter parsing

### DIFF
--- a/CHANGES/401.feature
+++ b/CHANGES/401.feature
@@ -1,0 +1,1 @@
+Allows for parameter parsing of booleans with URL.with_query.

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -14,6 +14,7 @@ def test_with_query():
     assert str(url.with_query({"a": "1"})) == "http://example.com/?a=1"
 
 
+
 def test_update_query():
     url = URL("http://example.com/")
     assert str(url.update_query({"a": "1"})) == "http://example.com/?a=1"
@@ -125,8 +126,7 @@ def test_with_query_non_str():
 
 def test_with_query_bool():
     url = URL("http://example.com")
-    with pytest.raises(TypeError):
-        url.with_query({"a": True})
+    assert str(url.with_query({"a": True})) == "http://example.com/?a=true"
 
 
 def test_with_query_none():

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -909,8 +909,8 @@ class URL:
     def with_query(self, *args, **kwargs):
         """Return a new URL with query part replaced.
 
-        Accepts any Mapping (e.g. dict, multidict.MultiDict instances)
-        or str, autoencode the argument if needed.
+        Accepts any Mapping (e.g. dict, multidict.MultiDict instances),
+        str, or bool; autoencode the argument if needed.
 
         A sequence of (key, value) pairs is supported as well.
 

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -858,6 +858,8 @@ class URL:
             return v
         if type(v) is int:  # no subclasses like bool
             return str(v)
+        if isinstance(v, bool):
+            return "true" if v else "false"
         raise TypeError(
             "Invalid variable type: value "
             "should be str or int, got {!r} "


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This pull request allows for parameter parsing of booleans in URL.with_query.

## Are there changes in behavior for the user?

TypeError will no longer be thrown for booleans in URL.with_query.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
