### PR TITLE
Fix `TypeError` with `MultiDictProxy` and Python 3.8

### DIFF
--- a/CHANGES/1084.bugfix.rst
+++ b/CHANGES/1084.bugfix.rst
@@ -1,0 +1,1 @@
+1107.bugfix.rst

--- a/CHANGES/1105.bugfix.rst
+++ b/CHANGES/1105.bugfix.rst
@@ -1,0 +1,1 @@
+1107.bugfix.rst

--- a/CHANGES/1107.bugfix.rst
+++ b/CHANGES/1107.bugfix.rst
@@ -1,3 +1,1 @@
-Fixed compatibility with ``multidict`` versions where ``MultiDictProxy`` is not a ``Generic`` -- by :user:`bdraco`.
-
-A :exc:`TypeError` would be raised in this case.
+Fixed a :exc:`TypeError` with ``MultiDictProxy`` and Python 3.8 -- by :user:`bdraco`.

--- a/CHANGES/1107.bugfix.rst
+++ b/CHANGES/1107.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed compatibility with ``multidict`` versions where ``MultiDictProxy`` is not a ``Generic`` -- by :user:`bdraco`.
+
+A :exc:`TypeError` would be raised in this case.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -640,7 +640,7 @@ class URL:
         return self._PATH_UNQUOTER(self.raw_path)
 
     @cached_property
-    def query(self) -> MultiDictProxy[str]:
+    def query(self) -> "MultiDictProxy[str]":
         """A MultiDictProxy representing parsed query parameters in decoded
         representation.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix non-subscriptable MultiDictProxy error as seen in #1105 when using older versions of multidict

<img width="689" alt="Screenshot 2024-09-04 at 4 00 13 PM" src="https://github.com/user-attachments/assets/4eb214f1-1c39-4965-b48b-ee59cea829be">

## Are there changes in behavior for the user?

no

## Related issue number
fixes #1105