### PR TITLE
Support External Classes' `__rtruediv__`

### DIFF
--- a/CHANGES/832.feature.rst
+++ b/CHANGES/832.feature.rst
@@ -1,0 +1,1 @@
+Made :py:meth:`URL.__truediv__` return ``NotImplemented`` if called with an unsupported type — by :user:`michaeljpeters`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -715,6 +715,12 @@ def test_div_path_starting_from_slash_is_forbidden():
         url / "/to/others"
 
 
+def test_div_bad_type():
+    url = URL("http://example.com/path/")
+    with pytest.raises(TypeError):
+        url / 3
+
+
 def test_div_cleanup_query_and_fragment():
     url = URL("http://example.com/path?a=1#frag")
     assert str(url / "to") == "http://example.com/path/to"

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -341,6 +341,8 @@ class URL:
         return self._val > other._val
 
     def __truediv__(self, name):
+        if not type(name) is str:
+            return NotImplemented
         return self._make_child((name,))
 
     def __mod__(self, query):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Allows external classes to extend functionality properly using `__rtruediv__`.

Previously, `URL` would raise a not-so-nice error like this:
```python
>>> from yarl import URL
>>> 
>>> u = URL('https://beefslab.com/abc')
>>> u
URL('https://beefslab.com/abc')
>>> u / 3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/peters/.env38/lib/python3.8/site-packages/yarl/_url.py", line 318, in __truediv__
    name = self._PATH_QUOTER(name)
  File "yarl/_quoting_c.pyx", line 213, in yarl._quoting_c._Quoter.__call__
TypeError: Argument should be str
```

Now, it will properly return NotImplemented (still eventually resulting in a TypeError).
```python
>>> u / 3
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for /: 'URL' and 'int'
```

https://docs.python.org/3/library/constants.html#NotImplemented
https://docs.python.org/3/reference/datamodel.html#object.__rtruediv__
"These functions are only called if the left operand does not support the corresponding operation"

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#832

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes - Not added, minor change
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
