### PR TITLE
Fix codecov blocking merges

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,6 +15,11 @@ comment:
 coverage:
   range: 99.34..100
   status:
+    patch:
+      default:
+        target: 100%
+        flags:
+        - pytest
     project:
       default:
         target: 100%

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -34,7 +34,7 @@ coverage:
         - pytest
         paths:
         - tests/
-        target: 99.88%  # 100%
+        target: 99.87%  # 100%
       overall-mypy:
         flags:
         - MyPy


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

- prevent mypy coverage from being considered in the `patch` coverage since it decreases the coverage and blocks merges
- codecov is rounding down sometimes for `tests-pytest` so drop it to .01

## Are there changes in behavior for the user?

no CI fix
