### PR TITLE
Release 1.9.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,47 @@ Changelog
 
 .. towncrier release notes start
 
+1.9.8
+=====
+
+*(2024-09-03)*
+
+
+Features
+--------
+
+- Covered the :class:`~yarl.URL` object with types -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1084`.
+
+- Cache parsing of IP Addresses when encoding hosts -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1086`.
+
+
+Contributor-facing changes
+--------------------------
+
+- Covered the :class:`~yarl.URL` object with types -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1084`.
+
+
+Miscellaneous internal changes
+------------------------------
+
+- Improved performance of handling ports -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1081`.
+
+
+----
+
+
 1.9.7
 =====
 

--- a/CHANGES/1081.misc.rst
+++ b/CHANGES/1081.misc.rst
@@ -1,1 +1,0 @@
-Improved performance of handling ports -- by :user:`bdraco`.

--- a/CHANGES/1084.contrib.rst
+++ b/CHANGES/1084.contrib.rst
@@ -1,1 +1,0 @@
-Covered the :class:`~yarl.URL` object with types -- by :user:`bdraco`.

--- a/CHANGES/1084.feature.rst
+++ b/CHANGES/1084.feature.rst
@@ -1,1 +1,0 @@
-1084.contrib.rst

--- a/CHANGES/1086.feature.rst
+++ b/CHANGES/1086.feature.rst
@@ -1,1 +1,0 @@
-Cache parsing of IP Addresses when encoding hosts -- by :user:`bdraco`.

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,5 +1,5 @@
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.9.8.dev0"
+__version__ = "1.9.8"
 
 __all__ = ("URL", "cache_clear", "cache_configure", "cache_info")


### PR DESCRIPTION
https://github.com/aio-libs/yarl/actions/runs/10694100174

no changes since rc0 (https://github.com/aio-libs/yarl/pull/1089) -- rc0 was to do some CI runs to verify mypy was ok externally. I'm doing a release ahead of merging https://github.com/aio-libs/yarl/pull/1082 since we had an issue with it on the first go round and I'd like to make it easier to isolate if there is an issue again (hopefully not since we have since added more coverage).


<img width="669" alt="Screenshot 2024-09-03 at 4 34 35 PM" src="https://github.com/user-attachments/assets/ee5988a1-e1a5-41ca-b9ac-2dc6e38141b1">
