### PR TITLE
Fix some errors in unquoter

### DIFF
--- a/CHANGES/516.bugfix
+++ b/CHANGES/516.bugfix
@@ -1,0 +1,1 @@
+Fix ValueError when decoding ``%`` which is not followed by two hexadecimal digits.

--- a/CHANGES/520.bugfix
+++ b/CHANGES/520.bugfix
@@ -1,0 +1,1 @@
+Fix decoding ``%`` followed by a space and hexadecimal digit.

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -182,25 +182,29 @@ def test_unquoting(num, unquoter):
         assert expect == result
 
 
-@pytest.mark.xfail
-# FIXME: Expected value should be the same as given.
+# Expected value should be the same as given.
 # See https://url.spec.whatwg.org/#percent-encoded-bytes
-def test_unquoting_bad_percent_escapes_1(unquoter):
-    assert "%" == unquoter()("%")
-
-
-@pytest.mark.xfail
-# FIXME: Expected value should be the same as given.
-# See https://url.spec.whatwg.org/#percent-encoded-bytes
-def test_unquoting_bad_percent_escapes_2(unquoter):
-    assert "%x" == unquoter()("%x")
-
-
-@pytest.mark.xfail
-# FIXME: Expected value should be the same as given.
-# See https://url.spec.whatwg.org/#percent-encoded-bytes
-def test_unquoting_bad_percent_escapes_3(unquoter):
-    assert "%xa" == unquoter()("%xa")
+@pytest.mark.parametrize(
+    ("input", "expected"),
+    [
+        ("%", "%"),
+        ("%2", "%2"),
+        ("%x", "%x"),
+        ("%€", "%€"),
+        ("%2x", "%2x"),
+        ("%2 ", "%2 "),
+        ("% 2", "% 2"),
+        ("%xa", "%xa"),
+        ("%%", "%%"),
+        ("%%3f", "%?"),
+        ("%2%", "%2%"),
+        ("%2%3f", "%2?"),
+        ("%x%3f", "%x?"),
+        ("%€%3f", "%€?"),
+    ],
+)
+def test_unquoting_bad_percent_escapes(unquoter, input, expected):
+    assert unquoter()(input) == expected
 
 
 @pytest.mark.xfail

--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -355,13 +355,13 @@ cdef class _Unquoter:
 
             if ch == '%' and idx <= length - 2:
                 ch = _restore_ch(val[idx], val[idx + 1])
-                if ch == <Py_UCS4>-1:
-                    ret.append("%")
-                else:
+                if ch != <Py_UCS4>-1:
                     pcts.append(ch)
                     last_pct = val[idx - 1 : idx + 2]
                     idx += 2
-                continue
+                    continue
+                else:
+                    ch = '%'
 
             if pcts:
                 ret.append(last_pct)  # %F8ab

--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -328,19 +328,17 @@ cdef class _Unquoter:
     cdef str _do_unquote(self, str val):
         if len(val) == 0:
             return val
-        cdef str pct = ''
         cdef str last_pct = ''
         cdef bytearray pcts = bytearray()
         cdef list ret = []
         cdef str unquoted
-        for ch in val:
-            if pct:
-                pct += ch
-                if len(pct) == 3:  # pragma: no branch   # peephole optimizer
-                    pcts.append(int(pct[1:], base=16))
-                    last_pct = pct
-                    pct = ''
-                continue
+        cdef Py_UCS4 ch = 0
+        cdef int idx = 0
+        cdef int length = len(val)
+
+        while idx < length:
+            ch = val[idx]
+            idx += 1
             if pcts:
                 try:
                     unquoted = pcts.decode('utf8')
@@ -355,8 +353,14 @@ cdef class _Unquoter:
                         ret.append(unquoted)
                     del pcts[:]
 
-            if ch == '%':
-                pct = ch
+            if ch == '%' and idx <= length - 2:
+                ch = _restore_ch(val[idx], val[idx + 1])
+                if ch == <Py_UCS4>-1:
+                    ret.append("%")
+                else:
+                    pcts.append(ch)
+                    last_pct = val[idx - 1 : idx + 2]
+                    idx += 2
                 continue
 
             if pcts:

--- a/yarl/_quoting_py.py
+++ b/yarl/_quoting_py.py
@@ -157,13 +157,9 @@ class _Unquoter:
             if ch == "%" and idx <= len(val) - 2:
                 pct = val[idx : idx + 2]  # noqa: E203
                 if _IS_HEX_STR.fullmatch(pct):
-                    try:
-                        pcts.append(int(pct, base=16))
-                    except ValueError:
-                        ret.append("%")
-                    else:
-                        last_pct = "%" + pct
-                        idx += 2
+                    pcts.append(int(pct, base=16))
+                    last_pct = "%" + pct
+                    idx += 2
                     continue
 
             if pcts:

--- a/yarl/_quoting_py.py
+++ b/yarl/_quoting_py.py
@@ -14,6 +14,7 @@ ALLOWED = UNRESERVED + SUB_DELIMS_WITHOUT_QS
 
 
 _IS_HEX = re.compile(b"[A-Z0-9][A-Z0-9]")
+_IS_HEX_STR = re.compile("[A-Fa-f0-9][A-Fa-f0-9]")
 
 
 class _Quoter:
@@ -126,18 +127,13 @@ class _Unquoter:
             raise TypeError("Argument should be str")
         if not val:
             return ""
-        pct = ""
         last_pct = ""
         pcts = bytearray()
         ret = []
-        for ch in val:
-            if pct:
-                pct += ch
-                if len(pct) == 3:  # pragma: no branch   # peephole optimizer
-                    pcts.append(int(pct[1:], base=16))
-                    last_pct = pct
-                    pct = ""
-                continue
+        idx = 0
+        while idx < len(val):
+            ch = val[idx]
+            idx += 1
             if pcts:
                 try:
                     unquoted = pcts.decode("utf8")
@@ -158,9 +154,17 @@ class _Unquoter:
                         ret.append(unquoted)
                     del pcts[:]
 
-            if ch == "%":
-                pct = ch
-                continue
+            if ch == "%" and idx <= len(val) - 2:
+                pct = val[idx : idx + 2]  # noqa: E203
+                if _IS_HEX_STR.fullmatch(pct):
+                    try:
+                        pcts.append(int(pct, base=16))
+                    except ValueError:
+                        ret.append("%")
+                    else:
+                        last_pct = "%" + pct
+                        idx += 2
+                    continue
 
             if pcts:
                 ret.append(last_pct)  # %F8ab


### PR DESCRIPTION
* No longer raise ValueError for % followed by non-hexdigits.
* Fix decoding % followed by a space and hexdigit.

Closes #516.
Closes #520.
