### PR TITLE
Require typing_extensions for py<3.8 only

### DIFF
--- a/CHANGES/484.misc
+++ b/CHANGES/484.misc
@@ -1,0 +1,1 @@
+Do not require typing_extensions on Python 3.8 and newer.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,5 +2,5 @@ pytest-cov>=2.3.1
 pytest==5.4.3
 multidict==4.7.6
 idna==2.10
-typing_extensions==3.7.4.2
+typing_extensions==3.7.4.2;python_version<"3.8"
 -e .

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,11 @@ with fname.open(encoding="utf8") as fp:
     except IndexError:
         raise RuntimeError("Unable to determine version.")
 
-install_requires = ["multidict>=4.0", "idna>=2.0", "typing_extensions>=3.7.4"]
+install_requires = [
+    "multidict>=4.0",
+    "idna>=2.0",
+    'typing_extensions>=3.7.4;python_version<"3.8"',
+]
 
 
 def read(name):

--- a/yarl/__init__.pyi
+++ b/yarl/__init__.pyi
@@ -1,7 +1,12 @@
 from typing import overload, Any, Tuple, Optional, Mapping, Union, Sequence, Type
-from typing_extensions import TypedDict, Final, final
 import multidict
 from functools import _CacheInfo
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict, Final, final
+else:
+    from typing_extensions import TypedDict, Final, final
 
 _QueryVariable = Union[str, int]
 _Query = Union[


### PR DESCRIPTION
## What do these changes do?

They make it possible to run on py3.8+ without external `typing_extensions`. This also fixes support for py3.9 where typing_extensions don't work (yet).

## Are there changes in behavior for the user?

Nope.

## Related issue number

Nope.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
