### PR TITLE
Fix annotation of with_query()/update_query() methods for key=[val1, val2] case

### DIFF
--- a/CHANGES/528.bugfix
+++ b/CHANGES/528.bugfix
@@ -1,0 +1,1 @@
+Fix annotation of ``with_query()``/``update_query()`` methods for ``key=[val1, val2]`` case.

--- a/yarl/__init__.pyi
+++ b/yarl/__init__.pyi
@@ -8,7 +8,8 @@ if sys.version_info >= (3, 8):
 else:
     from typing_extensions import TypedDict, Final, final
 
-_QueryVariable = Union[str, int, float]
+_SimpleQuery = Union[str, int, float]
+_QueryVariable = Union[_SimpleQuery, Sequence[_SimpleQuery]]
 _Query = Union[
     None, str, Mapping[str, _QueryVariable], Sequence[Tuple[str, _QueryVariable]]
 ]


### PR DESCRIPTION
Fixes #528