### PR TITLE
🔥 Drop `wheel` from sdist build deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ["setuptools>=40", "wheel"]
+requires = [
+  "setuptools>=40",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.towncrier]


### PR DESCRIPTION
It is auto-added by `setuptools`' build backend when building wheels but is absolutely unnecessary when building an sdist.