### PR TITLE
Improve performance of handling ports in the URL

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,6 +15,11 @@ comment:
 coverage:
   range: 99.34..100
   status:
+    patch:
+      default:
+        target: 100%
+        flags:
+        - pytest
     project:
       default:
         target: 100%

--- a/CHANGES/1081.misc.rst
+++ b/CHANGES/1081.misc.rst
@@ -1,1 +1,1 @@
-Improved performance of handling ports -- by :user:.
+Improved performance of handling ports -- by :user:`bdraco`.

--- a/CHANGES/1081.misc.rst
+++ b/CHANGES/1081.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of handling ports -- by :user:.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1146,7 +1146,7 @@ class URL:
                     user,
                     password,
                     host,
-                    self._val.port,
+                    self.explicit_port,
                     encode_host=False,
                 ),
                 path,

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -134,8 +134,6 @@ class URL:
     _PATH_UNQUOTER = _Unquoter(ignore="/", unsafe="+")
     _QS_UNQUOTER = _Unquoter(qs=True)
 
-    _val: SplitResult
-
     def __new__(cls, val="", *, encoded=False, strict=None):
         if strict is not None:  # pragma: no cover
             warnings.warn("strict parameter is ignored")

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1148,7 +1148,7 @@ class URL:
                     user,
                     password,
                     host,
-                    self.explicit_port,
+                    self._val.port,
                     encode_host=False,
                 ),
                 path,

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -134,6 +134,8 @@ class URL:
     _PATH_UNQUOTER = _Unquoter(ignore="/", unsafe="+")
     _QS_UNQUOTER = _Unquoter(qs=True)
 
+    _val: SplitResult
+
     def __new__(cls, val="", *, encoded=False, strict=None):
         if strict is not None:  # pragma: no cover
             warnings.warn("strict parameter is ignored")
@@ -262,7 +264,7 @@ class URL:
         val = self._val
         if not val.path and self.is_absolute() and (val.query or val.fragment):
             val = val._replace(path="/")
-        if (port := self._get_port()) is None:
+        if (port := self._port_not_default) is None:
             # port normalization - using None for default ports to remove from rendering
             # https://datatracker.ietf.org/doc/html/rfc3986.html#section-6.2.3
             val = val._replace(
@@ -371,7 +373,7 @@ class URL:
         if self.explicit_port is None:
             # A relative URL does not have an implicit port / default port
             return self.port is not None
-        default = self._get_default_port()
+        default = self._default_port
         if default is None:
             return False
         return self.port == default
@@ -421,17 +423,21 @@ class URL:
         """
         return self._val.netloc
 
-    def _get_default_port(self) -> Union[int, None]:
+    @cached_property
+    def _default_port(self) -> Union[int, None]:
+        """Default port for the scheme or None if not known."""
         scheme = self.scheme
         if not scheme:
             return None
         return DEFAULT_PORTS.get(scheme)
 
-    def _get_port(self) -> Union[int, None]:
-        """Port or None if default port"""
-        if self._get_default_port() == self.port:
+    @cached_property
+    def _port_not_default(self) -> Union[int, None]:
+        """The port part of URL normalized to None if its the default port."""
+        port = self.port
+        if self._default_port == port:
             return None
-        return self.port
+        return port
 
     @cached_property
     def authority(self):
@@ -520,9 +526,9 @@ class URL:
         scheme without default port substitution.
 
         """
-        return self._val.port or self._get_default_port()
+        return self.explicit_port or self._default_port
 
-    @property
+    @cached_property
     def explicit_port(self):
         """Port part of URL, without scheme-based fallback.
 
@@ -1142,7 +1148,7 @@ class URL:
                     user,
                     password,
                     host,
-                    self._val.port,
+                    self.explicit_port,
                     encode_host=False,
                 ),
                 path,


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

There were a few places were the port got parsed out of the underlying `SplitResult` object multiple times. Make sure they are all cached to avoid doing the same work over and over.

This solves a minor performance regression that was introduced with the port normalization in #1033


## Are there changes in behavior for the user?

performance improvement


## Related issue number

#1033

For reference, `is_default_port` from `update_headers` in `aiohttp` is showing significantly higher on the profile with recent yarl versions.

before
![is_default_port](https://github.com/user-attachments/assets/c1958684-921f-4164-8672-29dfdd7f82a0)

after
![update_headers_after](https://github.com/user-attachments/assets/fcff34a4-d864-4d9f-bad6-663f7288095a)

