### PR TITLE
Release 1.9.11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,35 @@ Changelog
 
 .. towncrier release notes start
 
+1.9.11
+======
+
+*(2024-09-04)*
+
+
+Bug fixes
+---------
+
+- Fixed a :exc:`TypeError` with ``MultiDictProxy`` and Python 3.8 -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1084`, :issue:`1105`, :issue:`1107`.
+
+
+Miscellaneous internal changes
+------------------------------
+
+- Improved performance of encoding hosts -- by :user:`bdraco`.
+
+  Previously, the library would unconditionally try to parse a host as an IP Address. The library now avoids trying to parse a host as an IP Address if the string is not in one of the formats described in :rfc:`3986#section-3.2.2`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1104`.
+
+
+----
+
+
 1.9.10
 ======
 

--- a/CHANGES/1084.bugfix.rst
+++ b/CHANGES/1084.bugfix.rst
@@ -1,1 +1,0 @@
-1107.bugfix.rst

--- a/CHANGES/1104.misc.rst
+++ b/CHANGES/1104.misc.rst
@@ -1,3 +1,0 @@
-Improved performance of encoding hosts -- by :user:`bdraco`.
-
-Previously, the library would unconditionally try to parse a host as an IP Address. The library now avoids trying to parse a host as an IP Address if the string is not in one of the formats described in :rfc:`3986#section-3.2.2`.

--- a/CHANGES/1105.bugfix.rst
+++ b/CHANGES/1105.bugfix.rst
@@ -1,1 +1,0 @@
-1107.bugfix.rst

--- a/CHANGES/1107.bugfix.rst
+++ b/CHANGES/1107.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a :exc:`TypeError` with ``MultiDictProxy`` and Python 3.8 -- by :user:`bdraco`.

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,5 +1,5 @@
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.9.11.dev0"
+__version__ = "1.9.11"
 
 __all__ = ("URL", "cache_clear", "cache_configure", "cache_info")


### PR DESCRIPTION
https://github.com/aio-libs/yarl/actions/runs/10712673934
Doing another release since the issue reported in #1105 is a blocking for Python 3.8 users with an older version of `multidict`
<img width="683" alt="Screenshot 2024-09-04 at 4 10 41 PM" src="https://github.com/user-attachments/assets/c61f418a-2d6e-423b-b9b0-e76a93888e9b">



