### PR TITLE
Document default port substitution on URL.with_scheme

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -533,6 +533,9 @@ section generates a new :class:`URL` instance.
       >>> URL('http://example.com').with_scheme('https')
       URL('https://example.com')
 
+   Returned URL may have a *different* ``port`` 
+   (:ref:`default-port-substitution`).
+
 .. method:: URL.with_user(user)
 
    Return a new URL with *user* replaced, auto-encode *user* if needed.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Make it clear that `with_scheme` can change the port.

## Are there changes in behavior for the user?

No

## Related issue number

No

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
