### PR TITLE
Fix the workflow backport filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,12 @@ on:
   push:
     branches:
       - master
-      - ?.?*  # matches to backport branches, e.g. 3.9
+      - '[0-9].[0-9]+'  # matches to backport branches, e.g. 3.9
     tags: [ 'v*' ]
   pull_request:
     branches:
       - master
-      - ?.?*
-    types: [opened, reopened]
+      - '[0-9].[0-9]+'  # matches to backport branches, e.g. 3.9
   schedule:
     - cron:  '0 6 * * *'  # Daily 6AM UTC build
 

--- a/CHANGES/703.misc.rst
+++ b/CHANGES/703.misc.rst
@@ -1,0 +1,1 @@
+Furter cleaned up github workflow event matching.


### PR DESCRIPTION
The current filter is way too broad, and uses invalid syntax. See the [Github
filter cheat
sheet](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet).
