### PR TITLE
Normalize URL string ports per RFC 3986 section 3.2.3

### DIFF
--- a/CHANGES/1033.bugfix.rst
+++ b/CHANGES/1033.bugfix.rst
@@ -1,4 +1,4 @@
 Normalize default ports according to :rfc:`3986`.
 
-Specified ports are removed from the str representation of an URL if the port matches
-the schemes default port -- by :user:`commonism`.
+Specified ports are removed from the :class:`str` representation of a :class:`~yarl.URL`
+if the port matches the scheme's default port -- by :user:`commonism`.

--- a/CHANGES/1033.bugfix.rst
+++ b/CHANGES/1033.bugfix.rst
@@ -1,4 +1,6 @@
-Normalize default ports according to :rfc:`3986`.
+The default protocol ports of well-known URI schemes are now taken into account
+during the normalization of the URL string representation in accordance with
+:rfc:`3986#section-3.2.3`.
 
 Specified ports are removed from the :class:`str` representation of a :class:`~yarl.URL`
 if the port matches the scheme's default port -- by :user:`commonism`.

--- a/CHANGES/1033.bugfix.rst
+++ b/CHANGES/1033.bugfix.rst
@@ -1,4 +1,4 @@
 Normalize default ports according to :rfc:`3986`.
 
 Specified ports are removed from the str representation of an URL if the port matches
-the schemes default port. -- by :user:`commonism`.
+the schemes default port -- by :user:`commonism`.

--- a/CHANGES/1033.bugfix.rst
+++ b/CHANGES/1033.bugfix.rst
@@ -1,0 +1,4 @@
+Normalize default ports according to :rfc:`3986`.
+
+Specified ports are removed from the str representation of an URL if the port matches
+the schemes default port. -- by :user:`commonism`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -219,6 +219,12 @@ def test_authority_full_nonasci() -> None:
     assert url.authority == "степан:пароль@слава.укр:8080"
 
 
+def test_authority_unknown_scheme():
+    v = "scheme://user:password@example.com:43/path/to?a=1&b=2"
+    url = URL(v)
+    assert str(url) == v
+
+
 def test_lowercase():
     url = URL("http://gitHUB.com")
     assert url.raw_host == "github.com"
@@ -1332,6 +1338,7 @@ def test_is_default_port_for_absolute_url_without_port():
 def test_is_default_port_for_absolute_url_with_default_port():
     url = URL("http://example.com:80")
     assert url.is_default_port()
+    assert str(url) == "http://example.com"
 
 
 def test_is_default_port_for_absolute_url_with_nondefault_port():
@@ -1542,7 +1549,7 @@ def test_parent_for_empty_url():
 
 def test_empty_value_for_query():
     url = URL("http://example.com/path").with_query({"a": ""})
-    assert str(url) == "http://example.com/path?a="
+    assert str(url) == "http://example.com/path?a"
 
 
 def test_none_value_for_query():

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1549,7 +1549,7 @@ def test_parent_for_empty_url():
 
 def test_empty_value_for_query():
     url = URL("http://example.com/path").with_query({"a": ""})
-    assert str(url) == "http://example.com/path?a"
+    assert str(url) == "http://example.com/path?a="
 
 
 def test_none_value_for_query():

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -219,7 +219,7 @@ def test_authority_full_nonasci() -> None:
     assert url.authority == "степан:пароль@слава.укр:8080"
 
 
-def test_authority_unknown_scheme():
+def test_authority_unknown_scheme() -> None:
     v = "scheme://user:password@example.com:43/path/to?a=1&b=2"
     url = URL(v)
     assert str(url) == v

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -191,14 +191,14 @@ def test_with_port():
     assert str(url.with_port(8888)) == "http://example.com:8888"
 
 
-def test_with_default_port_normalization():
+def test_with_default_port_normalization() -> None:
     url = URL("http://example.com")
     assert str(url.with_scheme("https")) == "https://example.com"
     assert str(url.with_scheme("https").with_port(443)) == "https://example.com"
     assert str(url.with_port(443).with_scheme("https")) == "https://example.com"
 
 
-def test_with_custom_port_normalization():
+def test_with_custom_port_normalization() -> None:
     url = URL("http://example.com")
     u88 = url.with_port(88)
     assert str(u88) == "http://example.com:88"
