### PR TITLE
🎨 Explicitly use setuptools PEP 517 build backend

### DIFF
--- a/CHANGES/886.misc.rst
+++ b/CHANGES/886.misc.rst
@@ -1,0 +1,2 @@
+Declared modern ``setuptools.build_meta`` as the :pep:`517` build
+backend in ``pyproject.toml`` explicitly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools>=40", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.towncrier]
 package = "yarl"


### PR DESCRIPTION
Before this patch, the legacy fallback was being selected automatically. This is not what we want and we should make use of the actual modern implementation.
