### PR TITLE
update_query({}) should be a no-op.

### DIFF
--- a/CHANGES/845.bugfix.rst
+++ b/CHANGES/845.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed an issue with ``update_query()`` getting rid of the query when the argument
+is empty but not ``None``.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -956,7 +956,7 @@ class URL:
             raise ValueError("Either kwargs or single query parameter must be present")
 
         if query is None:
-            query = ""
+            query = None
         elif isinstance(query, Mapping):
             quoter = self._QUERY_PART_QUOTER
             query = "&".join(self._query_seq_pairs(quoter, query.items()))
@@ -998,7 +998,7 @@ class URL:
         """
         # N.B. doesn't cleanup query/fragment
 
-        new_query = self._get_str_query(*args, **kwargs)
+        new_query = self._get_str_query(*args, **kwargs) or ""
         return URL(
             self._val._replace(path=self._val.path, query=new_query), encoded=True
         )
@@ -1007,12 +1007,14 @@ class URL:
         """Return a new URL with query part updated."""
         s = self._get_str_query(*args, **kwargs)
         query = None
-        if s:
+        if s is not None:
             new_query = MultiDict(parse_qsl(s, keep_blank_values=True))
             query = MultiDict(self.query)
             query.update(new_query)
 
-        return URL(self._val._replace(query=self._get_str_query(query)), encoded=True)
+        return URL(
+            self._val._replace(query=self._get_str_query(query) or ""), encoded=True
+        )
 
     def with_fragment(self, fragment):
         """Return a new URL with fragment replaced.


### PR DESCRIPTION
## What do these changes do?

The documentation states that `url.update_query(None)` clears the query string.

However, that means that _other valid arguments_, such as `{}`, should not.

## Are there changes in behavior for the user?

This behaviour was recently fixed in #792, but this specific edgecase was then
introduced. We haven't released a version with that change included, however.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`