@@ -206,7 +206,7 @@ def test_with_custom_port_normalization():
     assert str(u88.with_scheme("https")) == "https://example.com:88"
 
 
-def test_with_explicit_port_normalization():
+def test_with_explicit_port_normalization() -> None:
     url = URL("http://example.com")
     u80 = url.with_port(80)
     assert str(u80) == "http://example.com"

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -191,18 +191,23 @@ def test_with_port():
     assert str(url.with_port(8888)) == "http://example.com:8888"
 
 
-def test_with_port_normalization():
+def test_with_default_port_normalization():
     url = URL("http://example.com")
-
     assert str(url.with_scheme("https")) == "https://example.com"
     assert str(url.with_scheme("https").with_port(443)) == "https://example.com"
     assert str(url.with_port(443).with_scheme("https")) == "https://example.com"
 
+
+def test_with_custom_port_normalization():
+    url = URL("http://example.com")
     u88 = url.with_port(88)
     assert str(u88) == "http://example.com:88"
     assert str(u88.with_port(80)) == "http://example.com"
     assert str(u88.with_scheme("https")) == "https://example.com:88"
 
+
+def test_with_explicit_port_normalization():
+    url = URL("http://example.com")
     u80 = url.with_port(80)
     assert str(u80) == "http://example.com"
     assert str(u80.with_port(81)) == "http://example.com:81"

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -191,6 +191,24 @@ def test_with_port():
     assert str(url.with_port(8888)) == "http://example.com:8888"
 
 
+def test_with_port_normalization():
+    url = URL("http://example.com")
+
+    assert str(url.with_scheme("https")) == "https://example.com"
+    assert str(url.with_scheme("https").with_port(443)) == "https://example.com"
+    assert str(url.with_port(443).with_scheme("https")) == "https://example.com"
+
+    u88 = url.with_port(88)
+    assert str(u88) == "http://example.com:88"
+    assert str(u88.with_port(80)) == "http://example.com"
+    assert str(u88.with_scheme("https")) == "https://example.com:88"
+
+    u80 = url.with_port(80)
+    assert str(u80) == "http://example.com"
+    assert str(u80.with_port(81)) == "http://example.com:81"
+    assert str(u80.with_scheme("https")) == "https://example.com:80"
+
+
 def test_with_port_with_no_port():
     url = URL("http://example.com")
     assert str(url.with_port(None)) == "http://example.com"

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -198,7 +198,7 @@ def test_with_port_with_no_port():
 
 def test_with_port_ipv6():
     url = URL("http://[::1]:8080/")
-    assert str(url.with_port(80)) == "http://[::1]:80/"
+    assert str(url.with_port(81)) == "http://[::1]:81/"
 
 
 def test_with_port_keeps_query_and_fragment():

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -552,7 +552,7 @@ class URL:
         scheme without default port substitution.
 
         """
-        return self._val.port or DEFAULT_PORTS.get(self._val.scheme)
+        return self._val.port or self._get_default_port()
 
     @property
     def explicit_port(self):

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -394,7 +394,7 @@ class URL:
         e.g. 'http://python.org' or 'http://python.org:80', False
         otherwise.
 
-        Return False for relative URLs
+        Return False for relative URLs.
 
         """
         if self.explicit_port is None:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -5,6 +5,7 @@ import warnings
 from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from ipaddress import ip_address
+from typing import Union
 from urllib.parse import SplitResult, parse_qsl, quote, urljoin, urlsplit, urlunsplit
 
 import idna

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -396,7 +396,7 @@ class URL:
         """
         if self.port is None:
             return False
-        default = DEFAULT_PORTS.get(self.scheme)
+        default = self._get_default_port()
         if default is None:
             return False
         return self.port == default
@@ -446,19 +446,20 @@ class URL:
         """
         return self._val.netloc
 
+    def _get_default_port(self):
+        port = None
+        if self.scheme:
+            port = DEFAULT_PORTS.get(self.scheme)
+            if port is None:
+                with suppress(OSError):
+                    port = socket.getservbyname(self.scheme)
+        return port
+
     def _get_port(self):
         """Port or None if default port"""
