### PR TITLE
Add shellcheck to pre-commit and make helper scripts clean

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -188,8 +188,8 @@ repos:
       ^input "attestations" is not defined in action
       "pypa/gh-action-pypi-publish@release/v1". available inputs are ".*"$
 
-- repo: https://github.com/koalaman/shellcheck-precommit
-  rev: v0.9.0
+- repo: https://github.com/shellcheck-py/shellcheck-py.git
+  rev: v0.10.0.1
   hooks:
   - id: shellcheck
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -188,4 +188,9 @@ repos:
       ^input "attestations" is not defined in action
       "pypa/gh-action-pypi-publish@release/v1". available inputs are ".*"$
 
+- repo: https://github.com/koalaman/shellcheck-precommit
+  rev: v0.9.0
+  hooks:
+  - id: shellcheck
+
 ...

--- a/tools/build-wheels.sh
+++ b/tools/build-wheels.sh
@@ -13,7 +13,7 @@ fi
 
 export WORKDIR_PATH="${GITHUB_WORKSPACE:-/io}"
 
-BUILD_DIR=`mktemp -d "/tmp/${package_name}-manylinux2010-build.XXXXXXXXXX"`
+BUILD_DIR=$(mktemp -d "/tmp/${package_name}-manylinux2010-build.XXXXXXXXXX")
 ORIG_WHEEL_DIR="${BUILD_DIR}/original-wheelhouse"
 SRC_DIR="${BUILD_DIR}/src"
 WHEELHOUSE_DIR="${WORKDIR_PATH}/dist"
@@ -26,7 +26,7 @@ PYTHON_VERSIONS="cp36-cp36m cp37-cp37m"
 # Avoid creation of __pycache__/*.py[c|o]
 export PYTHONDONTWRITEBYTECODE=1
 
-arch=`uname -m`
+arch=$(uname -m)
 
 echo
 echo
@@ -46,10 +46,10 @@ echo
 echo
 echo "Compile wheels"
 for PYTHON in ${PYTHON_VERSIONS}; do
-    /opt/python/${PYTHON}/bin/python -m pip install -U pip
-    /opt/python/${PYTHON}/bin/python -m pip install -r "${WORKDIR_PATH}/requirements/wheel.txt"
+    /opt/python/"${PYTHON}"/bin/python -m pip install -U pip
+    /opt/python/"${PYTHON}"/bin/python -m pip install -r "${WORKDIR_PATH}/requirements/wheel.txt"
     PIP_CONSTRAINT="${WORKDIR_PATH}/requirements/cython.txt" \
-      /opt/python/${PYTHON}/bin/python -m pip wheel "${SRC_DIR}/" \
+      /opt/python/"${PYTHON}"/bin/python -m pip wheel "${SRC_DIR}/" \
       --config-settings=pure-python=false \
       --no-deps \
       -w "${ORIG_WHEEL_DIR}/${PYTHON}"
@@ -66,7 +66,7 @@ done
 echo
 echo
 echo "Cleanup OS specific wheels"
