### PR TITLE
Fix to query_update(None)

### DIFF
--- a/CHANGES/790.bugfix.rst
+++ b/CHANGES/790.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed an issue with update_query() not getting rid of the query when argument is None.

--- a/CHANGES/790.bugfix.rst
+++ b/CHANGES/790.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue with update_query() not getting rid of the query when argument is None.

--- a/CHANGES/792.bugfix.rst
+++ b/CHANGES/792.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue with update_query() not getting rid of the query when argument is None.

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -40,6 +40,12 @@ def test_update_query_with_multiple_args():
         url.update_query("a", "b")
 
 
+def test_update_query_with_none_arg():
+    url = URL("http://example.com/?foo=bar&baz=foo")
+    expected_url = URL("http://example.com/")
+    assert url.update_query(None) == expected_url
+
+
 def test_with_query_list_of_pairs():
     url = URL("http://example.com")
     assert str(url.with_query([("a", "1")])) == "http://example.com/?a=1"

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -982,9 +982,11 @@ class URL:
     def update_query(self, *args, **kwargs):
         """Return a new URL with query part updated."""
         s = self._get_str_query(*args, **kwargs)
-        new_query = MultiDict(parse_qsl(s, keep_blank_values=True))
-        query = MultiDict(self.query)
-        query.update(new_query)
+        query = None
+        if s:
+            new_query = MultiDict(parse_qsl(s, keep_blank_values=True))
+            query = MultiDict(self.query)
+            query.update(new_query)
 
         return URL(self._val._replace(query=self._get_str_query(query)), encoded=True)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

This fixes the query_update() function special case where the None argument should clear query.

<!-- Please give a short brief about these changes. -->

The query_update() function now works when None is passed to the function.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#723 

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
