### PR TITLE
Fix truediv joining against absolute URL with no path

### DIFF
--- a/CHANGES/854.bugfix.rst
+++ b/CHANGES/854.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression with truediv and absolute URLs with empty paths causing the raw path to lack the leading ``/``.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -690,23 +690,27 @@ def test_clear_query_on_getting_parent_toplevel():
 
 
 def test_div_root():
-    url = URL("http://example.com")
-    assert str(url / "path" / "to") == "http://example.com/path/to"
+    url = URL("http://example.com") / "path" / "to"
+    assert str(url) == "http://example.com/path/to"
+    assert url.raw_path == "/path/to"
 
 
 def test_div_root_with_slash():
-    url = URL("http://example.com/")
-    assert str(url / "path" / "to") == "http://example.com/path/to"
+    url = URL("http://example.com/") / "path" / "to"
+    assert str(url) == "http://example.com/path/to"
+    assert url.raw_path == "/path/to"
 
 
 def test_div():
-    url = URL("http://example.com/path")
-    assert str(url / "to") == "http://example.com/path/to"
+    url = URL("http://example.com/path") / "to"
+    assert str(url) == "http://example.com/path/to"
+    assert url.raw_path == "/path/to"
 
 
 def test_div_with_slash():
-    url = URL("http://example.com/path/")
-    assert str(url / "to") == "http://example.com/path/to"
+    url = URL("http://example.com/path/") / "to"
+    assert str(url) == "http://example.com/path/to"
+    assert url.raw_path == "/path/to"
 
 
 def test_div_path_starting_from_slash_is_forbidden():

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -734,6 +734,10 @@ class URL:
             parsed = [*old_path.rstrip("/").split("/"), *parsed]
         if self.is_absolute():
             parsed = _normalize_path_segments(parsed)
+            if parsed and parsed[0] != "":
+                # inject a leading slash when adding a path to an absolute URL
+                # where there was none before
+                parsed = ["", *parsed]
         new_path = "/".join(parsed)
         return URL(
             self._val._replace(path=new_path, query="", fragment=""), encoded=True


### PR DESCRIPTION
When joining path elements against an absolute URL, ensure that
the resulting path starts with a slash.

Fixes #854
