### PR TITLE
📦🎨 Move package attrs to declarative config

### DIFF
--- a/CHANGES/890.misc.rst
+++ b/CHANGES/890.misc.rst
@@ -1,0 +1,1 @@
+Converted most of the packaging setup into a declarative ``setup.cfg`` config.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,83 @@
+[bdist_wheel]
+# wheels should be OS-specific:
+# their names must contain macOS/manulinux1/2010/2014/Windows identifiers
+universal = 0
+
 [metadata]
-license_file = LICENSE
+name = yarl
+version = attr: yarl.__version__
+url = https://github.com/aio-libs/yarl
+project_urls =
+  Chat: Matrix = https://matrix.to/#/#aio-libs-space:matrix.org
+  CI: GitHub Workflows = https://github.com/aio-libs/yarl/actions?query=branch:master
+  Code of Conduct = https://github.com/aio-libs/.github/blob/master/CODE_OF_CONDUCT.md
+  Coverage: codecov = https://codecov.io/github/aio-libs/yarl
+  Docs: Changelog = https://github.com/aio-libs/yarl/blob/master/CHANGES.rst#changelog
+  Docs: RTD = https://yarl.aio-libs.org
+  GitHub: issues = https://github.com/aio-libs/yarl/issues
+  GitHub: repo = https://github.com/aio-libs/yarl
+description = Yet another URL library
+# long_description = file: README.rst, CHANGES.rst
+long_description_content_type = text/x-rst
+author = Andrew Svetlov
+author_email = andrew.svetlov@gmail.com
+maintainer = aiohttp team <team@aiohttp.org>
+maintainer_email = team@aiohttp.org
+license = Apache-2.0
+license_files =
+  LICENSE
+classifiers =
+  Development Status :: 5 - Production/Stable
+
+  Intended Audience :: Developers
+
+  License :: OSI Approved :: Apache Software License
+
+  Programming Language :: Cython
+  Programming Language :: Python
+  Programming Language :: Python :: 3
+  Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
+
+  Topic :: Internet :: WWW/HTTP
+  Topic :: Software Development :: Libraries :: Python Modules
+keywords =
+  cython
+  cext
+  yarl
+
+[options]
+python_requires = >=3.7
+# Ref:
+# https://setuptools.readthedocs.io/en/latest/setuptools.html#using-a-src-layout
+# (`src/` layout)
+# package_dir =
+#   = src
+packages =
+  yarl
+# https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag
+zip_safe = False
+include_package_data = True
+
+install_requires =
+  idna >= 2.0
+  multidict >= 4.0
+  typing-extensions >= 3.7.4; python_version < "3.8"
+
+[options.package_data]
+# Ref:
+# https://setuptools.readthedocs.io/en/latest/setuptools.html#options
+# (see notes for the asterisk/`*` meaning)
+* =
+  *.so
+
+[exclude_package_data]
+* =
+  *.c
+  *.h
 
 
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -12,24 +12,9 @@ if sys.implementation.name != "cpython":
 
 
 extensions = [Extension("yarl._quoting_c", ["yarl/_quoting_c.c"])]
-# extra_compile_args=["-g"],
-# extra_link_args=["-g"],
 
 
 here = pathlib.Path(__file__).parent
-fname = here / "yarl" / "__init__.py"
-
-with fname.open(encoding="utf8") as fp:
-    try:
-        version = re.findall(r'^__version__ = "([^"]+)"$', fp.read(), re.M)[0]
-    except IndexError:
-        raise RuntimeError("Unable to determine version.")
-
-install_requires = [
-    "multidict>=4.0",
-    "idna>=2.0",
-    'typing-extensions>=3.7.4;python_version<"3.8"',
-]
 
 
 def read(name):
@@ -48,34 +33,9 @@ def sanitize_rst_roles(rst_source_text: str) -> str:
 
 
 args = dict(
-    name="yarl",
-    version=version,
-    description=("Yet another URL library"),
     long_description="\n\n".join(
         [read("README.rst"), sanitize_rst_roles(read("CHANGES.rst"))]
     ),
-    long_description_content_type="text/x-rst",
-    classifiers=[
-        "License :: OSI Approved :: Apache Software License",
-        "Intended Audience :: Developers",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Topic :: Internet :: WWW/HTTP",
-    ],
-    author="Andrew Svetlov",
-    author_email="andrew.svetlov@gmail.com",
-    url="https://github.com/aio-libs/yarl/",
-    license="Apache-2.0",
-    packages=["yarl"],
-    install_requires=install_requires,
-    python_requires=">=3.7",
-    include_package_data=True,
-    exclude_package_data={"": ["*.c"]},
 )
 
 


### PR DESCRIPTION
This cleans up `setup.py`, keeping only things that are hard to move. It puts all possible attrs into `setup.cfg`. It doesn't attempt making use of `pyproject.toml` for this purpose because it's easier to maintain separate configs in dedicated files, on scale.