### PR TITLE
Support quoting list values in mappings

### DIFF
--- a/CHANGES/443.feature
+++ b/CHANGES/443.feature
@@ -1,6 +1,5 @@
-These changes fix https://github.com/aio-libs/aiohttp/issues/4714, that is,
-we now support the use of lists and tuples when quoting mappings such as
-Python's builtin dict. As an example from the tests:
+Allow use of sequences such as :class:`list` and :class:`tuple` in the values
+of a mapping such as :class:`dict` to represent that a key has many values:
 
     url = URL("http://example.com")
     assert url.with_query({"a": [1, 2]}) == URL("http://example.com/?a=1&a=2")

--- a/CHANGES/443.feature
+++ b/CHANGES/443.feature
@@ -1,0 +1,6 @@
+These changes fix https://github.com/aio-libs/aiohttp/issues/4714, that is,
+we now support the use of lists and tuples when quoting mappings such as
+Python's builtin dict. As an example from the tests:
+
+    url = URL("http://example.com")
+    assert url.with_query({"a": [1, 2]}) == URL("http://example.com/?a=1&a=2")

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -547,6 +547,9 @@ section generates a new *URL* instance.
 
       The library accepts :class:`str` and :class:`int` as query argument values.
 
+      If a mapping such as :class:`dict` is used, the values may also be
+      :class:`list` or :class:`tuple` to represent a key has many values.
+
       Please see :ref:`yarl-bools-support` for the reason why :class:`bool` is not
       supported out-of-the-box.
 
@@ -556,6 +559,8 @@ section generates a new *URL* instance.
       URL('http://example.com/path?c=d')
       >>> URL('http://example.com/path?a=b').with_query({'c': 'd'})
       URL('http://example.com/path?c=d')
+      >>> URL('http://example.com/path?a=b').with_query({'c': [1, 2]})
+      URL('http://example.com/path?c=1&c=2')
       >>> URL('http://example.com/path?a=b').with_query({'кл': 'зн'})
       URL('http://example.com/path?%D0%BA%D0%BB=%D0%B7%D0%BD')
       >>> URL('http://example.com/path?a=b').with_query(None)
@@ -591,6 +596,9 @@ section generates a new *URL* instance.
 
       The library accepts :class:`str` and :class:`int` as query argument values.
 
+      If a mapping such as :class:`dict` is used, the values may also be
+      :class:`list` or :class:`tuple` to represent a key has many values.
+
       Please see :ref:`yarl-bools-support` for the reason why :class:`bool` is not
       supported out-of-the-box.
 
@@ -600,6 +608,8 @@ section generates a new *URL* instance.
       URL('http://example.com/path?a=b&c=d')
       >>> URL('http://example.com/path?a=b').update_query({'c': 'd'})
       URL('http://example.com/path?a=b&c=d')
