### PR TITLE
Introduce absolute cached property

### DIFF
--- a/CHANGES/1100.feature.rst
+++ b/CHANGES/1100.feature.rst
@@ -1,1 +1,1 @@
-Added :attr:`~yarl.URL.absolute` which is now preferred over ``is_absolute`` -- by :user:`bdraco`.
+Added :attr:`~yarl.URL.absolute` which is now preferred over ``URL.is_absolute()`` -- by :user:`bdraco`.

--- a/CHANGES/1100.feature.rst
+++ b/CHANGES/1100.feature.rst
@@ -1,1 +1,1 @@
-Added :meth:`~yarl.URL.absolute` which is now preferred over ``is_absolute`` -- by :user:`bdraco`.
+Added :attr:`~yarl.URL.absolute` which is now preferred over ``is_absolute`` -- by :user:`bdraco`.

--- a/CHANGES/1100.feature.rst
+++ b/CHANGES/1100.feature.rst
@@ -1,0 +1,1 @@
+Added :meth:`~yarl.URL.absolute` which is now preferred over ``is_absolute`` -- by :user:`bdraco`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -470,7 +470,7 @@ The module supports both absolute and relative URLs.
 Absolute URL should start from either *scheme* or ``'//'``.
 
 
-.. method:: URL.is_absolute()
+.. attribute:: URL.absolute
 
     A check for absolute URLs.
 
@@ -479,14 +479,18 @@ Absolute URL should start from either *scheme* or ``'//'``.
 
    .. doctest::
 
-      >>> URL('http://example.com').is_absolute()
+      >>> URL('http://example.com').absolute
       True
-      >>> URL('//example.com').is_absolute()
+      >>> URL('//example.com').absolute
       True
-      >>> URL('/path/to').is_absolute()
+      >>> URL('/path/to').absolute
       False
-      >>> URL('path').is_absolute()
+      >>> URL('path').absolute
       False
+
+   .. versionchanged:: 1.9.10
+
+      The ``absolute`` property is preferred over the ``is_absolute`` method.
 
 
 New URL generation

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -490,7 +490,7 @@ Absolute URL should start from either *scheme* or ``'//'``.
 
    .. versionchanged:: 1.9.10
 
-      The ``absolute`` property is preferred over the ``is_absolute`` method.
+      The :attr:`~yarl.URL.absolute` property is preferred over the ``is_absolute()`` method.
 
 
 New URL generation

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1307,26 +1307,31 @@ def test_with_suffix_replace():
 def test_is_absolute_for_relative_url():
     url = URL("/path/to")
     assert not url.is_absolute()
+    assert not url.absolute
 
 
 def test_is_absolute_for_absolute_url():
     url = URL("http://example.com")
     assert url.is_absolute()
+    assert url.absolute
 
 
 def test_is_non_absolute_for_empty_url():
     url = URL()
     assert not url.is_absolute()
+    assert not url.absolute
 
 
 def test_is_non_absolute_for_empty_url2():
     url = URL("")
     assert not url.is_absolute()
+    assert not url.absolute
 
 
 def test_is_absolute_path_starting_from_double_slash():
     url = URL("//www.python.org")
     assert url.is_absolute()
+    assert url.absolute
 
 
 # is_default_port
@@ -1759,6 +1764,7 @@ def test_relative_is_relative():
     url = URL("http://user:pass@example.com:8080/path?a=b#frag")
     rel = url.relative()
     assert not rel.is_absolute()
+    assert not rel.absolute
 
 
 def test_relative_abs_parts_are_removed():


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

We call `is_absolute` quite often internally and externally. Currently this requires re-parsing the `netloc`. To make the API more consistent and perform better, `absolute` is now preferred over `is_absolute`. `is_absolute` is retained for backwards compatibility.

## Are there changes in behavior for the user?

`absolute` is now preferred over `is_absolute`, however there are no plans to remove `is_absolute`.

<img width="673" alt="Screenshot 2024-09-04 at 12 50 53 PM" src="https://github.com/user-attachments/assets/c4c3535f-a236-43ab-9997-f9530d45c6aa">



![is_absolute](https://github.com/user-attachments/assets/d4398e3d-3173-4a3d-9c0b-dc9edf84acd8)

Probably not the best representation of a microbenchmark since `raw_host` would previous be a cache miss most of the time and this change will perform much better either way:
```
>>> timeit.timeit("x.is_absolute()", globals=locals())
0.0817429160233587
>>> timeit.timeit("x.absolute", globals=locals())
0.06663041608408093
```

On previous version when `raw_host` is a cache miss
```
>>> from yarl import URL
>>> x=URL("")
>>> timeit.timeit("x.is_absolute()", globals=locals())
0.18370608310215175
```