### PR TITLE
Fix the Towncrier philosophy link

### DIFF
--- a/CHANGES/981.doc.rst
+++ b/CHANGES/981.doc.rst
@@ -1,0 +1,2 @@
+On the :doc:`Contributing docs <contributing/guidelines>` page,
+a link to the ``Towncrier philosophy`` has been fixed.

--- a/CHANGES/README.rst
+++ b/CHANGES/README.rst
@@ -106,4 +106,4 @@ File :file:`CHANGES/553.feature.rst`:
    (``tool.towncrier.type``).
 
 .. _Towncrier philosophy:
-   https://towncrier.readthedocs.io/en/actual-freaking-docs/#philosophy
+   https://towncrier.readthedocs.io/en/stable/#philosophy


### PR DESCRIPTION
_Hello @webknjaz,_

There's one more broken link to fix.

## What do these changes do?

These changes fix a broken link to `towncrier`'s philosophy.

## Are there changes in behavior for the user?

Link from [Contributing docs](https://yarl.aio-libs.org/en/latest/contributing/guidelines/#adding-change-notes-with-your-prs) to `towncrier`'s philosophy will be fixed.

## Related issue number

Similar PR:
  * aio-libs/frozenlist#574

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes
