### PR TITLE
Fix trailing slash dropped since v1.9.1

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -800,6 +800,9 @@ def test_div_with_dots():
             "/path/", ("to",), "http://example.com/path/to", id="path-with-slash"
         ),
         pytest.param(
+            "/path", ("",), "http://example.com/path/", id="path-add-trailing-slash"
+        ),
+        pytest.param(
             "/path?a=1#frag",
             ("to",),
             "http://example.com/path/to",

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -807,6 +807,15 @@ def test_div_with_dots():
         ),
         pytest.param("", ("path/",), "http://example.com/path/", id="trailing-slash"),
         pytest.param(
+            "",
+            (
+                "path",
+                "",
+            ),
+            "http://example.com/path/",
+            id="trailing-slash-empty-string",
+        ),
+        pytest.param(
             "", ("path/", "to/"), "http://example.com/path/to/", id="duplicate-slash"
         ),
         pytest.param("", (), "http://example.com", id="empty-segments"),

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -718,9 +718,7 @@ class URL:
         # keep the trailing slash if the last segment ends with /
         parsed = [""] if segments and segments[-1][-1:] == "/" else []
         for seg in reversed(segments):
-            if not seg:
-                continue
-            if seg[0] == "/":
+            if seg and seg[0] == "/":
                 raise ValueError(
                     f"Appending path {seg!r} starting from slash is forbidden"
                 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add back the ability to join with an empty string `""`, resulting in the `/` being appended to the URL. This was broken in v1.9.1, and since then it's not possible to create a URL with a trailing backslash (without doing string manipulation on the last segment).

## Are there changes in behavior for the user?

Yes, fix a regression introuduced in v1.9.1, where you can't join "" expecting to have a trailing "/" appended to the URL.

## Related issue number
Fixes https://github.com/aio-libs/yarl/issues/984.

Fixes https://github.com/aio-libs/yarl/issues/926.

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
