### PR TITLE
Remove fallback to getservbyname in _get_default_port

### DIFF
--- a/CHANGES/1076.breaking.rst
+++ b/CHANGES/1076.breaking.rst
@@ -1,0 +1,3 @@
+Removed support :rfc:`3986#section-3.2.3` port normalization when the scheme is not one of ``http``, ``https``, ``wss``, or ``ws`` -- by :user:`bdraco`.
+
+Support for port normalization was recently added in :issue:`1033` and contained code that would do blocking I/O if the scheme was not one of the four listed above. The code has been removed because this library is intended to be async safe.

--- a/CHANGES/1076.breaking.rst
+++ b/CHANGES/1076.breaking.rst
@@ -1,3 +1,3 @@
 Removed support :rfc:`3986#section-3.2.3` port normalization when the scheme is not one of ``http``, ``https``, ``wss``, or ``ws`` -- by :user:`bdraco`.
 
-Support for port normalization was recently added in :issue:`1033` and contained code that would do blocking I/O if the scheme was not one of the four listed above. The code has been removed because this library is intended to be async safe.
+Support for port normalization was recently added in :issue:`1033` and contained code that would do blocking I/O if the scheme was not one of the four listed above. The code has been removed because this library is intended to be safe for usage with ``asyncio``.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1,6 +1,5 @@
 import functools
 import math
-import socket
 import warnings
 from collections.abc import Mapping, Sequence
 from contextlib import suppress
@@ -425,14 +424,7 @@ class URL:
     def _get_default_port(self) -> Union[int, None]:
         if not self.scheme:
             return None
-
-        with suppress(KeyError):
-            return DEFAULT_PORTS[self.scheme]
-
-        with suppress(OSError):
-            return socket.getservbyname(self.scheme)
-
-        return None
+        return DEFAULT_PORTS.get(self.scheme)
 
     def _get_port(self) -> Union[int, None]:
         """Port or None if default port"""

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -422,9 +422,10 @@ class URL:
         return self._val.netloc
 
     def _get_default_port(self) -> Union[int, None]:
-        if not self.scheme:
+        scheme = self.scheme
+        if not scheme:
             return None
-        return DEFAULT_PORTS.get(self.scheme)
+        return DEFAULT_PORTS.get(scheme)
 
     def _get_port(self) -> Union[int, None]:
         """Port or None if default port"""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Remove support [RFC 3986 section-3.2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.3) port normalization when the scheme is not one of `http`, `https`, `wss`, or `ws`.

Support for port normalization was recently added in #1033 and contained code that would do blocking I/O if the scheme was not one of the four listed above. The code has been removed because this library is intended to be safe for usage with `asyncio`.

Additional details can be found in issue #1075

## Are there changes in behavior for the user?

RFC 3986 section 3.2.3 port normalization will only work for `http`, `https`, `ws`, and `wss`

## Related issue number

fixes #1075

## Checklist
