### PR TITLE
Don't use `git://` URLs in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
   - id: flake8
     exclude: "^docs/"
 
-- repo: git://github.com/Lucas-C/pre-commit-hooks-markup
+- repo: https://github.com/Lucas-C/pre-commit-hooks-markup
   rev: v1.0.1
   hooks:
   - id: rst-linter

--- a/CHANGES/699.misc.rst
+++ b/CHANGES/699.misc.rst
@@ -1,0 +1,1 @@
+Replaced git:// URL in pre-commit hook configuration with https://


### PR DESCRIPTION
Unauthenticated `git://` URLs are no longer supported by GitHub:

```
    fatal: remote error: 
      The unauthenticated git protocol on port 9418 is no longer supported.
    Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
