### PR TITLE
Mark semicolon-based tests as xfail in specific cases

### DIFF
--- a/CHANGES/850.bugfix.rst
+++ b/CHANGES/850.bugfix.rst
@@ -1,0 +1,1 @@
+Marked tests that fail on older Python patch releases (< 3.7.10, < 3.8.8 and < 3.9.2) as expected to fail due to missing a security fix for CVE-2021-23336.


### PR DESCRIPTION
In Python 3.7 patch releases before 3.7.10, 3.8 patch releases before
3.8.8 and 3.9 patch releases before 3.9.2, URL parsing will split
parameters on semicolons but this is no longer valid as of RFC3986 and
is a security issue.

The patch remedying this introduced a new parameter, `separator`, which
we use to detect wether or not the test will fail.

Fixes #850, unblocking the release process.

The markers were tested locally using Python 3.7.9, 3.8.7 and 3.9.1, as well as
newer patch releases of those Python versions.
