### PR TITLE
🧪🚑 Fix coverage.py-included paths @ XML

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -16,6 +16,6 @@ cover_pylib = false
 plugins = Cython.Coverage
 relative_files = true
 source =
-  tests
+  .
 source_pkgs =
   yarl


### PR DESCRIPTION
This patch fixes the directory misattribution of test file paths by marking the entire repository directory as source.

closes #1071