### PR TITLE
Fix URL parsing with Python 3.8.1 and 2.7.15

### DIFF
--- a/CHANGES/409.bugfix
+++ b/CHANGES/409.bugfix
@@ -1,0 +1,1 @@
+Fix tests with newer Python (3.7.6, 3.8.1 and 3.9.0+).

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -40,9 +40,15 @@ class TestScheme:
 
     def test_no_scheme1(self):
         u = URL("google.com:80")
-        assert u.scheme == ""
-        assert u.host is None
-        assert u.path == "google.com:80"
+        # See: https://bugs.python.org/issue27657
+        if sys.version_info[:3] == (3, 7, 6) or sys.version_info[:3] == (3, 8, 1) or sys.version_info >= (3, 9, 0):
+            assert u.scheme == "google.com"
+            assert u.host is None
+            assert u.path == "80"
+        else:
+            assert u.scheme == ""
+            assert u.host is None
+            assert u.path == "google.com:80"
         assert u.query_string == ""
         assert u.fragment == ""
 


### PR DESCRIPTION
## What do these changes do?

URL parsing has been changed in newer Python releases, see: https://bugs.python.org/issue27657

## Are there changes in behavior for the user?

No, just test fix.

## Related issue number

None.

## Checklist

- [X] I think the code is well written
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
