### PR TITLE
Fix update_query(None) doesn't clear the query

### DIFF
--- a/CHANGES/723.bugfix.rst
+++ b/CHANGES/723.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issue when update_query(None) doesn't clear the query.

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -272,6 +272,11 @@ def test_with_query_None():
     assert url.with_query(None).query_string == ""
 
 
+def test_update_query_None():
+    url = URL("http://example.com/path?a=b")
+    assert url.update_query(None).query_string == ""
+
+
 def test_with_query_bad_type():
     url = URL("http://example.com")
     with pytest.raises(TypeError):

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -983,8 +983,11 @@ class URL:
         """Return a new URL with query part updated."""
         s = self._get_str_query(*args, **kwargs)
         new_query = MultiDict(parse_qsl(s, keep_blank_values=True))
-        query = MultiDict(self.query)
-        query.update(new_query)
+        if args and args[0] is None:
+            query = new_query
+        else:
+            query = MultiDict(self.query)
+            query.update(new_query)
 
         return URL(self._val._replace(query=self._get_str_query(query)), encoded=True)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This fix bug when method url.update_query(None) doesn't clear the query.

## Are there changes in behavior for the user?

This changes clear the query if None is passed to method update_query().

## Related issue number

#723 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
