### PR TITLE
Fix query type annotation

### DIFF
--- a/CHANGES/671.misc
+++ b/CHANGES/671.misc
@@ -1,0 +1,1 @@
+Fixed `query` type annotation.

--- a/CHANGES/671.misc
+++ b/CHANGES/671.misc
@@ -1,1 +1,1 @@
-Fixed `query` type annotation.
+Fixed ``query`` type annotation.

--- a/yarl/__init__.pyi
+++ b/yarl/__init__.pyi
@@ -35,7 +35,7 @@ class URL:
     raw_path_qs: Final[str]
     raw_fragment: Final[str]
     fragment: Final[str]
-    query: Final[multidict.MultiDict[str]]
+    query: Final[multidict.MultiDict[str, str]]
     raw_name: Final[str]
     name: Final[str]
     raw_parts: Final[Tuple[str, ...]]


### PR DESCRIPTION
## What do these changes do?
Add missing type arg to `query` following https://github.com/aio-libs/multidict/commit/48f29bd3a4339ac1474a21bcc35f39254c74e296.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
—

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