+      >>> URL('http://example.com/path?a=b').update_query({'c': [1, 2]})
+      URL('http://example.com/path?a=b&c=1&c=2')
       >>> URL('http://example.com/path?a=b').update_query({'кл': 'зн'})
       URL('http://example.com/path?a=b&%D0%BA%D0%BB=%D0%B7%D0%BD')
       >>> URL('http://example.com/path?a=b&b=1').update_query(b='2')

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -122,6 +122,7 @@ def test_with_query_list_int():
     [
         pytest.param({"a": [1, 2]}, "?a=1&a=2", id="list"),
         pytest.param({"a": (1, 2)}, "?a=1&a=2", id="tuple"),
+        pytest.param({"a[]": [1, 2]}, "?a[]=1&a[]=2", id="key with braces"),
         pytest.param({"a": ["1", 2]}, "?a=1&a=2", id="mixed types"),
         pytest.param({"a": 1, "b": [2, 3]}, "?a=1&b=2&b=3", id="single then list"),
         pytest.param({"a": [1, 2], "b": 3}, "?a=1&a=2&b=3", id="list then single"),

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -134,12 +134,14 @@ def test_with_query_sequence_mixed_types():
 
 def test_with_query_sequence_single_then_list():
     url = URL("http://example.com")
-    assert url.with_query({"a": 1, "b": [2, 3]}) == URL("http://example.com/?a=1&b=2&b=3")
+    expected = URL("http://example.com/?a=1&b=2&b=3")
+    assert url.with_query({"a": 1, "b": [2, 3]}) == expected
 
 
 def test_with_query_sequence_list_then_single():
     url = URL("http://example.com")
-    assert url.with_query({"a": [1, 2], "b": 3}) == URL("http://example.com/?a=1&a=2&b=3")
+    expected = URL("http://example.com/?a=1&a=2&b=3")
+    assert url.with_query({"a": [1, 2], "b": 3}) == expected
 
 
 def test_with_query_sequence_nested_sequence():

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -120,25 +120,26 @@ def test_with_query_list_int():
 @pytest.mark.parametrize(
     ("query", "expected"),
     [
-        pytest.param({"a": []}, "?", id="empty list"),
-        pytest.param({"a": ()}, "?", id="empty tuple"),
-        pytest.param({"a": [1]}, "?a=1", id="single list"),
-        pytest.param({"a": (1,)}, "?a=1", id="single tuple"),
-        pytest.param({"a": [1, 2]}, "?a=1&a=2", id="list"),
-        pytest.param({"a": (1, 2)}, "?a=1&a=2", id="tuple"),
-        pytest.param({"a[]": [1, 2]}, "?a[]=1&a[]=2", id="key with braces"),
-        pytest.param({"&": [1, 2]}, "?%26=1&%26=2", id="quote key"),
-        pytest.param({"a": ["1", 2]}, "?a=1&a=2", id="mixed types"),
-        pytest.param({"&": ["=", 2]}, "?%26=%3D&%26=2", id="quote key and value"),
-        pytest.param({"a": 1, "b": [2, 3]}, "?a=1&b=2&b=3", id="single then list"),
-        pytest.param({"a": [1, 2], "b": 3}, "?a=1&a=2&b=3", id="list then single"),
-        pytest.param({"a": ["1&a=2", 3]}, "?a=1%26a%3D2&a=3", id="ampersand then int"),
-        pytest.param({"a": [1, "2&a=3"]}, "?a=1&a=2%26a%3D3", id="int then ampersand"),
+        pytest.param({"a": []}, "", id="empty list"),
+        pytest.param({"a": ()}, "", id="empty tuple"),
+        pytest.param({"a": [1]}, "/?a=1", id="single list"),
+        pytest.param({"a": (1,)}, "/?a=1", id="single tuple"),
+        pytest.param({"a": [1, 2]}, "/?a=1&a=2", id="list"),
+        pytest.param({"a": (1, 2)}, "/?a=1&a=2", id="tuple"),
+        pytest.param({"a[]": [1, 2]}, "/?a[]=1&a[]=2", id="key with braces"),
+        pytest.param({"&": [1, 2]}, "/?%26=1&%26=2", id="quote key"),
+        pytest.param({"a": ["1", 2]}, "/?a=1&a=2", id="mixed types"),
+        pytest.param({"&": ["=", 2]}, "/?%26=%3D&%26=2", id="quote key and value"),
+        pytest.param({"a": 1, "b": [2, 3]}, "/?a=1&b=2&b=3", id="single then list"),
+        pytest.param({"a": [1, 2], "b": 3}, "/?a=1&a=2&b=3", id="list then single"),
+        pytest.param({"a": ["1&a=2", 3]}, "/?a=1%26a%3D2&a=3", id="ampersand then int"),
+        pytest.param({"a": [1, "2&a=3"]}, "/?a=1&a=2%26a%3D3", id="int then ampersand"),
     ],
 )
 def test_with_query_sequence(query, expected):
     url = URL("http://example.com")
-    assert url.with_query(query) == URL("http://example.com/" + expected)
+    expected = "http://example.com{expected}".format_map(locals())
+    assert str(url.with_query(query)) == expected
 
 
 @pytest.mark.parametrize(
@@ -234,7 +235,7 @@ def test_with_query_memoryview():
 
 
 @pytest.mark.parametrize(
-    ("query" , "expected"),
+    ("query", "expected"),
     [
         pytest.param([("key", "1;2;3")], "?key=1%3B2%3B3", id="tuple list semicolon"),
         pytest.param({"key": "1;2;3"}, "?key=1%3B2%3B3", id="mapping semicolon"),

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -117,6 +117,43 @@ def test_with_query_list_int():
     assert str(url.with_query([("a", 1)])) == "http://example.com/?a=1"
 
 
+def test_with_query_sequence():
+    url = URL("http://example.com")
+    assert url.with_query({"a": [1, 2]}) == URL("http://example.com/?a=1&a=2")
+
+
+def test_with_query_sequence_tuple():
+    url = URL("http://example.com")
+    assert url.with_query({"a": (1, 2)}) == URL("http://example.com/?a=1&a=2")
+
+
+def test_with_query_sequence_mixed_types():
+    url = URL("http://example.com")
+    assert url.with_query({"a": ["1", 2]}) == URL("http://example.com/?a=1&a=2")
+
+
+def test_with_query_sequence_single_then_list():
+    url = URL("http://example.com")
+    assert url.with_query({"a": 1, "b": [2, 3]}) == URL("http://example.com/?a=1&b=2&b=3")
+
+
+def test_with_query_sequence_list_then_single():
+    url = URL("http://example.com")
+    assert url.with_query({"a": [1, 2], "b": 3}) == URL("http://example.com/?a=1&a=2&b=3")
+
+
+def test_with_query_sequence_nested_sequence():
+    url = URL("http://example.com")
+    with pytest.raises(TypeError):
+        url.with_query({"a": [[1]]})
+
+
+def test_with_query_sequence_using_pairs():
+    url = URL("http://example.com")
+    with pytest.raises(TypeError):
+        url.with_query([("a", [1, 2])])
+
+
 def test_with_query_non_str():
     url = URL("http://example.com")
     with pytest.raises(TypeError):

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -120,6 +120,10 @@ def test_with_query_list_int():
 @pytest.mark.parametrize(
     "query,expected",
     [
+        pytest.param({"a": []}, "?", id="empty list"),
+        pytest.param({"a": ()}, "?", id="empty tuple"),
+        pytest.param({"a": [1]}, "?a=1", id="single list"),
+        pytest.param({"a": (1,)}, "?a=1", id="single tuple"),
         pytest.param({"a": [1, 2]}, "?a=1&a=2", id="list"),
         pytest.param({"a": (1, 2)}, "?a=1&a=2", id="tuple"),
         pytest.param({"a[]": [1, 2]}, "?a[]=1&a[]=2", id="key with braces"),

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -126,7 +126,7 @@ def test_with_query_list_int():
         pytest.param({"a": (1,)}, "/?a=1", id="single tuple"),
         pytest.param({"a": [1, 2]}, "/?a=1&a=2", id="list"),
         pytest.param({"a": (1, 2)}, "/?a=1&a=2", id="tuple"),
-        pytest.param({"a[]": [1, 2]}, "/?a[]=1&a[]=2", id="key with braces"),
+        pytest.param({"a[]": [1, 2]}, "/?a%5B%5D=1&a%5B%5D=2", id="key with braces"),
         pytest.param({"&": [1, 2]}, "/?%26=1&%26=2", id="quote key"),
         pytest.param({"a": ["1", 2]}, "/?a=1&a=2", id="mixed types"),
         pytest.param({"&": ["=", 2]}, "/?%26=%3D&%26=2", id="quote key and value"),
@@ -243,6 +243,12 @@ def test_with_query_memoryview():
         pytest.param({"key": "1&a=2"}, "?key=1%26a%3D2", id="mapping ampersand"),
         pytest.param([("&", "=")], "?%26=%3D", id="tuple list quote key"),
         pytest.param({"&": "="}, "?%26=%3D", id="mapping quote key"),
+        pytest.param([("a[]", "3")], "?a%5B%5D=3", id="quote one key braces",),
+        pytest.param(
+            [("a[]", "3"), ("a[]", "4")],
+            "?a%5B%5D=3&a%5B%5D=4",
+            id="quote many key braces",
+        ),
     ],
 )
 def test_with_query_params(query, expected):

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -226,16 +226,19 @@ def test_with_query_memoryview():
         url.with_query(memoryview(b"123"))
 
 
-def test_with_query_params():
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        pytest.param([("key", "1;2;3")], "?key=1%3B2%3B3", id="tuple list semicolon"),
+        pytest.param({"key": "1;2;3"}, "?key=1%3B2%3B3", id="mapping semicolon"),
+        pytest.param([("key", "1&a=2")], "?key=1%26a%3D2", id="tuple list ampersand"),
+        pytest.param({"key": "1&a=2"}, "?key=1%26a%3D2", id="mapping ampersand"),
+    ],
+)
+def test_with_query_params(query, expected):
     url = URL("http://example.com/get")
-    url2 = url.with_query([("key", "1;2;3")])
-    assert str(url2) == "http://example.com/get?key=1%3B2%3B3"
-
-
-def test_with_query_params2():
-    url = URL("http://example.com/get")
-    url2 = url.with_query({"key": "1;2;3"})
-    assert str(url2) == "http://example.com/get?key=1%3B2%3B3"
+    url2 = url.with_query(query)
+    assert str(url2) == ("http://example.com/get" + expected)
 
 
 def test_with_query_only():

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -123,7 +123,9 @@ def test_with_query_list_int():
         pytest.param({"a": [1, 2]}, "?a=1&a=2", id="list"),
         pytest.param({"a": (1, 2)}, "?a=1&a=2", id="tuple"),
         pytest.param({"a[]": [1, 2]}, "?a[]=1&a[]=2", id="key with braces"),
+        pytest.param({"&": [1, 2]}, "?%26=1&%26=2", id="quote key"),
         pytest.param({"a": ["1", 2]}, "?a=1&a=2", id="mixed types"),
+        pytest.param({"&": ["=", 2]}, "?%26=%3D&%26=2", id="quote key and value"),
         pytest.param({"a": 1, "b": [2, 3]}, "?a=1&b=2&b=3", id="single then list"),
         pytest.param({"a": [1, 2], "b": 3}, "?a=1&a=2&b=3", id="list then single"),
         pytest.param({"a": ["1&a=2", 3]}, "?a=1%26a%3D2&a=3", id="ampersand then int"),
@@ -234,6 +236,8 @@ def test_with_query_memoryview():
         pytest.param({"key": "1;2;3"}, "?key=1%3B2%3B3", id="mapping semicolon"),
         pytest.param([("key", "1&a=2")], "?key=1%26a%3D2", id="tuple list ampersand"),
         pytest.param({"key": "1&a=2"}, "?key=1%26a%3D2", id="mapping ampersand"),
+        pytest.param([("&", "=")], "?%26=%3D", id="tuple list quote key"),
+        pytest.param({"&": "="}, "?%26=%3D", id="mapping quote key"),
     ],
 )
 def test_with_query_params(query, expected):

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -117,22 +117,36 @@ def test_with_query_list_int():
     assert str(url.with_query([("a", 1)])) == "http://example.com/?a=1"
 
 
