### PR TITLE
Add test for empty host #821

### DIFF
--- a/CHANGES/822.contrib.rst
+++ b/CHANGES/822.contrib.rst
@@ -1,0 +1,2 @@
+A regression test for no-host URLs was added per :issue:`821`
+and :rfc:`3986` -- by :user:`kenballus`.

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -214,7 +214,7 @@ class TestPort:
         assert u.query_string == ""
         assert u.fragment == ""
 
-    @pytest.mark.xfail
+    @pytest.mark.xfail(reason="https://github.com/aio-libs/yarl/issues/821")
     def test_no_host(self):
         u = URL("//:80")
         assert u.scheme == ""

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -214,6 +214,7 @@ class TestPort:
         assert u.query_string == ""
         assert u.fragment == ""
 
+    @pytest.mark.xfail
     def test_no_host(self):
         u = URL("//:80")
         assert u.scheme == ""

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -215,8 +215,13 @@ class TestPort:
         assert u.fragment == ""
 
     def test_no_host(self):
-        with pytest.raises(ValueError):
-            URL("//:80")
+        u = URL("//:80")
+        assert u.scheme == ""
+        assert u.host == ""
+        assert u.port == 80
+        assert u.path == "/"
+        assert u.query_string == ""
+        assert u.fragment == ""
 
     def test_double_port(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Adds a test to ensure that empty hosts are handled in the correct way, as requested in #821.