### PR TITLE
Migrate issue templates from aiohttp and link discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,66 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve
+labels: bug
+assignees: aio-libs/triagers
+
+---
+
+🐞 **Describe the bug**
+<!-- A clear and concise description of what the bug is, on the next line. -->
+
+
+💡 **To Reproduce**
+<!-- How to reproduce the behavior?
+
+For example:
+1. Have certain environment
+2. Run given code snippet in a certain way
+3. See some behavior described
+
+Add these steps below this comment: -->
+
+
+💡 **Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+
+📋 **Logs/tracebacks**
+<!-- If applicable, add logs/tracebacks to help explain your problem. -->
+```python-traceback (paste your traceback in the next line)
+
+```
+
+📋 **Your version of the Python**
+<!-- Attach your version of the Python. -->
+```console
+$ python --version
+...
+```
+
+📋 **Your version of the aiohttp/yarl/multidict distributions**
+<!-- Attach your version of the distributions in the code blocks below. -->
+```console
+$ python -m pip show aiohttp
+...
+```
+```console
+$ python -m pip show multidict
+...
+```
+```console
+$ python -m pip show yarl
+...
+```
+
+📋 **Additional context**
+<!-- Add any other context about the problem here, in the next line. -->
+
+<!-- Describe the environment you have that lead to your issue.
+     This includes aiohttp version, OS, proxy server and other bits that
+     are related to your case.
+
+     IMPORTANT: aiohttp is both server framework and client library.
+     For getting rid of confusing please put 'server', 'client' or 'both'
+     word here.
+     -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -12,9 +12,17 @@ contact_links:
 
     For more information, see
     https://github.com/aio-libs/.github/security/policy
+- name: >-
+    [🎉 NEW 🎉]
+    🤷💻🤦 GitHub Discussions
+  url: https://github.com/aio-libs/yarl/discussions
+  about: >-
+    Please ask typical Q&A in the Discussions tab or on StackOverflow
 - name: 🤷💻🤦 StackOverflow
   url: https://stackoverflow.com/questions/tagged/aiohttp
-  about: Please ask typical Q&A here or in the Discussions tab
+  about: >-
+    Please ask typical Q&A here or in the
+    Discussions tab @ https://github.com/aio-libs/yarl/discussions
 - name: 💬 Gitter Chat
   url: https://gitter.im/aio-libs/Lobby
   about: Chat with devs and community

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea for this project
+labels: enhancement
+assignees: aio-libs/triagers
+
+---
+
+🐣 **Is your feature request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+
+💡 **Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+
+❓ **Describe alternatives you've considered**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+
+📋 **Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->
+


### PR DESCRIPTION


-----
[View rendered .github/ISSUE_TEMPLATE/bug_report.md](https://github.com/aio-libs/yarl/blob/maintenance/issue-templates/.github/ISSUE_TEMPLATE/bug_report.md)
[View rendered .github/ISSUE_TEMPLATE/feature_request.md](https://github.com/aio-libs/yarl/blob/maintenance/issue-templates/.github/ISSUE_TEMPLATE/feature_request.md)