-rm -fv ${WHEELHOUSE_DIR}/*-linux_*.whl
+rm -fv "${WHEELHOUSE_DIR}"/*-linux_*.whl
 
 echo
 echo
@@ -77,7 +77,7 @@ echo
 echo
 echo "Install packages and test"
 echo "dist directory:"
-ls ${WHEELHOUSE_DIR}
+ls "${WHEELHOUSE_DIR}"
 
 for PYTHON in ${PYTHON_VERSIONS}; do
     # clear python cache
@@ -85,8 +85,8 @@ for PYTHON in ${PYTHON_VERSIONS}; do
 
     echo
     echo -n "Test $PYTHON: "
-    /opt/python/${PYTHON}/bin/python -c "import platform; print('Building wheel for {platform} platform.'.format(platform=platform.platform()))"
-    /opt/python/${PYTHON}/bin/pip install -r ${WORKDIR_PATH}/requirements/ci-wheel.txt
-    /opt/python/${PYTHON}/bin/pip install "$package_name" --no-index -f "file://${WHEELHOUSE_DIR}"
-    /opt/python/${PYTHON}/bin/py.test ${WORKDIR_PATH}/tests
+    /opt/python/"${PYTHON}"/bin/python -c "import platform; print('Building wheel for {platform} platform.'.format(platform=platform.platform()))"
+    /opt/python/"${PYTHON}"/bin/pip install -r "${WORKDIR_PATH}"/requirements/ci-wheel.txt
+    /opt/python/"${PYTHON}"/bin/pip install "$package_name" --no-index -f "file://${WHEELHOUSE_DIR}"
+    /opt/python/"${PYTHON}"/bin/py.test "${WORKDIR_PATH}"/tests
 done

--- a/tools/build-wheels.sh
+++ b/tools/build-wheels.sh
@@ -58,7 +58,7 @@ done
 echo
 echo
 echo "Bundle external shared libraries into the wheels"
-for whl in ${ORIG_WHEEL_DIR}/*/${package_name}-*-linux_${arch}.whl; do
+for whl in "${ORIG_WHEEL_DIR}"/*/"${package_name}"-*-linux_"${arch}".whl; do
     echo "Repairing $whl..."
     auditwheel repair "$whl" -w "${WHEELHOUSE_DIR}"
 done

--- a/tools/run_docker.sh
+++ b/tools/run_docker.sh
@@ -27,12 +27,12 @@ do
     echo
     echo
     arch_pull_pid=${docker_pull_pids[$arch]}
-    echo Waiting for docker pull PID $arch_pull_pid to complete downloading container for $arch arch...
-    wait $arch_pull_pid  # await for docker image for current arch to be pulled from hub
+    echo Waiting for docker pull PID "$arch_pull_pid" to complete downloading container for $arch arch...
+    wait "$arch_pull_pid"  # await for docker image for current arch to be pulled from hub
     [ $arch == "i686" ] && dock_ext_args="linux32"
 
     echo Building wheel for $arch arch
-    docker run --rm -v `pwd`:/io "${manylinux1_image_prefix}${arch}" $dock_ext_args /io/tools/build-wheels.sh "$package_name"
+    docker run --rm -v $(pwd):/io "${manylinux1_image_prefix}${arch}" $dock_ext_args /io/tools/build-wheels.sh "$package_name"
 
     dock_ext_args=""  # Reset docker args, just in case
 done

--- a/tools/run_docker.sh
+++ b/tools/run_docker.sh
@@ -32,7 +32,7 @@ do
     [ $arch == "i686" ] && dock_ext_args="linux32"
 
     echo Building wheel for $arch arch
-    docker run --rm -v $(pwd):/io "${manylinux1_image_prefix}${arch}" $dock_ext_args /io/tools/build-wheels.sh "$package_name"
+    docker run --rm -v "$(pwd):/io" "${manylinux1_image_prefix}${arch}" $dock_ext_args /io/tools/build-wheels.sh "$package_name"
 
     dock_ext_args=""  # Reset docker args, just in case
 done


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix up found helper shell scripts so they become more robust and shellcheck clean.

Adds shellcheck to pre-commit

## Are there changes in behavior for the user?

no

## Checklist

- [ ] Fix remaining fails

<details>
<summary>I left following ones not fixed to see if CI would run pre-commit to ensure that nothing sneaks in
</summary> 

```shell
❯ pre-commit run --all shellcheck
ShellCheck v0.9.0........................................................Failed
- hook id: shellcheck
- exit code: 1

In tools/build-wheels.sh line 61:
for whl in ${ORIG_WHEEL_DIR}/*/${package_name}-*-linux_${arch}.whl; do
           ^---------------^ SC2231 (info): Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt .
                               ^-------------^ SC2231 (info): Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt .
                                                       ^-----^ SC2231 (info): Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt .


In tools/run_docker.sh line 35:
    docker run --rm -v $(pwd):/io "${manylinux1_image_prefix}${arch}" $dock_ext_args /io/tools/build-wheels.sh "$package_name"
                       ^----^ SC2046 (warning): Quote this to prevent word splitting.

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2231 -- Quote expansions in this for loop...

```
</details>