### PR TITLE
🚑🧪 Store absolute paths in coverage database

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,7 +14,7 @@ show_missing = true
 branch = true
 cover_pylib = false
 plugins = Cython.Coverage
-relative_files = true
+relative_files = false
 source =
   tests
 source_pkgs =


### PR DESCRIPTION
This will hopefully act as a workaround for the codecov-action v4 regression that stopped understanding relative paths.