### PR TITLE
Fix [] was being escaped in query key position

### DIFF
--- a/CHANGES/445.bugfix
+++ b/CHANGES/445.bugfix
@@ -1,0 +1,1 @@
+Fix unintended quoting of braces (``[]``) in the keys of a query.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -575,7 +575,7 @@ section generates a new *URL* instance.
       URL('http://example.com/path?b=2')
       >>> URL('http://example.com/path?a[]=1&b[]=2')\
       ...     .with_query([("a[]", "b"), ("a[]", "c")])
-      URL('http://example.com/?a[]=b&a[]=c')
+      URL('http://example.com/path?a[]=b&a[]=c')
 
    .. versionchanged:: 1.4.3
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -439,6 +439,10 @@ section generates a new *URL* instance.
       >>> URL.build(scheme="http", host="example.com", query_string="a=b")
       URL('http://example.com/?a=b')
 
+      >>> URL.build(scheme="http", host="example.com",
+      ...           query=[("a[]", "b"), ("a[]", "c")])
+      URL('http://example.com/?a[]=b&a[]=c')
+
       >>> URL.build()
       URL('')
 
@@ -451,6 +455,11 @@ section generates a new *URL* instance.
 
    .. note::
       Only one of ``query`` or ``query_string`` should be passed then AssertionError will be raised.
+
+   .. versionchanged:: 1.4.3
+
+      The ``'[]'`` characters are not escaped in the keys of the query
+      because some endpoints expect those to be present when specifying arrays.
 
 .. method:: URL.with_scheme(scheme)
 
@@ -564,6 +573,14 @@ section generates a new *URL* instance.
       URL('http://example.com/path?b=2')
       >>> URL('http://example.com/path?a=b&b=1').with_query([('b', '2')])
       URL('http://example.com/path?b=2')
+      >>> URL('http://example.com/path?a[]=1&b[]=2')\
+      ...     .with_query([("a[]", "b"), ("a[]", "c")])
+      URL('http://example.com/?a[]=b&a[]=c')
+
+   .. versionchanged:: 1.4.3
+
+      The ``'[]'`` characters are not escaped in the keys of the query
+      because some endpoints expect those to be present when specifying arrays.
 
 .. method:: URL.update_query(query)
             URL.update_query(**kwargs)
@@ -610,10 +627,18 @@ section generates a new *URL* instance.
       URL('http://example.com/path?a=b&c=d')
       >>> URL('http://example.com/path?a=b').update_query('c=d&c=f')
       URL('http://example.com/path?a=b&c=d&c=f')
+      >>> URL('http://example.com/path?a=b')\
+      ...     .update_query([("c[]", "d"), ("c[]", "e")])
+      URL('http://example.com/path?a=b&c[]=d&c[]=e')
 
    .. versionchanged:: 1.0
 
       All multiple key/value pairs are applied to the multi-dictionary.
+
+   .. versionchanged:: 1.4.3
+
+      The ``'[]'`` characters are not escaped in the keys of the query
+      because some endpoints expect those to be present when specifying arrays.
 
 .. method:: URL.with_fragment(fragment)
 

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -219,3 +219,9 @@ def test_update_query_multiple_keys():
     u2 = url.update_query([("a", "3"), ("a", "4")])
 
     assert str(u2) == "http://example.com/path?a=3&a=4"
+
+
+def test_with_query_no_escape_braces():
+    url = URL("http://example.com/get")
+    url2 = url.with_query([("a[]", "3"), ("a[]", "4")])
+    assert str(url2) == "http://example.com/get?a[]=3&a[]=4"

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -126,7 +126,8 @@ class URL:
     _QUOTER = _Quoter()
     _PATH_QUOTER = _Quoter(safe="@:", protected="/+")
     _QUERY_QUOTER = _Quoter(safe="?/:@", protected="=+&;", qs=True)
-    _QUERY_PART_QUOTER = _Quoter(safe="?/:@", qs=True)
+    _QUERY_PART_KEY_QUOTER = _Quoter(safe="?/:@[]", qs=True)
+    _QUERY_PART_VALUE_QUOTER = _Quoter(safe="?/:@", qs=True)
     _FRAGMENT_QUOTER = _Quoter(safe="?/:@")
 
     _UNQUOTER = _Unquoter()
@@ -881,9 +882,11 @@ class URL:
         if query is None:
             query = ""
         elif isinstance(query, Mapping):
-            quoter = self._QUERY_PART_QUOTER
+            key_quoter = self._QUERY_PART_KEY_QUOTER
+            val_quoter = self._QUERY_PART_VALUE_QUOTER
             query = "&".join(
-                quoter(k) + "=" + quoter(self._query_var(v)) for k, v in query.items()
+                key_quoter(k) + "=" + val_quoter(self._query_var(v))
+                for k, v in query.items()
             )
         elif isinstance(query, str):
             query = self._QUERY_QUOTER(query)
@@ -892,9 +895,10 @@ class URL:
                 "Invalid query type: bytes, bytearray and " "memoryview are forbidden"
             )
         elif isinstance(query, Sequence):
-            quoter = self._QUERY_PART_QUOTER
+            key_quoter = self._QUERY_PART_KEY_QUOTER
+            val_quoter = self._QUERY_PART_VALUE_QUOTER
             query = "&".join(
-                quoter(k) + "=" + quoter(self._query_var(v)) for k, v in query
+                key_quoter(k) + "=" + val_quoter(self._query_var(v)) for k, v in query
             )
         else:
             raise TypeError(


### PR DESCRIPTION
## What do these changes do?

These changes fix a bug where `[]` was being escaped when used in the key of queries, namely:

```python
def test_with_query_no_escape_braces():
    url = URL("http://example.com/get")
    url2 = url.with_query([("a[]", "3"), ("a[]", "4")])
    assert str(url2) == "http://example.com/get?a[]=3&a[]=4"
```

## Are there changes in behavior for the user?

Yes, if users were relying on unintended, buggy behaviour (`[]` being escaped) this change may cause issues in their code.

## Related issue number

None as far as I know.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