-@pytest.mark.parametrize("query,expected", [
-    ({"a": [1, 2]}, "http://example.com/?a=1&a=2"),
-    ({"a": (1, 2)}, "http://example.com/?a=1&a=2"),
-    ({"a": ["1", 2]}, "http://example.com/?a=1&a=2"),
-    ({"a": 1, "b": [2, 3]}, "http://example.com/?a=1&b=2&b=3"),
-    ({"a": [1, 2], "b": 3}, "http://example.com/?a=1&a=2&b=3"),
-])
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        pytest.param({"a": [1, 2]}, "http://example.com/?a=1&a=2", id="list"),
+        pytest.param({"a": (1, 2)}, "http://example.com/?a=1&a=2", id="tuple"),
+        pytest.param({"a": ["1", 2]}, "http://example.com/?a=1&a=2", id="mixed types"),
+        pytest.param(
+            {"a": 1, "b": [2, 3]},
+            "http://example.com/?a=1&b=2&b=3",
+            id="single then list",
+        ),
+        pytest.param(
+            {"a": [1, 2], "b": 3},
+            "http://example.com/?a=1&a=2&b=3",
+            id="list then single",
+        ),
+    ],
+)
 def test_with_query_sequence(query, expected):
     url = URL("http://example.com")
     assert url.with_query(query) == URL(expected)
 
 
