### PR TITLE
Update isort in pre-commit deps to unbreak linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
   hooks:
   - id: yesqa
 - repo: https://github.com/PyCQA/isort
-  rev: '5.10.0'
+  rev: '5.11.5'
   hooks:
   - id: isort
 - repo: https://github.com/psf/black


### PR DESCRIPTION
## What do these changes do?

See PyCQA/isort#2077; will leave it to the pre-commit update bot
to push this to 5.12.

