### PR TITLE
📦 Start building wheels with free-threading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ before-test = [
   # Ref: https://github.com/pypa/cibuildwheel/issues/1666
   "PIP_CONSTRAINT= pip install PyYAML",
 ]
+free-threaded-support = true
 test-requires = "-r requirements/test.txt"
 test-command = "pytest -v --no-cov {project}/tests"
 # don't build PyPy wheels, install from source instead


### PR DESCRIPTION
## What do these changes do?

Fancy 3.13t stuff.

## Are there changes in behavior for the user?

Being able to install from wheels under free-threaded Python builds.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