-@pytest.mark.parametrize("query", [
-    {"a": [[1]]},
-    [("a", [1, 2])],
-])
+@pytest.mark.parametrize(
+    "query",
+    [
+        pytest.param({"a": [[1]]}, id="nested"),
+        pytest.param([("a", [1, 2])], id="tuple list"),
+    ],
+)
 def test_with_query_sequence_invalid_use(query):
     url = URL("http://example.com")
     with pytest.raises(TypeError):

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -120,24 +120,16 @@ def test_with_query_list_int():
 @pytest.mark.parametrize(
     "query,expected",
     [
-        pytest.param({"a": [1, 2]}, "http://example.com/?a=1&a=2", id="list"),
-        pytest.param({"a": (1, 2)}, "http://example.com/?a=1&a=2", id="tuple"),
-        pytest.param({"a": ["1", 2]}, "http://example.com/?a=1&a=2", id="mixed types"),
-        pytest.param(
-            {"a": 1, "b": [2, 3]},
-            "http://example.com/?a=1&b=2&b=3",
-            id="single then list",
-        ),
-        pytest.param(
-            {"a": [1, 2], "b": 3},
-            "http://example.com/?a=1&a=2&b=3",
-            id="list then single",
-        ),
+        pytest.param({"a": [1, 2]}, "?a=1&a=2", id="list"),
+        pytest.param({"a": (1, 2)}, "?a=1&a=2", id="tuple"),
+        pytest.param({"a": ["1", 2]}, "?a=1&a=2", id="mixed types"),
+        pytest.param({"a": 1, "b": [2, 3]}, "?a=1&b=2&b=3", id="single then list",),
+        pytest.param({"a": [1, 2], "b": 3}, "?a=1&a=2&b=3", id="list then single",),
     ],
 )
 def test_with_query_sequence(query, expected):
     url = URL("http://example.com")
