### PR TITLE
Test lone surrogate handling in encoded and parsed URL paths

### DIFF
--- a/CHANGES/991.misc.rst
+++ b/CHANGES/991.misc.rst
@@ -1,0 +1,5 @@
+Added regression tests ensuring that lone surrogates produced by
+decoding invalid UTF-8 with ``surrogateescape`` are preserved when
+building a URL with ``encoded=True`` and are dropped consistently by
+the C and pure-Python quoting backends when parsing
+-- by :user:`pajod`.

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -580,6 +580,47 @@ class TestStripEmptyParts:
         assert u.query_string == ""
         assert u.fragment == ""
 
+    def test_truncated_utf_sequence(self) -> None:
+        # A truncated UTF-8 sequence decoded with surrogateescape yields lone
+        # surrogates. With encoded=True the caller takes responsibility for
+        # the value, so they are preserved verbatim; parsing the same path
+        # normally runs the quoter, which drops them, identically on the C
+        # and pure-Python backends.
+        raw_path = b"/P\xc3\xbcnktchen\xa0\xef\xb7#"
+        abspath, _hash_separator, frag = raw_path.decode(
+            "utf-8", "surrogateescape"
+        ).partition("#")
+        u = URL.build(path=abspath, query_string="", fragment=frag, encoded=True)
+        u2 = URL("/P%C3%BCnktchen\udca0\udcef\udcb7")
+        assert u.scheme == ""
+        assert u.user is None
+        assert u.password is None
+        assert u.path == "/Pünktchen\udca0\udcef\udcb7"
+        assert u.query_string == ""
+        assert u.fragment == ""
+        assert u2.raw_path == "/P%C3%BCnktchen"
+        assert u2.path == "/Pünktchen"
+
+    def test_truncated_utf_sequence_frag(self) -> None:
+        # Same as test_truncated_utf_sequence, with the lone surrogates
+        # appearing in the fragment as well as the path.
+        raw_path = b"/P\xc3\xbcnktchen\xa0\xef\xb7#P\xc3\xbcnktelchen\xa0\xef\xb6"
+        abspath, _hash_separator, frag = raw_path.decode(
+            "utf-8", "surrogateescape"
+        ).partition("#")
+        u = URL.build(path=abspath, query_string="", fragment=frag, encoded=True)
+        u2 = URL("/P%C3%BCnktchen\udca0\udcef\udcb7#Pünktelchen\udca0\udcef\udcb6")
+        assert u.scheme == ""
+        assert u.user is None
+        assert u.password is None
+        assert u.path == "/Pünktchen\udca0\udcef\udcb7"
+        assert u.query_string == ""
+        assert u.fragment == "Pünktelchen\udca0\udcef\udcb6"
+        assert u2.raw_path == "/P%C3%BCnktchen"
+        assert u2.path == "/Pünktchen"
+        assert u2.raw_fragment == "P%C3%BCnktelchen"
+        assert u2.fragment == "Pünktelchen"
+
 
 @pytest.mark.parametrize(
     ("scheme"),

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -580,46 +580,52 @@ class TestStripEmptyParts:
         assert u.query_string == ""
         assert u.fragment == ""
 
-    def test_truncated_utf_sequence(self) -> None:
+    @pytest.mark.parametrize(
+        ("raw_path", "parsed_url", "expected_raw_fragment", "expected_fragment"),
+        [
+            pytest.param(
+                b"/P\xc3\xbcnktchen\xa0\xef\xb7#",
+                "/P%C3%BCnktchen\udca0\udcef\udcb7",
+                "",
+                "",
+                id="path-only",
+            ),
+            pytest.param(
+                b"/P\xc3\xbcnktchen\xa0\xef\xb7#P\xc3\xbcnktelchen\xa0\xef\xb6",
+                "/P%C3%BCnktchen\udca0\udcef\udcb7#Pünktelchen\udca0\udcef\udcb6",
+                "P%C3%BCnktelchen",
+                "Pünktelchen",
+                id="path-and-fragment",
+            ),
+        ],
+    )
+    def test_truncated_utf_sequence(
+        self,
+        raw_path: bytes,
+        parsed_url: str,
+        expected_raw_fragment: str,
+        expected_fragment: str,
+    ) -> None:
         # A truncated UTF-8 sequence decoded with surrogateescape yields lone
         # surrogates. With encoded=True the caller takes responsibility for
-        # the value, so they are preserved verbatim; parsing the same path
-        # normally runs the quoter, which drops them, identically on the C
-        # and pure-Python backends.
-        raw_path = b"/P\xc3\xbcnktchen\xa0\xef\xb7#"
+        # the value, so they are preserved verbatim; parsing the same URL
+        # normally runs the quoter, which drops them from the path and the
+        # fragment alike, identically on the C and pure-Python backends.
         abspath, _hash_separator, frag = raw_path.decode(
             "utf-8", "surrogateescape"
         ).partition("#")
         u = URL.build(path=abspath, query_string="", fragment=frag, encoded=True)
-        u2 = URL("/P%C3%BCnktchen\udca0\udcef\udcb7")
+        u2 = URL(parsed_url)
         assert u.scheme == ""
         assert u.user is None
         assert u.password is None
         assert u.path == "/Pünktchen\udca0\udcef\udcb7"
         assert u.query_string == ""
-        assert u.fragment == ""
+        assert u.fragment == frag
         assert u2.raw_path == "/P%C3%BCnktchen"
         assert u2.path == "/Pünktchen"
-
-    def test_truncated_utf_sequence_frag(self) -> None:
-        # Same as test_truncated_utf_sequence, with the lone surrogates
-        # appearing in the fragment as well as the path.
-        raw_path = b"/P\xc3\xbcnktchen\xa0\xef\xb7#P\xc3\xbcnktelchen\xa0\xef\xb6"
-        abspath, _hash_separator, frag = raw_path.decode(
-            "utf-8", "surrogateescape"
-        ).partition("#")
-        u = URL.build(path=abspath, query_string="", fragment=frag, encoded=True)
-        u2 = URL("/P%C3%BCnktchen\udca0\udcef\udcb7#Pünktelchen\udca0\udcef\udcb6")
-        assert u.scheme == ""
-        assert u.user is None
-        assert u.password is None
-        assert u.path == "/Pünktchen\udca0\udcef\udcb7"
-        assert u.query_string == ""
-        assert u.fragment == "Pünktelchen\udca0\udcef\udcb6"
-        assert u2.raw_path == "/P%C3%BCnktchen"
-        assert u2.path == "/Pünktchen"
-        assert u2.raw_fragment == "P%C3%BCnktelchen"
-        assert u2.fragment == "Pünktelchen"
+        assert u2.raw_fragment == expected_raw_fragment
+        assert u2.fragment == expected_fragment
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds regression tests for lone surrogates produced by decoding invalid
UTF-8 with ``surrogateescape``. Building a URL with ``encoded=True``
preserves them verbatim, while parsing the same path percent-encodes the
valid text and drops the surrogates, identically on the C and
pure-Python quoting backends.

When this PR was opened it demonstrated a divergence between the two
backends: the compiled quoter kept lone surrogates that the pure-Python
quoter dropped. That gap was closed by #1799, #1751 and #1752, so the
tests now assert the shared behaviour and pass both with the compiled
extension and with `YARL_NO_EXTENSIONS=1`.

## Are there changes in behavior for the user?

No, tests only.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Related to https://github.com/aio-libs/aiohttp/pull/8088 and to #1799,
#1751 and #1752, which resolved the inconsistency these tests originally
demonstrated.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes (N/A; tests only, no public API change)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
