### PR TITLE
ci: Remove long-obsolete black dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,9 +16,6 @@ repos:
   hooks:
   - id: black
     language_version: python3 # Should be a command that runs python3.6+
-    # Black misbehaved and broke when click 8.1.0 was released with an internal
-    # module removed. See https://github.com/psf/black/issues/2964
-    additional_dependencies: ['click<8.1.0']
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: 'v4.0.1'
   hooks:


### PR DESCRIPTION
The current releases of black have long since moved beyond the issue.