-    assert url.with_query(query) == URL(expected)
+    assert url.with_query(query) == URL("http://example.com/" + expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -143,7 +143,7 @@ def test_with_query_sequence(query, expected):
 )
 def test_with_query_sequence_invalid_use(query):
     url = URL("http://example.com")
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="Invalid variable type"):
         url.with_query(query)
 
 

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -118,7 +118,7 @@ def test_with_query_list_int():
 
 
 @pytest.mark.parametrize(
-    "query,expected",
+    ("query", "expected"),
     [
         pytest.param({"a": []}, "?", id="empty list"),
         pytest.param({"a": ()}, "?", id="empty tuple"),
@@ -234,7 +234,7 @@ def test_with_query_memoryview():
 
 
 @pytest.mark.parametrize(
-    "query,expected",
+    ("query" , "expected"),
     [
         pytest.param([("key", "1;2;3")], "?key=1%3B2%3B3", id="tuple list semicolon"),
         pytest.param({"key": "1;2;3"}, "?key=1%3B2%3B3", id="mapping semicolon"),

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -123,8 +123,10 @@ def test_with_query_list_int():
         pytest.param({"a": [1, 2]}, "?a=1&a=2", id="list"),
         pytest.param({"a": (1, 2)}, "?a=1&a=2", id="tuple"),
         pytest.param({"a": ["1", 2]}, "?a=1&a=2", id="mixed types"),
-        pytest.param({"a": 1, "b": [2, 3]}, "?a=1&b=2&b=3", id="single then list",),
-        pytest.param({"a": [1, 2], "b": 3}, "?a=1&a=2&b=3", id="list then single",),
+        pytest.param({"a": 1, "b": [2, 3]}, "?a=1&b=2&b=3", id="single then list"),
+        pytest.param({"a": [1, 2], "b": 3}, "?a=1&a=2&b=3", id="list then single"),
+        pytest.param({"a": ["1&a=2", 3]}, "?a=1%26a%3D2&a=3", id="ampersand then int"),
+        pytest.param({"a": [1, "2&a=3"]}, "?a=1&a=2%26a%3D3", id="int then ampersand"),
     ],
 )
 def test_with_query_sequence(query, expected):

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -117,43 +117,26 @@ def test_with_query_list_int():
     assert str(url.with_query([("a", 1)])) == "http://example.com/?a=1"
 
 
-def test_with_query_sequence():
+@pytest.mark.parametrize("query,expected", [
+    ({"a": [1, 2]}, "http://example.com/?a=1&a=2"),
+    ({"a": (1, 2)}, "http://example.com/?a=1&a=2"),
+    ({"a": ["1", 2]}, "http://example.com/?a=1&a=2"),
+    ({"a": 1, "b": [2, 3]}, "http://example.com/?a=1&b=2&b=3"),
+    ({"a": [1, 2], "b": 3}, "http://example.com/?a=1&a=2&b=3"),
+])
+def test_with_query_sequence(query, expected):
     url = URL("http://example.com")
-    assert url.with_query({"a": [1, 2]}) == URL("http://example.com/?a=1&a=2")
+    assert url.with_query(query) == URL(expected)
 
 
-def test_with_query_sequence_tuple():
-    url = URL("http://example.com")
-    assert url.with_query({"a": (1, 2)}) == URL("http://example.com/?a=1&a=2")
-
-
-def test_with_query_sequence_mixed_types():
-    url = URL("http://example.com")
-    assert url.with_query({"a": ["1", 2]}) == URL("http://example.com/?a=1&a=2")
-
-
-def test_with_query_sequence_single_then_list():
-    url = URL("http://example.com")
-    expected = URL("http://example.com/?a=1&b=2&b=3")
-    assert url.with_query({"a": 1, "b": [2, 3]}) == expected
-
-
-def test_with_query_sequence_list_then_single():
-    url = URL("http://example.com")
-    expected = URL("http://example.com/?a=1&a=2&b=3")
-    assert url.with_query({"a": [1, 2], "b": 3}) == expected
-
-
-def test_with_query_sequence_nested_sequence():
+@pytest.mark.parametrize("query", [
+    {"a": [[1]]},
+    [("a", [1, 2])],
+])
+def test_with_query_sequence_invalid_use(query):
     url = URL("http://example.com")
     with pytest.raises(TypeError):
-        url.with_query({"a": [[1]]})
-
-
-def test_with_query_sequence_using_pairs():
-    url = URL("http://example.com")
-    with pytest.raises(TypeError):
-        url.with_query([("a", [1, 2])])
+        url.with_query(query)
 
 
 def test_with_query_non_str():


### PR DESCRIPTION
## What do these changes do?

These changes resolve aio-libs/aiohttp#4714.

## Are there changes in behavior for the user?

Yes, users can now use lists or tuples when quoting mappings.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
