### PR TITLE
CI: Also test on 3.11 alpha with Cython

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
           - os: ubuntu
             pyver: "3.11.0-alpha - 3.11.0"
             experimental: true
+            no-extensions: ''
+          - os: ubuntu
+            pyver: "3.11.0-alpha - 3.11.0"
+            experimental: true
             no-extensions: 'Y'
       fail-fast: false
     runs-on: ${{ matrix.os }}-latest


### PR DESCRIPTION
With Cython upgraded to include 3.11 support, the test should pass cleanly.
