### PR TITLE
Release 1.9.8rc0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,47 @@ Changelog
 
 .. towncrier release notes start
 
+1.9.8rc0
+========
+
+*(2024-09-03)*
+
+
+Features
+--------
+
+- Covered the :class:`~yarl.URL` object with types -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1084`.
+
+- Cache parsing of IP Addresses when encoding hosts -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1086`.
+
+
+Contributor-facing changes
+--------------------------
+
+- Covered the :class:`~yarl.URL` object with types -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1084`.
+
+
+Miscellaneous internal changes
+------------------------------
+
+- Improved performance of handling ports -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1081`.
+
+
+----
+
+
 1.9.7
 =====
 

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,5 +1,5 @@
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.9.8.dev0"
+__version__ = "1.9.8rc0"
 
 __all__ = ("URL", "cache_clear", "cache_configure", "cache_info")


### PR DESCRIPTION
https://github.com/aio-libs/yarl/actions/runs/10692273129

- [x] Home Assistant CI run https://github.com/home-assistant/core/pull/125189
- [x] uiprotect CI RUN https://github.com/uilibs/uiprotect/pull/201

<img width="676" alt="Screenshot 2024-09-03 at 1 25 20 PM" src="https://github.com/user-attachments/assets/d84326a2-df25-498a-a07c-25389afc54ef">
