### PR TITLE
📦 Simplify build settings dropping leading `--`

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Build sdists and pure-python wheel
       env:
         PIP_CONSTRAINT: requirements/cython.txt
-      run: python -Im build --config-setting=--pure-python=true
+      run: python -Im build --config-setting=pure-python=true
     - name: Upload built artifacts for testing
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -70,8 +70,8 @@ jobs:
       env:
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
         CIBW_CONFIG_SETTINGS: >-  # Cython line tracing for coverage collection
-          --pure-python=false
-          --with-cython-tracing=${{ inputs.cython-tracing }}
+          pure-python=false
+          with-cython-tracing=${{ inputs.cython-tracing }}
 
     - name: Upload built artifacts for testing and publishing
       uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable-linters.yml
+++ b/.github/workflows/reusable-linters.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Prepare twine checker
       run: |
         pip install -U build twine
-        python -m build --config-setting=--pure-python=true
+        python -m build --config-setting=pure-python=true
     - name: Run twine checker
       run: |
         twine check --strict dist/*

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,7 @@ build:
     post_create_environment:
     - >-
       pip install .
-      --config-settings=--pure-python=true
+      --config-settings=pure-python=true
 
 python:
   install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,7 +44,7 @@ Packaging updates and notes for downstreams
 
   .. code-block:: console
 
-      $ python -m pip install . --config-settings=--pure-python=
+      $ python -m pip install . --config-settings=--pure-python=false
 
   This will also work with ``-e | --editable``.
 
@@ -52,10 +52,16 @@ Packaging updates and notes for downstreams
 
   .. code-block:: console
 
-      $ python -m build --config-setting=--pure-python=
+      $ python -m build --config-setting=--pure-python=false
 
   Adding ``-w | --wheel`` can force ``pypa/build`` produce a wheel from source
   directly, as opposed to building an ``sdist`` and then building from it. (:issue:`893`)
+
+  .. attention::
+
+     v1.9.3 was the only version using the ``--pure-python`` setting name.
+     Later versions dropped the ``--`` prefix, making it just ``pure-python``.
+
 - Declared Python 3.12 supported officially in the distribution package metadata
   -- by :user:`edgarrmondragon`. (:issue:`942`)
 

--- a/CHANGES/962.contrib.rst
+++ b/CHANGES/962.contrib.rst
@@ -1,5 +1,5 @@
 It is now possible to request line tracing in Cython builds using the
-``--with-cython-tracing`` :pep:`517` config setting
+``with-cython-tracing`` :pep:`517` config setting
 -- :user:`webknjaz`.
 
 This can be used in CI and development environment to measure coverage
@@ -10,7 +10,7 @@ Here's a usage example:
 
 .. code-block:: console
 
-    $ python -Im pip install . --with-cython-tracing=true
+    $ python -Im pip install . --config-settings=with-cython-tracing=true
 
 For editable installs, this setting is on by default. Otherwise, it's
 off unless requested explicitly.

--- a/CHANGES/963.packaging.rst
+++ b/CHANGES/963.packaging.rst
@@ -1,0 +1,11 @@
+The leading ``--`` has been dropped from the :pep:`517` in-tree build
+backend config setting names. ``--pure-python`` is now just ``pure-python``
+-- by :user:`webknjaz`.
+
+The usage now looks as follows:
+
+.. code-block:: console
+
+    $ python -m build \
+        --config-setting=pure-python=true \
+        --config-setting=with-cython-tracing=true

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ cythonize: .cythonize
 
 
 .develop: .install-deps $(shell find yarl -type f)
-	@pip install -e . --config-settings=--pure-python=false
+	@pip install -e .
 	@touch .develop
 
 fmt:

--- a/README.rst
+++ b/README.rst
@@ -115,12 +115,12 @@ used with our wheels) the the tarball will be used to compile the library from
 the source code. It requires a C compiler and and Python headers installed.
 
 To skip the compilation you must explicitly opt-in by using a PEP 517
-configuration setting ``--pure-python``, or setting the ``YARL_NO_EXTENSIONS``
+configuration setting ``pure-python``, or setting the ``YARL_NO_EXTENSIONS``
 environment variable to a non-empty value, e.g.:
 
 .. code-block:: console
 
-   $ pip install yarl --config-settings=--pure-python=
+   $ pip install yarl --config-settings=pure-python=false
 
 Please note that the pure-Python (uncompiled) version is much slower. However,
 PyPy always uses a pure-Python implementation, and, as such, it is unaffected

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,12 +102,12 @@ used with our wheels) the the tarball will be used to compile the library from
 the source code. It requires a C compiler and and Python headers installed.
 
 To skip the compilation you must explicitly opt-in by using a PEP 517
-configuration setting ``--pure-python``, or setting the ``YARL_NO_EXTENSIONS``
+configuration setting ``pure-python``, or setting the ``YARL_NO_EXTENSIONS``
 environment variable to a non-empty value, e.g.:
 
 .. code-block:: console
 
-   $ pip install yarl --config-settings=--pure-python=
+   $ pip install yarl --config-settings=pure-python=false
 
 Please note that the pure-Python (uncompiled) version is much slower. However,
 PyPy always uses a pure-Python implementation, and, as such, it is unaffected

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -42,4 +42,5 @@ subclass
 subclasses
 svetlov
 uncompiled
+v1
 yarl

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -43,7 +43,7 @@ from distutils.dist import DistributionMetadata as _DistutilsDistributionMetadat
 with suppress(ImportError):
     # NOTE: Only available for wheel builds that bundle C-extensions. Declared
     # NOTE: by `get_requires_for_build_wheel()` and
-    # NOTE: `get_requires_for_build_editable()`, when `--pure-python`
+    # NOTE: `get_requires_for_build_editable()`, when `pure-python`
     # NOTE: is not passed.
     from Cython.Build.Cythonize import main as _cythonize_cli_cmd
 
@@ -70,13 +70,13 @@ __all__ = (  # noqa: WPS410
 )
 
 
-CYTHON_TRACING_CONFIG_SETTING = '--with-cython-tracing'
+CYTHON_TRACING_CONFIG_SETTING = 'with-cython-tracing'
 """Config setting name toggle to include line tracing to C-exts."""
 
 CYTHON_TRACING_ENV_VAR = 'YARL_CYTHON_TRACING'
 """Environment variable name toggle used to opt out of making C-exts."""
 
-PURE_PYTHON_CONFIG_SETTING = '--pure-python'
+PURE_PYTHON_CONFIG_SETTING = 'pure-python'
 """Config setting name toggle that is used to opt out of making C-exts."""
 
 PURE_PYTHON_ENV_VAR = 'YARL_NO_EXTENSIONS'
@@ -89,7 +89,7 @@ IS_CPYTHON = _system_implementation.name == "cpython"
 """A flag meaning that the current interpreter implementation is CPython."""
 
 PURE_PYTHON_MODE_CLI_FALLBACK = not IS_CPYTHON
-"""A fallback for `--pure-python` is not set."""
+"""A fallback for ``pure-python`` is not set."""
 
 
 def _is_truthy_setting_value(setting_value) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ PRE_COMMIT_COLOR = "always"
 PY_COLORS = "1"
 
 [tool.cibuildwheel.config-settings]
---pure-python = "false"
+pure-python = "false"
 
 [tool.cibuildwheel.windows]
 before-test = []  # Windows cmd has different syntax and pip chooses wheels

--- a/tools/build-wheels.sh
+++ b/tools/build-wheels.sh
@@ -50,7 +50,7 @@ for PYTHON in ${PYTHON_VERSIONS}; do
     /opt/python/${PYTHON}/bin/python -m pip install -r "${WORKDIR_PATH}/requirements/wheel.txt"
     PIP_CONSTRAINT="${WORKDIR_PATH}/requirements/cython.txt" \
       /opt/python/${PYTHON}/bin/python -m pip wheel "${SRC_DIR}/" \
-      --config-settings=--pure-python=false \
+      --config-settings=pure-python=false \
       --no-deps \
       -w "${ORIG_WHEEL_DIR}/${PYTHON}"
 done


### PR DESCRIPTION
Since these are not CLI options, there's no need to prefix them as ones. It is also less confusing to the unsuspecting reader.