### PR TITLE
Fix to URL.with_port() input filtering

### DIFF
--- a/CHANGES/793.bugfix.rst
+++ b/CHANGES/793.bugfix.rst
@@ -1,0 +1,1 @@
+Added some input restrictions on with_port() function to prevent invalid boolean inputs or out of valid port inputs.

--- a/CHANGES/793.bugfix.rst
+++ b/CHANGES/793.bugfix.rst
@@ -1,1 +1,1 @@
-Added some input restrictions on with_port() function to prevent invalid boolean inputs or out of valid port inputs.
+Added some input restrictions on with_port() function to prevent invalid boolean inputs or out of valid port inputs; handled incorrect 0 port representation.

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -40,6 +40,12 @@ def test_update_query_with_multiple_args():
         url.update_query("a", "b")
 
 
+def test_update_query_with_none_arg():
+    url = URL("http://example.com/?foo=bar&baz=foo")
+    expected_url = URL("http://example.com/")
+    assert url.update_query(None) == expected_url
+
+
 def test_with_query_list_of_pairs():
     url = URL("http://example.com")
     assert str(url.with_query([("a", "1")])) == "http://example.com/?a=1"

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -40,12 +40,6 @@ def test_update_query_with_multiple_args():
         url.update_query("a", "b")
 
 
-def test_update_query_with_none_arg():
-    url = URL("http://example.com/?foo=bar&baz=foo")
-    expected_url = URL("http://example.com/")
-    assert url.update_query(None) == expected_url
-
-
 def test_with_query_list_of_pairs():
     url = URL("http://example.com")
     assert str(url.with_query([("a", "1")])) == "http://example.com/?a=1"

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -225,4 +225,4 @@ def test_with_port_invalid_type():
 
 def test_with_port_invalid_range():
     with pytest.raises(ValueError):
-        URL("http://example.com").with_port(0)
+        URL("http://example.com").with_port(-1)

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -191,6 +191,11 @@ def test_with_port():
     assert str(url.with_port(8888)) == "http://example.com:8888"
 
 
+def test_with_port_with_no_port():
+    url = URL("http://example.com")
+    assert str(url.with_port(None)) == "http://example.com"
+
+
 def test_with_port_ipv6():
     url = URL("http://[::1]:8080/")
     assert str(url.with_port(80)) == "http://[::1]:80/"
@@ -214,3 +219,10 @@ def test_with_port_for_relative_url():
 def test_with_port_invalid_type():
     with pytest.raises(TypeError):
         URL("http://example.com").with_port("123")
+    with pytest.raises(TypeError):
+        URL("http://example.com").with_port(True)
+
+
+def test_with_port_invalid_range():
+    with pytest.raises(ValueError):
+        URL("http://example.com").with_port(0)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -872,8 +872,8 @@ class URL:
         if port is not None:
             if isinstance(port, bool) or not isinstance(port, int):
                 raise TypeError(f"port should be int or None, got {type(port)}")
-            if port < 1 or port > 65535:
-                raise ValueError(f"port must be between 1 and 65535, got {port}")
+            if port < 0 or port > 65535:
+                raise ValueError(f"port must be between 0 and 65535, got {port}")
         if not self.is_absolute():
             raise ValueError("port replacement is not allowed for relative URLs")
         val = self._val

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -407,7 +407,7 @@ class URL:
 
     @property
     def scheme(self):
-        """Scheme for absolute URLs._make_netloc
+        """Scheme for absolute URLs.
 
         Empty string for relative URLs or URLs starting with //
 
@@ -985,11 +985,9 @@ class URL:
     def update_query(self, *args, **kwargs):
         """Return a new URL with query part updated."""
         s = self._get_str_query(*args, **kwargs)
-        query = None
-        if s:
-            new_query = MultiDict(parse_qsl(s, keep_blank_values=True))
-            query = MultiDict(self.query)
-            query.update(new_query)
+        new_query = MultiDict(parse_qsl(s, keep_blank_values=True))
+        query = MultiDict(self.query)
+        query.update(new_query)
 
         return URL(self._val._replace(query=self._get_str_query(query)), encoded=True)
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -982,9 +982,11 @@ class URL:
     def update_query(self, *args, **kwargs):
         """Return a new URL with query part updated."""
         s = self._get_str_query(*args, **kwargs)
-        new_query = MultiDict(parse_qsl(s, keep_blank_values=True))
-        query = MultiDict(self.query)
-        query.update(new_query)
+        query = None
+        if s:
+            new_query = MultiDict(parse_qsl(s, keep_blank_values=True))
+            query = MultiDict(self.query)
+            query.update(new_query)
 
         return URL(self._val._replace(query=self._get_str_query(query)), encoded=True)
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -407,7 +407,7 @@ class URL:
 
     @property
     def scheme(self):
-        """Scheme for absolute URLs.
+        """Scheme for absolute URLs._make_netloc
 
         Empty string for relative URLs or URLs starting with //
 
@@ -761,7 +761,7 @@ class URL:
             ret = cls._encode_host(host)
         else:
             ret = host
-        if port:
+        if port is not None:
             ret = ret + ":" + str(port)
         if password is not None:
             if not user:
@@ -869,8 +869,11 @@ class URL:
 
         """
         # N.B. doesn't cleanup query/fragment
-        if port is not None and not isinstance(port, int):
-            raise TypeError(f"port should be int or None, got {type(port)}")
+        if port is not None:
+            if isinstance(port, bool) or not isinstance(port, int):
+                raise TypeError(f"port should be int or None, got {type(port)}")
+            if port < 1 or port > 65535:
+                raise ValueError(f"port must be between 1 and 65535, got {port}")
         if not self.is_absolute():
             raise ValueError("port replacement is not allowed for relative URLs")
         val = self._val


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
These changes fix the improper validation issues with URL.with_port(). Essentially, it restricts ports to be from 0 to 65535 (tcp limit), and fixes the weird handling of the 0 port
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behavior for the end users. -->
The URL.with_port() function will now throw errors when Booleans or invalid ports are arguments.
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#746 

## Implementation Inquiry
Currently, this is set up to allow port 0 to function and not throw errors. From what I looked up it seems to be possible to use the 0 port (officially it does "not exist"), though since it's a special case and issue #746 says that the output should throw an error, I'm unsure if I'm handling it correctly.

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes - Documentation does not go into specifics for input/output on this function
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
