### PR TITLE
Enforce towncrier requirements for docs to fix CI

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,2 +1,2 @@
 -r test.txt
-towncrier==23.11.0
+-r towncrier.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -1,3 +1,4 @@
+-r towncrier.txt
 myst-parser >= 0.10.0
 sphinx==7.4.7
 sphinxcontrib-towncrier


### PR DESCRIPTION
Starting with the release of towncrier 24.7 the CI/CD regulary fails as the linter does not work.

sphinxcontrib-towncrier does have an upper boundary for the towncrier version and is incompatible to 24.7.
c.f. https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/92

Installing tc 23.11 for docs to avoid getting 24.7.