### PR TITLE
Adjust missing type changelog message to be attr instead of meth

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Changelog
 Bug fixes
 ---------
 
-- Added missing type on :meth:`~yarl.URL.port` -- by :user:`bdraco`.
+- Added missing type on :attr:`~yarl.URL.port` -- by :user:`bdraco`.
 
   *Related issues and pull requests on GitHub:*
   :issue:`1097`.


### PR DESCRIPTION
It should show without the `()`s

<img width="650" alt="Screenshot 2024-09-04 at 12 51 36 PM" src="https://github.com/user-attachments/assets/72225789-404e-45bc-a59e-b965639f4bf0">
