### PR TITLE
Fix get-releasenote parsing the changelog

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -431,7 +431,7 @@ jobs:
         version_file: ${{ env.PROJECT_NAME }}/__init__.py
         github_token: ${{ secrets.GITHUB_TOKEN }}
         head_line: >-
-          v{version}\n{'=' * (len(version) + 1)}\n\n\*\({date}\)\*\n
+          {version}\n=+\n\n\*\({date}\)\*\n
         fix_issue_regex: >-
           :issue:`(\d+)`
         fix_issue_repl: >-

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,11 @@ Changelog
 
 .. towncrier release notes start
 
-1.9.5 (2024-08-30)
-==================
+1.9.5
+=====
+
+*(2024-08-30)*
+
 
 Bug fixes
 ---------


### PR DESCRIPTION
Adjust ci workflow to handle the format change in 4eb7dfa05a79222472bf37802a9b90928865f635 as the 1.9.5 release failed with `KeyError: "'=' * (len(version) + 1)"`

Tested with

```
(venv) yarl % git checkout version_format_ci
Switched to branch 'version_format_ci'
(venv) yarl %  INPUT_CHANGES_FILE="CHANGES.rst" INPUT_OUTPUT_FILE="release_note.md" INPUT_VERSION_FILE="yarl/__init__.py" INPUT_START_LINE=".. towncrier release notes start" INPUT_HEAD_LINE="{version}\n=+\n\n\*\({date}\)\*\n" INPUT_FIX_ISSUE_REGEX=':issue:`(\d+)`' INPUT_FIX_ISSUE_REPL="#\1" INPUT_DIST_DIR="dist" INPUT_VERSION="" INPUT_CHECK_REF="" INPUT_NAME="yarl" python3 get_releasenote.py
::set-output name=version::1.9.5
::set-output name=prerelease::false
::set-output name=devrelease::false
```