### PR TITLE
Allow int Subclasses in Query

### DIFF
--- a/CHANGES/492.feature
+++ b/CHANGES/492.feature
@@ -1,0 +1,1 @@
+Allow for int and float subclasses in query, while still denying bool.

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -159,11 +159,16 @@ class _CStr(str):
     pass
 
 
-class _CInt(int):
+class _EmptyStrEr:
+    def __str__(self):
+        return ""
+
+
+class _CInt(int, _EmptyStrEr):
     pass
 
 
-class _CFloat(float):
+class _CFloat(float, _EmptyStrEr):
     pass
 
 
@@ -185,7 +190,12 @@ def test_with_query_valid_type(value, expected):
 
 
 @pytest.mark.parametrize(
-    ("value"), [pytest.param(True, id="bool"), pytest.param(None, id="none")]
+    ("value"),
+    [
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none"),
+        pytest.param(float("inf"), id="non-finite float"),
+    ],
 )
 def test_with_query_invalid_type(value):
     url = URL("http://example.com")

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -155,9 +155,16 @@ def test_with_query_sequence_invalid_use(query):
         url.with_query(query)
 
 
-class _CStr(str): pass
-class _CInt(int): pass
-class _CFloat(float): pass
+class _CStr(str):
+    pass
+
+
+class _CInt(int):
+    pass
+
+
+class _CFloat(float):
+    pass
 
 
 @pytest.mark.parametrize(
@@ -168,8 +175,8 @@ class _CFloat(float): pass
         pytest.param(1, "1", id="int"),
         pytest.param(_CInt(1), "1", id="custom int"),
         pytest.param(1.1, "1.1", id="float"),
-        pytest.param(_CFloat(1.1), "1.1", id="custom float")
-    ]
+        pytest.param(_CFloat(1.1), "1.1", id="custom float"),
+    ],
 )
 def test_with_query_valid_type(value, expected):
     url = URL("http://example.com")
@@ -178,11 +185,7 @@ def test_with_query_valid_type(value, expected):
 
 
 @pytest.mark.parametrize(
-    ("value"),
-    [
-        pytest.param(True, id="bool"),
-        pytest.param(None, id="none")
-    ]
+    ("value"), [pytest.param(True, id="bool"), pytest.param(None, id="none")]
 )
 def test_with_query_invalid_type(value):
     url = URL("http://example.com")
@@ -198,8 +201,8 @@ def test_with_query_invalid_type(value):
         pytest.param(1, "1", id="int"),
         pytest.param(_CInt(1), "1", id="custom int"),
         pytest.param(1.1, "1.1", id="float"),
-        pytest.param(_CFloat(1.1), "1.1", id="custom float")
-    ]
+        pytest.param(_CFloat(1.1), "1.1", id="custom float"),
+    ],
 )
 def test_with_query_list_valid_type(value, expected):
     url = URL("http://example.com")
@@ -208,11 +211,7 @@ def test_with_query_list_valid_type(value, expected):
 
 
 @pytest.mark.parametrize(
-    ("value"),
-    [
-        pytest.param(True, id="bool"),
-        pytest.param(None, id="none")
-    ]
+    ("value"), [pytest.param(True, id="bool"), pytest.param(None, id="none")]
 )
 def test_with_query_list_invalid_type(value):
     url = URL("http://example.com")

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -155,34 +155,69 @@ def test_with_query_sequence_invalid_use(query):
         url.with_query(query)
 
 
-def test_with_query_non_str():
+class _CStr(str): pass
+class _CInt(int): pass
+class _CFloat(float): pass
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("1", "1", id="str"),
+        pytest.param(_CStr("1"), "1", id="custom str"),
+        pytest.param(1, "1", id="int"),
+        pytest.param(_CInt(1), "1", id="custom int"),
+        pytest.param(1.1, "1.1", id="float"),
+        pytest.param(_CFloat(1.1), "1.1", id="custom float")
+    ]
+)
+def test_with_query_valid_type(value, expected):
+    url = URL("http://example.com")
+    expected = "http://example.com/?a={expected}".format_map(locals())
+    assert str(url.with_query({"a": value})) == expected
+
+
+@pytest.mark.parametrize(
+    ("value"),
+    [
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none")
+    ]
+)
+def test_with_query_invalid_type(value):
     url = URL("http://example.com")
     with pytest.raises(TypeError):
