### PR TITLE
Preserve the case of username and password in URL.build

### DIFF
--- a/CHANGES/880.bugfix.rst
+++ b/CHANGES/880.bugfix.rst
@@ -1,0 +1,1 @@
+Preserve the case of username and password in URL.build when extracted from host.

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -257,3 +257,14 @@ def test_build_with_none_query_string():
 def test_build_with_none_fragment():
     with pytest.raises(TypeError):
         URL.build(scheme="http", host="example.com", fragment=None)
+
+
+def test_build_with_case_sensitive_user_and_password():
+    url = URL.build(scheme='httPS', host='usER:passWORD@hostNAME', path='/paTH')
+    assert url.user == "usER"
+    assert url.password == "passWORD"
+
+
+def test_build_with_case_sensitive_user():
+    url = URL.build(scheme='httPS', host='usER@hostNAME', path='/paTH')
+    assert url.user == "usER"

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -261,6 +261,12 @@ class URL:
         elif not user and not password and not host and not port:
             netloc = ""
         else:
+            if "@" in host and not user and not password:
+                user_pass, host = host.split("@", 1)
+                if ":" in user_pass:
+                    user, password = user_pass.split(":", 1)
+                else:
+                    user = user_pass
             netloc = cls._make_netloc(
                 user, password, host, port, encode=not encoded, encode_host=not encoded
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
The new changes preserve casing of username and password when extracted from host in URL.build

```python
>>> yarl.URL.build(scheme='httPS', host='usER:passWORD@hostNAME', path='/paTH')
URL('httPS://usER:passWORD@hostname/paTH')
>>> yarl.URL.build(scheme='httPS', host='usER:passWORD@hostNAME', path='/paTH').user
'usER'
>>> yarl.URL.build(scheme='httPS', host='usER:passWORD@hostNAME', path='/paTH').password
'passWORD'
```

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#880 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
