### PR TITLE
Cleanup released changelog messages

### DIFF
--- a/CHANGES/1067.bugfix.rst
+++ b/CHANGES/1067.bugfix.rst
@@ -1,3 +1,0 @@
-Reverted RFC3986 compatible URL.join honoring empty segments which was introduced in :issue:`1039`.
-
-This change introduced a regression handling query string parameters with joined URLs. The change was reverted to maintain compatibility with the previous behavior.


### PR DESCRIPTION
I missed removing this late last night when I did the 1.9.6 release to revert the change that caused the query string decoding regression with joined URLs.


