### PR TITLE
Normalize the `typing-extensions` dependency name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ with fname.open(encoding="utf8") as fp:
 install_requires = [
     "multidict>=4.0",
     "idna>=2.0",
-    'typing_extensions>=3.7.4;python_version<"3.8"',
+    'typing-extensions>=3.7.4;python_version<"3.8"',
 ]
 
 


### PR DESCRIPTION
`typing_extensions` -> `typing-extensions`, Python packages don't use underscores in their names.

It works now because the name is normalized so it does not really matter what symbol you use but the correct name is the one with `-`. This is a really small change, so no changelog entry is needed.