### PR TITLE
Explicitly set a language

### DIFF
--- a/CHANGES/739.misc.rst
+++ b/CHANGES/739.misc.rst
@@ -1,0 +1,1 @@
+Changed the Sphinx ``language`` parameter to ``"en"`` to allow for Sphinx 5.0.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,7 @@ release = "{major}.{minor}.{patch}-{tag}".format(**_version_info)
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:


### PR DESCRIPTION
## What do these changes do?

Change the Sphinx `language` parameter from `None` to `en`, explicitly setting
the language.

All documentation is in English, and Sphinx 5 complains loudly if this isn't
set.

## Related issue number

#733, a dependabot PR that upgrades Sphinx to 5.0.1. The CI lint step fails due
to the warning.

## Checklist

- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
