### PR TITLE
Fix an arg mistake in the `with_fragment()` method signature doc

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -615,7 +615,7 @@ section generates a new *URL* instance.
 
       All multiple key/value pairs are applied to the multi-dictionary.
 
-.. method:: URL.with_fragment(port)
+.. method:: URL.with_fragment(fragment)
 
    Return a new URL with *fragment* replaced, auto-encode *fragment* if needed.
 


### PR DESCRIPTION
Do this because it confused me when I tried to read the docs.

<!-- Thank you for your contribution! -->

## What do these changes do?

Fix a typo in the user documentation.

## Are there changes in behavior for the user?

No.

## Related issue number

No.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
