### PR TITLE
Fix the Cython implementation for requoting a single percent.

### DIFF
--- a/CHANGES/514.bugfix
+++ b/CHANGES/514.bugfix
@@ -1,0 +1,1 @@
+Fixed  requoting a single percent followed by a percent-encoded character in the Cython implementation.

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -44,8 +44,28 @@ def test_quote_unfinished_tail_percent_non_strict(quoter):
     assert quoter()("%") == "%25"
 
 
-def test_quote_unfinished_tail_non_strict(quoter):
+def test_quote_unfinished_tail_digit_non_strict(quoter):
     assert quoter()("%2") == "%252"
+
+
+def test_quote_unfinished_tail_safe_non_strict(quoter):
+    assert quoter()("%x") == "%25x"
+
+
+def test_quote_unfinished_tail_unsafe_non_strict(quoter):
+    assert quoter()("%#") == "%25%23"
+
+
+def test_quote_unfinished_tail_non_ascii_non_strict(quoter):
+    assert quoter()("%ß") == "%25%C3%9F"
+
+
+def test_quote_unfinished_tail_non_ascii2_non_strict(quoter):
+    assert quoter()("%€") == "%25%E2%82%AC"
+
+
+def test_quote_unfinished_tail_non_ascii3_non_strict(quoter):
+    assert quoter()("%🐍") == "%25%F0%9F%90%8D"
 
 
 def test_quote_from_bytes(quoter):
@@ -307,6 +327,34 @@ def test_quote_non_ascii(quoter):
 
 def test_quote_non_ascii2(quoter):
     assert quoter()("a%F8b") == "a%F8b"
+
+
+def test_quote_percent_percent_encoded(quoter):
+    assert quoter()("%%3f") == "%25%3F"
+
+
+def test_quote_percent_digit_percent_encoded(quoter):
+    assert quoter()("%2%3f") == "%252%3F"
+
+
+def test_quote_percent_safe_percent_encoded(quoter):
+    assert quoter()("%x%3f") == "%25x%3F"
+
+
+def test_quote_percent_unsafe_percent_encoded(quoter):
+    assert quoter()("%#%3f") == "%25%23%3F"
+
+
+def test_quote_percent_non_ascii_percent_encoded(quoter):
+    assert quoter()("%ß%3f") == "%25%C3%9F%3F"
+
+
+def test_quote_percent_non_ascii2_percent_encoded(quoter):
+    assert quoter()("%€%3f") == "%25%E2%82%AC%3F"
+
+
+def test_quote_percent_non_ascii3_percent_encoded(quoter):
+    assert quoter()("%🐍%3f") == "%25%F0%9F%90%8D%3F"
 
 
 class StrLike(str):

--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -39,6 +39,10 @@ cdef inline int _from_hex(Py_UCS4 v):
         return -1
 
 
+cdef inline int _is_lower_hex(Py_UCS4 v):
+    return 'a' <= v <= 'f'
+
+
 cdef inline Py_UCS4 _restore_ch(Py_UCS4 d1, Py_UCS4 d2):
     cdef int digit1 = _from_hex(d1)
     if digit1 < 0:
@@ -124,26 +128,6 @@ cdef inline int _write_pct(Writer* writer, uint8_t ch, bint changed):
     if _write_char(writer, _to_hex(<uint8_t>ch >> 4), changed) < 0:
         return -1
     return _write_char(writer, _to_hex(<uint8_t>ch & 0x0f), changed)
-
-
-cdef inline int _write_percent(Writer* writer):
-    if _write_char(writer, '%', True) < 0:
-        return -1
-    if _write_char(writer, '2', True) < 0:
-        return -1
-    return _write_char(writer, '5', True)
-
-
-cdef inline int _write_pct_check(Writer* writer, Py_UCS4 ch, Py_UCS4 pct[]):
-    cdef Py_UCS4 pct1 = _to_hex(<uint8_t>ch >> 4)
-    cdef Py_UCS4 pct2 = _to_hex(<uint8_t>ch & 0x0f)
-    cdef bint changed = pct[0] != pct1 or pct[1] != pct2
-
-    if _write_char(writer, '%', changed) < 0:
-        return -1
-    if _write_char(writer, pct1, changed) < 0:
-        return -1
-    return _write_char(writer, pct2, changed)
 
 
 cdef inline int _write_utf8(Writer* writer, Py_UCS4 symbol):
@@ -236,27 +220,17 @@ cdef class _Quoter:
 
     cdef str _do_quote(self, str val, Writer *writer):
         cdef Py_UCS4 ch
-        cdef int has_pct = 0
-        cdef Py_UCS4 pct[2]
+        cdef int changed
         cdef int idx = 0
+        cdef int length = len(val)
 
-        for ch in val:
-            if has_pct:
-                pct[has_pct-1] = ch
-                has_pct += 1
-                if has_pct == 3:
-                    ch = _restore_ch(pct[0], pct[1])
-                    has_pct = 0
-
-                    if ch == <Py_UCS4>-1:
-                        if _write_percent(writer) < 0:
-                            raise
-                        if self._write(writer, pct[0]) < 0:
-                            raise
-                        if self._write(writer, pct[1]) < 0:
-                            raise
-                        continue
-
+        while idx < length:
+            ch = val[idx]
+            idx += 1
+            if ch == '%' and self._requote and idx <= length - 2:
+                ch = _restore_ch(val[idx], val[idx + 1])
+                if ch != <Py_UCS4>-1:
+                    idx += 2
                     if ch < 128:
                         if bit_at(self._protected_table, ch):
                             if _write_pct(writer, ch, True) < 0:
@@ -268,23 +242,16 @@ cdef class _Quoter:
                                 raise
                             continue
 
-                    if _write_pct_check(writer, ch, pct) < 0:
+                    changed = (_is_lower_hex(val[idx - 2]) or
+                               _is_lower_hex(val[idx - 1]))
+                    if _write_pct(writer, ch, changed) < 0:
                         raise
-                continue
-
-            elif ch == '%' and self._requote:
-                has_pct = 1
-                continue
+                    continue
+                else:
+                    ch = '%'
 
             if self._write(writer, ch) < 0:
                 raise
-
-        if has_pct:
-            if _write_percent(writer) < 0:
-                raise
-            if has_pct > 1:  # the value is 2
-                if self._write(writer, ch) < 0:
-                    raise
 
         if not writer.changed:
             return val


### PR DESCRIPTION
Fixed cases "%%xx" and "%a%xx".

Closes #514.
