### PR TITLE
🧪 Build `arm64` wheels in pull requests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -172,28 +172,41 @@ jobs:
         - 3.8
         - 3.7
         no-extensions: ['', 'Y']
-        os: [ubuntu, macos, windows]
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
         experimental: [false]
         exclude:
-        - os: macos
+        - os: macos-latest
           no-extensions: Y
-        - os: windows
+        - os: windows-latest
           no-extensions: Y
+        - os: macos-latest
+          pyver: 3.7  # Python < v3.8 does not support Apple Silicon ARM64
         include:
         - pyver: pypy-3.10
           no-extensions: Y
           experimental: false
-          os: ubuntu
+          os: ubuntu-latest
         - pyver: pypy-3.9
           no-extensions: Y
           experimental: false
-          os: ubuntu
+          os: ubuntu-latest
         - pyver: pypy-3.8
           no-extensions: Y
           experimental: false
-          os: ubuntu
+          os: ubuntu-latest
+        - os: macos-13  # run legacy versions on Intel CPUs
+          pyver: 3.7
+          no-extensions: ''
+          experimental: false
+        - os: macos-13  # run legacy versions on Intel CPUs
+          pyver: 3.7
+          no-extensions: Y
+          experimental: false
       fail-fast: false
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     continue-on-error: ${{ matrix.experimental }}
     steps:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -139,7 +139,6 @@ jobs:
         *-macosx_universal2
         *-musllinux_*
         *-win32
-        *_arm64
         pp*'
         || ''
         }}

--- a/CHANGES/1015.contrib.rst
+++ b/CHANGES/1015.contrib.rst
@@ -1,0 +1,3 @@
+The CI/CD setup has been updated to test ``arm64`` wheels
+under macOS 14, except for Python 3.7 that is unsupported
+in that environment -- by :user:`webknjaz`.


### PR DESCRIPTION
This is needed since GitHub Actions CI/CD workflows switched their default macOS runners to `arm64` and this caused the test jobs to start running tests against pure-python wheels.

Additionally, this PR sets up Python 3.7 tests to run on older macOS 13.

Refs:
* https://github.com/psf/cachecontrol/pull/334
* https://github.com/actions/setup-python/issues/856