### PR TITLE
ci: remove docs from the ci requirements for tests

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,4 +1,3 @@
 -e .
 -r test.txt
--r doc.txt
 -r lint.txt


### PR DESCRIPTION
Tests don't need to have the doc requirements installed, and we can't
move to modern doc tools while also supporting 3.7 in tests.
