### PR TITLE
fix requoting query components

### DIFF
--- a/CHANGES/426.bugfix
+++ b/CHANGES/426.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where query component, passed in a form of mapping or sequence, is unquoted in unexpected way.

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -93,6 +93,8 @@ def test_default_quoting_percent(quoter):
     assert "%25" == result
     result = quoter(qs=True)("%25")
     assert "%25" == result
+    result = quoter(requote=False)("%25")
+    assert "%2525" == result
 
 
 def test_default_quoting_partial(quoter):
@@ -324,7 +326,7 @@ def test_unquote_plus_to_space_unsafe(unquoter):
     assert unquoter(unsafe="+", qs=True)("a+b") == "a+b"
 
 
-def test_qoute_qs_with_colon(quoter):
+def test_quote_qs_with_colon(quoter):
     s = quoter(safe="=+&?/:@", qs=True)("next=http%3A//example.com/")
     assert s == "next=http://example.com/"
 

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -263,6 +263,12 @@ def test_with_query_only():
     assert str(url2) == "?key=value"
 
 
+def test_with_query_complex_url():
+    target_url = "http://example.com/?game=bulls+%26+cows"
+    url = URL("/redir").with_query({"t": target_url})
+    assert url.query["t"] == target_url
+
+
 def test_update_query_multiple_keys():
     url = URL("http://example.com/path?a=1&a=2")
     u2 = url.update_query([("a", "3"), ("a", "4")])

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -126,7 +126,7 @@ class URL:
     _QUOTER = _Quoter()
     _PATH_QUOTER = _Quoter(safe="@:", protected="/+")
     _QUERY_QUOTER = _Quoter(safe="?/:@", protected="=+&;", qs=True)
-    _QUERY_PART_QUOTER = _Quoter(safe="?/:@", qs=True)
+    _QUERY_PART_QUOTER = _Quoter(safe="?/:@", qs=True, requote=False)
     _FRAGMENT_QUOTER = _Quoter(safe="?/:@")
 
     _UNQUOTER = _Unquoter()

--- a/yarl/_quoting.pyx
+++ b/yarl/_quoting.pyx
@@ -185,14 +185,18 @@ cdef inline int _write_utf8(Writer* writer, Py_UCS4 symbol):
 
 cdef class _Quoter:
     cdef bint _qs
+    cdef bint _requote
 
     cdef uint8_t _safe_table[16]
     cdef uint8_t _protected_table[16]
 
-    def __init__(self, *, str safe='', str protected='', bint qs=False):
+    def __init__(
+            self, *, str safe='', str protected='', bint qs=False, bint requote=True,
+    ):
         cdef Py_UCS4 ch
 
         self._qs = qs
+        self._requote = requote
 
         if not self._qs:
             memcpy(self._safe_table,
@@ -268,7 +272,7 @@ cdef class _Quoter:
                         raise
                 continue
 
-            elif ch == '%':
+            elif ch == '%' and self._requote:
                 has_pct = 1
                 continue
 

--- a/yarl/quoting.py
+++ b/yarl/quoting.py
@@ -26,11 +26,17 @@ _IS_HEX = re.compile(b"[A-Z0-9][A-Z0-9]")
 
 class _Quoter:
     def __init__(
-        self, *, safe: str = "", protected: str = "", qs: bool = False
+        self,
+        *,
+        safe: str = "",
+        protected: str = "",
+        qs: bool = False,
+        requote: bool = True
     ) -> None:
         self._safe = safe
         self._protected = protected
         self._qs = qs
+        self._requote = requote
 
     def __call__(self, val: Optional[str]) -> Optional[str]:
         if val is None:
@@ -88,7 +94,7 @@ class _Quoter:
 
                 continue
 
-            elif ch == ord("%"):
+            elif ch == ord("%") and self._requote:
                 pct.clear()
                 pct.append(ch)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes fix a bug where query component, passed in a form of mapping or sequence, is unquoted in unexpected way.
```python
def test_with_query_complex_url():
    target_url = "http://example.com/?game=bulls+%26+cows"
    url = URL("/redir").with_query({"t": target_url})
    assert url.query["t"] == target_url
```

## Are there changes in behavior for the user?

User will now be able to use any string as query component in `URL.with_query`, `URL.update_query` and `URL.build`.
Which will be properly encoded.

## Related issue number

Fixes #426 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`