-        url.with_query({"a": 1.1})
+        url.with_query({"a": value})
 
 
-def test_with_query_bool():
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("1", "1", id="str"),
+        pytest.param(_CStr("1"), "1", id="custom str"),
+        pytest.param(1, "1", id="int"),
+        pytest.param(_CInt(1), "1", id="custom int"),
+        pytest.param(1.1, "1.1", id="float"),
+        pytest.param(_CFloat(1.1), "1.1", id="custom float")
+    ]
+)
+def test_with_query_list_valid_type(value, expected):
+    url = URL("http://example.com")
+    expected = "http://example.com/?a={expected}".format_map(locals())
+    assert str(url.with_query([("a", value)])) == expected
+
+
+@pytest.mark.parametrize(
+    ("value"),
+    [
+        pytest.param(True, id="bool"),
+        pytest.param(None, id="none")
+    ]
+)
+def test_with_query_list_invalid_type(value):
     url = URL("http://example.com")
     with pytest.raises(TypeError):
-        url.with_query({"a": True})
-
-
-def test_with_query_none():
-    url = URL("http://example.com")
-    with pytest.raises(TypeError):
-        url.with_query({"a": None})
-
-
-def test_with_query_list_non_str():
-    url = URL("http://example.com")
-    with pytest.raises(TypeError):
-        url.with_query([("a", 1.0)])
-
-
-def test_with_query_list_bool():
-    url = URL("http://example.com")
-    with pytest.raises(TypeError):
-        url.with_query([("a", False)])
+        url.with_query([("a", value)])
 
 
 def test_with_query_multidict():

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -8,6 +8,8 @@ from urllib.parse import SplitResult, parse_qsl, urljoin, urlsplit, urlunsplit
 from multidict import MultiDict, MultiDictProxy
 import idna
 
+import math
+
 
 from ._quoting import _Quoter, _Unquoter
 
@@ -905,8 +907,10 @@ class URL:
         cls = type(v)
         if issubclass(cls, str):
             return v
-        if issubclass(cls, (int, float)) and not cls is bool:
-            return int.__str__(v) # same as float.__str__
+        if issubclass(cls, (int, float)) and cls is not bool:
+            if not math.isfinite(v):
+                raise TypeError("Value should be finite")
+            return int.__str__(v)  # same as float.__str__
         raise TypeError(
             "Invalid variable type: value "
             "should be str, int or float, got {!r} "

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -904,11 +904,11 @@ class URL:
     def _query_var(v):
         if isinstance(v, str):
             return v
-        if isinstance(v, int) and not isinstance(v, bool):  # no subclasses like bool
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
             return str(v)
         raise TypeError(
             "Invalid variable type: value "
-            "should be str or int, got {!r} "
+            "should be str, int or float, got {!r} "
             "of type {}".format(v, type(v))
         )
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -902,14 +902,15 @@ class URL:
 
     @staticmethod
     def _query_var(v):
-        if isinstance(v, str):
+        cls = type(v)
+        if issubclass(cls, str):
             return v
-        if isinstance(v, (int, float)) and not isinstance(v, bool):
-            return str(v)
+        if issubclass(cls, (int, float)) and not cls is bool:
+            return int.__str__(v) # same as float.__str__
         raise TypeError(
             "Invalid variable type: value "
             "should be str, int or float, got {!r} "
-            "of type {}".format(v, type(v))
+            "of type {}".format(v, cls)
         )
 
     def _get_str_query(self, *args, **kwargs):

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -904,7 +904,7 @@ class URL:
     def _query_var(v):
         if isinstance(v, str):
             return v
-        if type(v) is int:  # no subclasses like bool
+        if isinstance(v, int) and not isinstance(v, bool):  # no subclasses like bool
             return str(v)
         raise TypeError(
             "Invalid variable type: value "


### PR DESCRIPTION
I have found myself having to do explicit type conversions of `int` subclasses that should definitely work.

## What do these changes do?

This new check allows all `int` subclasses through except `bool`, which should obviously be rejected.

## Are there changes in behavior for the user?

Nope. I can't imagine backward compatibility being an issue.

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
