### PR TITLE
Unbreak black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,13 @@ repos:
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: '21.10b0'
+  rev: '22.1.0'
   hooks:
   - id: black
     language_version: python3 # Should be a command that runs python3.6+
+    # Black misbehaved and broke when click 8.1.0 was released with an internal
+    # module removed. See https://github.com/psf/black/issues/2964
+    additional_dependencies: ['click<8.1.0']
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: 'v4.0.1'
   hooks:

--- a/CHANGES/701.misc.rst
+++ b/CHANGES/701.misc.rst
@@ -1,0 +1,2 @@
+Updated the black .pre-commit-hook configuration to avoid it breaking due to
+`Black issue #2964 <https://github.com/psf/black/issues/2964>`_.

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -16,7 +16,6 @@ if not NO_EXTENSIONS:
     def unquoter(request):
         return request.param
 
-
 else:
 
     @pytest.fixture(params=[_PyQuoter], ids=["py_quoter"])


### PR DESCRIPTION
Move to the stable release and pin click, as black used the wrong exception to
work around a click interaction causing issues. See https://github.com/psf/black/issues/2964
