### PR TITLE
Simplified caching in Github actions configuration.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.8
-    - name: Cache PyPI
-      uses: actions/cache@v3
-      with:
-        key: pip-lint-${{ hashFiles('requirements/*.txt') }}
-        path: ~/.cache/pip
-        restore-keys: |
-            pip-lint-
+        cache: 'pip'
+        cache-dependency-path: 'requirements/*.txt'
     - name: Install dependencies
       uses: py-actions/py-dependency-install@v3
       with:
@@ -95,17 +90,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.pyver }}
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"    # - name: Cache
-    - name: Cache PyPI
-      uses: actions/cache@v3
-      with:
-        key: pip-ci-${{ runner.os }}-${{ matrix.pyver }}-{{ matrix.no-extensions }}-${{ hashFiles('requirements/*.txt') }}
-        path: ${{ steps.pip-cache.outputs.dir }}
-        restore-keys: |
-            pip-ci-${{ runner.os }}-${{ matrix.pyver }}-{{ matrix.no-extensions }}-
+        cache: 'pip'
+        cache-dependency-path: 'requirements/*.txt'
     - name: Install cython
       if: ${{ matrix.no-extensions == '' }}
       uses: py-actions/py-dependency-install@v3

--- a/CHANGES/694.misc.rst
+++ b/CHANGES/694.misc.rst
@@ -1,0 +1,1 @@
+Simplified cache handling in GitHub workflows.


### PR DESCRIPTION
## What do these changes do?

This bumps `checkout` and `setup-python` versions in the GitHub actions configuration to **v3** and simplifies dependency caching.

## Are there changes in behavior for the user?

No.

## Related issue number

No.

## Checklist

- [X] I think the code is well written
- [x] (**no needed**) Unit tests for the changes exist
- [x] (**no needed**) Documentation reflects the changes
- [x] (**no needed**) Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`