### PR TITLE
Cleanup asyncio reference in the 1.9.7 changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ Removals and backward incompatible breaking changes
 
 - Removed support :rfc:`3986#section-3.2.3` port normalization when the scheme is not one of ``http``, ``https``, ``wss``, or ``ws`` -- by :user:`bdraco`.
 
-  Support for port normalization was recently added in :issue:`1033` and contained code that would do blocking I/O if the scheme was not one of the four listed above. The code has been removed because this library is intended to be safe for usage with ``asyncio``.
+  Support for port normalization was recently added in :issue:`1033` and contained code that would do blocking I/O if the scheme was not one of the four listed above. The code has been removed because this library is intended to be safe for usage with :mod:`asyncio`.
 
   *Related issues and pull requests on GitHub:*
   :issue:`1076`.


### PR DESCRIPTION
reference https://github.com/aio-libs/yarl/pull/1076#discussion_r1740185791

<img width="658" alt="Screenshot 2024-09-01 at 10 12 21 AM" src="https://github.com/user-attachments/assets/ebdf2837-d72d-42a6-a923-7177274c64f9">
