### PR TITLE
Fix minor test issues

### DIFF
--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -59,7 +59,7 @@ def test_with_query_list_of_pairs():
 def test_with_query_list_non_pairs():
     url = URL("http://example.com")
     with pytest.raises(ValueError):
-        url.with_query(["a=1", "b=2" "c=3"])
+        url.with_query(["a=1", "b=2", "c=3"])
 
 
 def test_with_query_kwargs():

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -431,7 +431,7 @@ def test_raw_parts_for_relative_path_starting_from_slash():
 
 def test_raw_parts_for_relative_double_path():
     url = URL("path/to")
-    assert url.raw_parts == url.raw_parts
+    assert ("path", "to") == url.raw_parts
 
 
 def test_parts_for_empty_url():


### PR DESCRIPTION
- Include a comma in the tested-for 'wrong' query parts
- Test the `raw_parts` value against an expected value and not against
  itself.

Both issues were caught by CodeQL scans.
