### PR TITLE
Bump black from 24.4.2 to 24.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   hooks:
   - id: isort
 - repo: https://github.com/psf/black
-  rev: '24.4.2'
+  rev: '24.8.0'
   hooks:
   - id: black
     language_version: python3  # Should be a command that runs python


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Bump black to 24.8.0

black keeps moving the mypy ignore in https://github.com/aio-libs/yarl/pull/1031 Newer versions are supposed to be better about this.

