### PR TITLE
Raise `TypeError` when a string is passed for `port` to `URL.build()`

### DIFF
--- a/CHANGES/883.bugfix
+++ b/CHANGES/883.bugfix
@@ -1,1 +1,3 @@
-Fix URL.build with port="" creating invalid URLs
+Started treating an empty-string ``port=""`` passed into :py:meth:`~yarl.URL.build` as unset -- :user:`commonism`.
+
+The logic has changed to create URL with no colon and port rendered in its string representation.

--- a/CHANGES/883.bugfix
+++ b/CHANGES/883.bugfix
@@ -1,3 +1,4 @@
-Started treating string ``port`` passed into :py:meth:`~yarl.URL.build` as TypeError -- :user:`commonism`.
+Started raising :py:exc:`TypeError` when a string value is passed into
+:py:meth:`~yarl.URL.build` as the ``port`` argument  -- :user:`commonism`.
 
 The logic has changed to create URL with no colon and port rendered in its string representation.

--- a/CHANGES/883.bugfix
+++ b/CHANGES/883.bugfix
@@ -1,3 +1,3 @@
-Started treating an empty-string ``port=""`` passed into :py:meth:`~yarl.URL.build` as unset -- :user:`commonism`.
+Started treating string ``port`` passed into :py:meth:`~yarl.URL.build` as TypeError -- :user:`commonism`.
 
 The logic has changed to create URL with no colon and port rendered in its string representation.

--- a/CHANGES/883.bugfix
+++ b/CHANGES/883.bugfix
@@ -1,4 +1,4 @@
 Started raising :py:exc:`TypeError` when a string value is passed into
-:py:meth:`~yarl.URL.build` as the ``port`` argument  -- :user:`commonism`.
+:py:meth:`~yarl.URL.build` as the ``port`` argument  -- by :user:`commonism`.
 
 Previously the empty string as port would create malformed URLs when rendered as string representations.

--- a/CHANGES/883.bugfix
+++ b/CHANGES/883.bugfix
@@ -1,4 +1,4 @@
 Started raising :py:exc:`TypeError` when a string value is passed into
 :py:meth:`~yarl.URL.build` as the ``port`` argument  -- :user:`commonism`.
 
-The logic has changed to create URL with no colon and port rendered in its string representation.
+Previously the empty string as port would create malformed URLs when rendered as string representations.

--- a/CHANGES/883.bugfix
+++ b/CHANGES/883.bugfix
@@ -1,0 +1,1 @@
+Fix URL.build with port="" creating invalid URLs

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -33,7 +33,7 @@ def test_build_with_scheme_and_host():
 
 
 @pytest.mark.parametrize(
-    "port,exc,match",
+    ("port", "exc", "match"),
     [
         pytest.param(8000, ValueError, None, id="port-only"),
         pytest.param("", TypeError, "port is required to be int", id="port-str"),

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -39,6 +39,9 @@ def test_build_with_port():
     u = URL.build(scheme="http", host="127.0.0.1", port=8000)
     assert str(u) == "http://127.0.0.1:8000"
 
+    u = URL.build(scheme="http", host="127.0.0.1", port="", path="/v1")
+    assert str(u) == "http://127.0.0.1/v1", str(u)
+
 
 def test_build_with_user():
     u = URL.build(scheme="http", host="127.0.0.1", user="foo")

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -38,10 +38,12 @@ def test_build_with_scheme_and_host():
         pytest.param(
             8000,
             ValueError,
-            r'^Can\'t build URL with "port" but without "host".$',
+            r'^Can\'t build URL with "port" but without "host"\.$',
             id="port-only",
         ),
-        pytest.param("", TypeError, r"^port is required to be int$", id="port-str"),
+        pytest.param(
+            "", TypeError, r"^The port is required to be int\.$", id="port-str"
+        ),
     ],
 )
 def test_build_with_port(port, exc, match):

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -36,7 +36,7 @@ def test_build_with_scheme_and_host():
     ("port", "exc", "match"),
     [
         pytest.param(8000, ValueError, None, id="port-only"),
-        pytest.param("", TypeError, "port is required to be int", id="port-str"),
+        pytest.param("", TypeError, r"^port is required to be int$", id="port-str"),
     ],
 )
 def test_build_with_port(port, exc, match):

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -35,7 +35,12 @@ def test_build_with_scheme_and_host():
 @pytest.mark.parametrize(
     ("port", "exc", "match"),
     [
-        pytest.param(8000, ValueError, None, id="port-only"),
+        pytest.param(
+            8000,
+            ValueError,
+            r'^Can\'t build URL with "port" but without "host".$',
+            id="port-only",
+        ),
         pytest.param("", TypeError, r"^port is required to be int$", id="port-str"),
     ],
 )

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -33,14 +33,14 @@ def test_build_with_scheme_and_host():
 
 
 @pytest.mark.parametrize(
-    "port,exc",
+    "port,exc,match",
     [
-        pytest.param(8000, ValueError, id="port-only"),
-        pytest.param("", TypeError, id="port-str"),
+        pytest.param(8000, ValueError, None, id="port-only"),
+        pytest.param("", TypeError, "port is required to be int", id="port-str"),
     ],
 )
