### PR TITLE
Release 1.9.6

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,26 @@ Changelog
 
 .. towncrier release notes start
 
+1.9.6
+=====
+
+*(2024-08-30)*
+
+
+Bug fixes
+---------
+
+- Reverted :rfc:`3986` compatible :meth:`URL.join() <yarl.URL.join>` honoring empty segments which was introduced in :issue:`1039`.
+
+  This change introduced a regression handling query string parameters with joined URLs. The change was reverted to maintain compatibility with the previous behavior.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1067`.
+
+
+----
+
+
 1.9.5
 =====
 
@@ -98,6 +118,11 @@ Removals and backward incompatible breaking changes
 
   *Related issues and pull requests on GitHub:*
   :issue:`1057`.
+
+- Dropped support for Python 3.7 -- by :user:`Dreamsorcerer`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1016`.
 
 
 Improved documentation

--- a/CHANGES/1016.removal.rst
+++ b/CHANGES/1016.removal.rst
@@ -1,1 +1,0 @@
-Dropped support for Python 3.7 -- by :user:`Dreamsorcerer`.

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,5 +1,5 @@
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.9.6.dev0"
+__version__ = "1.9.6"
 
 __all__ = ("URL", "cache_clear", "cache_configure", "cache_info")


### PR DESCRIPTION
~~https://github.com/aio-libs/yarl/actions/runs/10642760388~~ failed. (forgot to [drop `v`](https://yarl.aio-libs.org/en/latest/contributing/release_guide/#pre-release-activities) from CHANGES.rst)
https://github.com/aio-libs/yarl/actions/runs/10643373937

Re-release to revert https://github.com/aio-libs/yarl/pull/1039 since it introduced a regression in query string handling with `%2B` (aka `+`) and url joins.

See https://github.com/aio-libs/yarl/pull/1066 for test case

<img width="683" alt="Screenshot 2024-08-30 at 7 24 06 PM" src="https://github.com/user-attachments/assets/f178fca3-a44d-4ebf-b3a3-612072c87945">



