### PR TITLE
Stop reencoding URL when calling with_port()

### DIFF
--- a/CHANGES/623.bugfix.rst
+++ b/CHANGES/623.bugfix.rst
@@ -1,0 +1,1 @@
+Changed call in `with_port()` to stop reencoding parts of the URL that were already encoded.

--- a/CHANGES/623.bugfix.rst
+++ b/CHANGES/623.bugfix.rst
@@ -1,1 +1,1 @@
-Changed call in `with_port()` to stop reencoding parts of the URL that were already encoded.
+Changed call in ``with_port()`` to stop reencoding parts of the URL that were already encoded.

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -202,6 +202,11 @@ def test_with_port_keeps_query_and_fragment():
     assert str(url.with_port(8888)) == "http://example.com:8888/?a=1#frag"
 
 
+def test_with_port_percent_encoded():
+    url = URL("http://user%name:pass%word@example.com/")
+    assert str(url.with_port(808)) == "http://user%25name:pass%25word@example.com:808/"
+
+
 def test_with_port_for_relative_url():
     with pytest.raises(ValueError):
         URL("path/to").with_port(1234)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -883,9 +883,7 @@ class URL:
         val = self._val
         return URL(
             self._val._replace(
-                netloc=self._make_netloc(
-                    val.username, val.password, val.hostname, port, encode=True
-                )
+                netloc=self._make_netloc(val.username, val.password, val.hostname, port)
             ),
             encoded=True,
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes reencoding of URL elements after calling with_port().

## Are there changes in behavior for the user?

No.

## Related issue number

Fixes #620.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
