### PR TITLE
Prevent copying tmp dir to itself in build backend

### DIFF
--- a/CHANGES/1014.packaging.rst
+++ b/CHANGES/1014.packaging.rst
@@ -1,0 +1,9 @@
+A flaw in the logic for copying the project directory into a
+temporary folder that led to infinite recursion when :envvar:`TMPDIR`
+was set to a project subdirectory path. This was happening in Fedora
+and its downstream due to the use of `pyproject-rpm-macros
+<https://src.fedoraproject.org/rpms/pyproject-rpm-macros>`__. It was
+only reproducible with ``pip wheel`` and was not affecting the
+``pyproject-build`` users.
+
+-- by :user:`hroncok` and :user:`webknjaz`

--- a/CHANGES/992.packaging.rst
+++ b/CHANGES/992.packaging.rst
@@ -1,0 +1,1 @@
+1014.packaging.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -442,6 +442,9 @@ texinfo_documents = [
 
 default_role = "any"
 nitpicky = True
+nitpick_ignore = [
+    ("envvar", "TMPDIR"),
+]
 
 # -- Options for towncrier_draft extension -----------------------------------
 

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -199,7 +199,17 @@ def _in_temporary_directory(src_dir: Path) -> t.Iterator[None]:
     with TemporaryDirectory(prefix='.tmp-yarl-pep517-') as tmp_dir:
         with chdir_cm(tmp_dir):
             tmp_src_dir = Path(tmp_dir) / 'src'
-            copytree(src_dir, tmp_src_dir, symlinks=True)
+
+            def _ignore(d, _):
+                """
+                Prevent temporary directory to be copied into self
+                recursively forever.
+                Fixes https://github.com/aio-libs/yarl/issues/992
+                """
+                if Path(d) == tmp_src_dir.parent:
+                    return [tmp_src_dir.name]
+                return []
+            copytree(src_dir, tmp_src_dir, symlinks=True, ignore=_ignore)
             os.chdir(tmp_src_dir)
             yield
 

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 import typing as t
 from contextlib import contextmanager, nullcontext, suppress
+from functools import partial
 from pathlib import Path
 from shutil import copytree
 from sys import implementation as _system_implementation
@@ -194,22 +195,44 @@ def patched_dist_get_long_description():
         _DistutilsDistributionMetadata.get_long_description = _orig_func
 
 
+def _exclude_dir_path(
+    excluded_dir_path: Path,
+    visited_directory: str,
+    _visited_dir_contents: list[str],
+) -> list[str]:
+    """Prevent recursive directory traversal."""
+    # This stops the temporary directory from being copied
+    # into self recursively forever.
+    # Ref: https://github.com/aio-libs/yarl/issues/992
+    visited_directory_subdirs_to_ignore = [
+        subdir
+        for subdir in _visited_dir_contents
+        if excluded_dir_path == Path(visited_directory) / subdir
+    ]
+    if visited_directory_subdirs_to_ignore:
+        print(
+            f'Preventing `{excluded_dir_path !s}` from being '
+            'copied into itself recursively...',
+            file=_standard_error_stream,
+        )
+    return visited_directory_subdirs_to_ignore
+
+
 @contextmanager
 def _in_temporary_directory(src_dir: Path) -> t.Iterator[None]:
     with TemporaryDirectory(prefix='.tmp-yarl-pep517-') as tmp_dir:
-        with chdir_cm(tmp_dir):
-            tmp_src_dir = Path(tmp_dir) / 'src'
+        tmp_dir_path = Path(tmp_dir)
+        root_tmp_dir_path = tmp_dir_path.parent
+        _exclude_tmpdir_parent = partial(_exclude_dir_path, root_tmp_dir_path)
 
-            def _ignore(d, _):
-                """
-                Prevent temporary directory to be copied into self
-                recursively forever.
-                Fixes https://github.com/aio-libs/yarl/issues/992
-                """
-                if Path(d) == tmp_src_dir.parent:
-                    return [tmp_src_dir.name]
-                return []
-            copytree(src_dir, tmp_src_dir, symlinks=True, ignore=_ignore)
+        with chdir_cm(tmp_dir):
+            tmp_src_dir = tmp_dir_path / 'src'
+            copytree(
+                src_dir,
+                tmp_src_dir,
+                ignore=_exclude_tmpdir_parent,
+                symlinks=True,
+            )
             os.chdir(tmp_src_dir)
             yield
 


### PR DESCRIPTION
Previously, setting `TMPDIR="$(pwd)/smth-inside"` would cause the
in-tree PEP 517 build backend to go into infinite recursion,
attempting to copy the project directory into a nested folder.

Specifically, this is happening in the Fedora land because macros
used in RPM packaging (`pyproject-rpm-macros`) are setting it up
like this. Additionally, this is only happening with `pip wheel` and
doesn't affect `pyproject-build`, because the latter pre-copies the
project directory by itself early, and changes current working
directory to it while the former does not.

This patch addresses the issue by excluding the temporary directory
from traversal when copying the directory tree within the build
backend.

Fixes #992.