-        port = self.port
-        if self.scheme:
-            p = DEFAULT_PORTS.get(self.scheme)
-            if p == self.port:
-                port = None
-            elif p is None:
-                with suppress(OSError):
-                    p = socket.getservbyname(self.scheme)
-                    if p == self.port:
-                        port = None
-        return port
+        if self._get_default_port() == self.port:
+            return None
+        return self.port
 
     @cached_property
     def authority(self):

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -450,7 +450,7 @@ class URL:
         """
         return self._val.netloc
 
-    def _get_default_port(self):
+    def _get_default_port(self) -> Optional[int]:
         port = None
         if self.scheme:
             port = DEFAULT_PORTS.get(self.scheme)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -468,7 +468,7 @@ class URL:
 
         """
         return self._make_netloc(
-            self.user, self.password, self.host, self._get_port(), encode_host=False
+            self.user, self.password, self.host, self.port, encode_host=False
         )
 
     @property

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -393,9 +393,14 @@ class URL:
         e.g. 'http://python.org' or 'http://python.org:80', False
         otherwise.
 
+        Return False for relative URLs
+
         """
-        if self.port is None:
-            return False
+        if self.explicit_port is None:
+            """
+            a relative URL does not have an implicit port / default port
+            """
+            return self.port is not None
         default = self._get_default_port()
         if default is None:
             return False

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -757,7 +757,9 @@ class URL:
                     f"Appending path {path!r} starting from slash is forbidden"
                 )
             path = path if encoded else self._PATH_QUOTER(path)
-            segments = list(reversed(path.split("/")))
+            segments = [
+                segment for segment in reversed(path.split("/")) if segment != "."
+            ]
             if not segments:
                 continue
             # remove trailing empty segment for all but the last path

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -450,7 +450,7 @@ class URL:
         """
         return self._val.netloc
 
-    def _get_default_port(self) -> Optional[int]:
+    def _get_default_port(self) -> Union[int, None]:
         if not self.scheme:
             return None
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -294,6 +294,7 @@ class URL:
         if not val.path and self.is_absolute() and (val.query or val.fragment):
             val = val._replace(path="/")
         if (port := self._get_port()) is None:
+            # port normalization - using None for default ports to remove from rendering
             # https://datatracker.ietf.org/doc/html/rfc3986.html#section-6.2.3
             val = val._replace(
                 netloc=self._make_netloc(

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -464,7 +464,7 @@ class URL:
 
         return None
 
-    def _get_port(self):
+    def _get_port(self) -> Union[int, None]:
         """Port or None if default port"""
         if self._get_default_port() == self.port:
             return None

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -397,9 +397,7 @@ class URL:
 
         """
         if self.explicit_port is None:
-            """
-            a relative URL does not have an implicit port / default port
-            """
+            # A relative URL does not have an implicit port / default port
             return self.port is not None
         default = self._get_default_port()
         if default is None:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -451,13 +451,16 @@ class URL:
         return self._val.netloc
 
     def _get_default_port(self) -> Optional[int]:
-        port = None
-        if self.scheme:
-            port = DEFAULT_PORTS.get(self.scheme)
-            if port is None:
-                with suppress(OSError):
-                    port = socket.getservbyname(self.scheme)
-        return port
+        if not self.scheme:
+            return None
+
+        with suppress(KeyError):
+            return DEFAULT_PORTS[self.scheme]
+
+        with suppress(OSError):
+            return socket.getservbyname(self.scheme)
+
+        return None
 
     def _get_port(self):
         """Port or None if default port"""

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -293,6 +293,7 @@ class URL:
         if not val.path and self.is_absolute() and (val.query or val.fragment):
             val = val._replace(path="/")
         if (port := self._get_port()) is None:
+            # https://datatracker.ietf.org/doc/html/rfc3986.html#section-6.2.3
             val = val._replace(
                 netloc=self._make_netloc(
                     self.raw_user,


### PR DESCRIPTION
## What do these changes do?

The changes add a missing step in rfc3986 normalization - strip default port from URL str representation.

## Are there changes in behavior for the user?

Yes

## Related issue number

https://github.com/aio-libs/yarl/pull/1023#discussion_r1636861213
> In the future, with another PR, I think the only normalisation step currently missing is https://datatracker.ietf.org/doc/html/rfc3986.html#section-6.2.3
> Which would include (for HTTP/HTTPS schemes) setting the path to / when empty and removing the port number when matching the default 80/443.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
