### PR TITLE
Keep a trailing slash in URL.joinpath

### DIFF
--- a/CHANGES/862.bugfix.rst
+++ b/CHANGES/862.bugfix.rst
@@ -1,0 +1,1 @@
+Stopped dropping trailing slashes in ``URL.joinpath``.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -797,6 +797,21 @@ def test_div_with_dots():
             "http://example.com/path/to",
             id="cleanup-query-and-fragment",
         ),
+        pytest.param("", ("path/",), "http://example.com/path/", id="trailing-slash"),
+        pytest.param(
+            "", ("path/", "to/"), "http://example.com/path/to/", id="duplicate-slash"
+        ),
+        pytest.param("", (), "http://example.com", id="empty-segments"),
+        pytest.param(
+            "/", ("path/",), "http://example.com/path/", id="base-slash-trailing-slash"
+        ),
+        pytest.param(
+            "/",
+            ("path/", "to/"),
+            "http://example.com/path/to/",
+            id="base-slash-duplicate-slash",
+        ),
+        pytest.param("/", (), "http://example.com", id="base-slash-empty-segments"),
     ],
 )
 def test_joinpath(base, to_join, expected):
@@ -811,6 +826,9 @@ def test_joinpath(base, to_join, expected):
         pytest.param(URL("a"), ("b",), ("a", "b"), id="relative-path"),
         pytest.param(URL("a"), ("b", "", "c"), ("a", "b", "c"), id="empty-element"),
         pytest.param(URL("/a"), ("b"), ("/", "a", "b"), id="absolute-path"),
+        pytest.param(URL(), ("a/",), ("a", ""), id="trailing-slash"),
+        pytest.param(URL(), ("a/", "b/"), ("a", "b", ""), id="duplicate-slash"),
+        pytest.param(URL(), (), ("",), id="empty-segments"),
     ],
 )
 def test_joinpath_relative(url, to_join, expected):

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -713,7 +713,8 @@ class URL:
 
     def _make_child(self, segments, encoded=False):
         """add segments to self._val.path, accounting for absolute vs relative paths"""
-        parsed = []
+        # keep the trailing slash if the last segment ends with /
+        parsed = [""] if segments and segments[-1][-1:] == "/" else []
         for seg in reversed(segments):
             if not seg:
                 continue


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This fixes the regression in `URL.joinpath` that stopped it from preserving a trailing slash in the path components to be joined.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

A statement like `URL("http://example.com") / "foo/"` will again preserve the trailing slash.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #862 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