-def test_build_with_port(port, exc):
-    with pytest.raises(exc):
+def test_build_with_port(port, exc, match):
+    with pytest.raises(exc, match=match):
         URL.build(port=port)
 
 

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -32,15 +32,16 @@ def test_build_with_scheme_and_host():
     assert u == URL("http://127.0.0.1")
 
 
-def test_build_with_port():
-    with pytest.raises(ValueError):
-        URL.build(port=8000)
-
-    u = URL.build(scheme="http", host="127.0.0.1", port=8000)
-    assert str(u) == "http://127.0.0.1:8000"
-
-    u = URL.build(scheme="http", host="127.0.0.1", port="", path="/v1")
-    assert str(u) == "http://127.0.0.1/v1", str(u)
+@pytest.mark.parametrize(
+    "port,exc",
+    [
+        pytest.param(8000, ValueError, id="port-only"),
+        pytest.param("", TypeError, id="port-str"),
+    ],
+)
+def test_build_with_port(port, exc):
+    with pytest.raises(exc):
+        URL.build(port=port)
 
 
 def test_build_with_user():

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -40,7 +40,7 @@ def test_build_with_scheme_and_host():
             ValueError,
             r"""(?x)
             ^
-            Can't build URL with "port" but without "host"\.
+            Can't\ build\ URL\ with\ "port"\ but\ without\ "host"\.
             $
             """,
             id="port-only",
@@ -51,6 +51,7 @@ def test_build_with_scheme_and_host():
     ],
 )
 def test_build_with_port(port, exc, match):
+    print(match)
     with pytest.raises(exc, match=match):
         URL.build(port=port)
 

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -38,7 +38,11 @@ def test_build_with_scheme_and_host():
         pytest.param(
             8000,
             ValueError,
-            r'^Can\'t build URL with "port" but without "host"\.$',
+            r"""(?x)
+            ^
+            Can't build URL with "port" but without "host"\.
+            $
+            """,
             id="port-only",
         ),
         pytest.param(

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -233,7 +233,7 @@ class URL:
             raise ValueError(
                 'Can\'t mix "authority" with "user", "password", "host" or "port".'
             )
-        if not isinstance(port, (int, None.__class__)):
+        if not isinstance(port, (int, type(None))):
             raise TypeError("port is required to be int")
         if port and not host:
             raise ValueError('Can\'t build URL with "port" but without "host".')

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -233,8 +233,8 @@ class URL:
             raise ValueError(
                 'Can\'t mix "authority" with "user", "password", "host" or "port".'
             )
-        if port == "":
-            port = None
+        if port is not None and not isinstance(port, int):
+            raise TypeError("port is required to be int")
         if port and not host:
             raise ValueError('Can\'t build URL with "port" but without "host".')
         if query and query_string:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -233,7 +233,7 @@ class URL:
             raise ValueError(
                 'Can\'t mix "authority" with "user", "password", "host" or "port".'
             )
-        if not isinstance(port, (int, NoneType)):
+        if not isinstance(port, (int, None.__class__)):
             raise TypeError("port is required to be int")
         if port and not host:
             raise ValueError('Can\'t build URL with "port" but without "host".')

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -233,7 +233,7 @@ class URL:
             raise ValueError(
                 'Can\'t mix "authority" with "user", "password", "host" or "port".'
             )
-        if isinstance(port, str) and port == "":
+        if port == "":
             port = None
         if port and not host:
             raise ValueError('Can\'t build URL with "port" but without "host".')

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -234,7 +234,7 @@ class URL:
                 'Can\'t mix "authority" with "user", "password", "host" or "port".'
             )
         if not isinstance(port, (int, type(None))):
-            raise TypeError("port is required to be int")
+            raise TypeError("The port is required to be int.")
         if port and not host:
             raise ValueError('Can\'t build URL with "port" but without "host".')
         if query and query_string:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -233,7 +233,7 @@ class URL:
             raise ValueError(
                 'Can\'t mix "authority" with "user", "password", "host" or "port".'
             )
-        if port is not None and not isinstance(port, int):
+        if not isinstance(port, (int, NoneType)):
             raise TypeError("port is required to be int")
         if port and not host:
             raise ValueError('Can\'t build URL with "port" but without "host".')

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -233,6 +233,8 @@ class URL:
             raise ValueError(
                 'Can\'t mix "authority" with "user", "password", "host" or "port".'
             )
+        if isinstance(port, str) and port == "":
+            port = None
         if port and not host:
             raise ValueError('Can\'t build URL with "port" but without "host".')
         if query and query_string:


### PR DESCRIPTION
## What do these changes do?

Using port="" resulted in malformed urls, now using string for port raises TypeError

## Are there changes in behavior for the user?

URL.build does not accept strings as port any longer.
URL.build does not create invalid urls when using "" as value for port.

## Related issue number

fix #883

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
