### PR TITLE
`URL.build()`: Raise `TypeError` if `host` argument is `None`

### DIFF
--- a/CHANGES/808.bugfix.rst
+++ b/CHANGES/808.bugfix.rst
@@ -1,1 +1,1 @@
-Made ``URL.build()`` raise a ``TypeError`` if the ``host`` argument is ``None``.
+Made :py:meth:`URL.build` raise a :py:exc:`TypeError` if the ``host`` argument is :py:data:`None` — by :user:`paulpapacz`.

--- a/CHANGES/808.bugfix.rst
+++ b/CHANGES/808.bugfix.rst
@@ -1,0 +1,1 @@
+Made ``URL.build()`` raise a ``TypeError`` if the ``host`` argument is ``None``.

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -239,6 +239,11 @@ def test_build_with_authority_with_path_without_leading_slash():
         URL.build(scheme="http", host="example.com", path="path_without_leading_slash")
 
 
+def test_build_with_none_host():
+    with pytest.raises(TypeError, match="NoneType is illegal for.*host"):
+        URL.build(scheme="http", host=None)
+
+
 def test_build_with_none_path():
     with pytest.raises(TypeError):
         URL.build(scheme="http", host="example.com", path=None)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -240,12 +240,13 @@ class URL:
         if (
             scheme is None
             or authority is None
+            or host is None
             or path is None
             or query_string is None
             or fragment is None
         ):
             raise TypeError(
-                'NoneType is illegal for "scheme", "authority", "path", '
+                'NoneType is illegal for "scheme", "authority", "host", "path", '
                 '"query_string", and "fragment" args, use empty string instead.'
             )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Make `URL.build()` raise a `TypeError` if `host` argument is `None`

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#808

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
