### PR TITLE
Bump the project version to 1.9.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,19 @@ Changelog
 
 .. towncrier release notes start
 
+1.9.1 (2023-04-21)
+==================
+
+Bugfixes
+--------
+
+- Marked tests that fail on older Python patch releases (< 3.7.10, < 3.8.8 and < 3.9.2) as expected to fail due to missing a security fix for CVE-2021-23336. (`#850 <https://github.com/aio-libs/yarl/issues/850>`_)
+
+
 1.9.0 (2023-04-19)
 ==================
+
+This release was never published to PyPI, due to issues with the build process.
 
 Features
 --------

--- a/CHANGES/850.bugfix.rst
+++ b/CHANGES/850.bugfix.rst
@@ -1,1 +1,0 @@
-Marked tests that fail on older Python patch releases (< 3.7.10, < 3.8.8 and < 3.9.2) as expected to fail due to missing a security fix for CVE-2021-23336.

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,5 +1,5 @@
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 
 __all__ = ("URL", "cache_clear", "cache_configure", "cache_info")


### PR DESCRIPTION
Since 1.9.0 failed to release, lets release 1.9.1 now that the tests will also
pass on 2.7.9 as used by cibuildwheels.
