### PR TITLE
Upgrade black to 22.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,13 +12,10 @@ repos:
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: '22.1.0'
+  rev: '22.3.0'
   hooks:
   - id: black
     language_version: python3 # Should be a command that runs python3.6+
-    # Black misbehaved and broke when click 8.1.0 was released with an internal
-    # module removed. See https://github.com/psf/black/issues/2964
-    additional_dependencies: ['click<8.1.0']
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: 'v4.0.1'
   hooks:

--- a/CHANGES/702.misc.rst
+++ b/CHANGES/702.misc.rst
@@ -1,0 +1,2 @@
+Updated pre-commit-hooks black to a newer release with a fix for black#2964,
+dropping the need for a work-around.


### PR DESCRIPTION
This release fixes the issues that required pinning click, so we can drop that
pin again.
