### PR TITLE
Avoid running the workflow twice on PR pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,14 @@ on:
     branches:
       - master
       - ?.?*
+    types: [opened, reopened]
   schedule:
     - cron:  '0 6 * * *'  # Daily 6AM UTC build
+
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 
 jobs:

--- a/CHANGES/700.misc.rst
+++ b/CHANGES/700.misc.rst
@@ -1,0 +1,1 @@
+Updated the GitHub workflow to avoid running unnecessary extra jobs.


### PR DESCRIPTION
When someone force-pushes to a PR or adds a new commit, the workflow would run
_twice_, as both `push` and `pull_request` events would trigger.

The default for `types` is `[opened, reopened, synchronize]`; the latter is the
type that overlaps with `push`.
