### PR TITLE
Optimize cython cached_property implementation

### DIFF
--- a/CHANGES/1122.misc.rst
+++ b/CHANGES/1122.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the Cython ``cached_property`` implementation -- by :user:`bdraco`.

--- a/yarl/_helpers_c.pyx
+++ b/yarl/_helpers_c.pyx
@@ -1,5 +1,7 @@
 # cython: language_level=3
 
+cdef _sentinel = object()
+
 cdef class cached_property:
     """Use as a class method decorator.  It operates almost exactly like
     the Python `@property` decorator, but it puts the result of the
@@ -21,17 +23,14 @@ cdef class cached_property:
         return self.wrapped.__doc__
 
     def __get__(self, inst, owner):
-        try:
-            try:
-                return inst._cache[self.name]
-            except KeyError:
-                val = self.wrapped(inst)
-                inst._cache[self.name] = val
-                return val
-        except AttributeError:
-            if inst is None:
-                return self
-            raise
+        if inst is None:
+            return self
+        cdef dict cache = inst._cache
+        val = cache.get(self.name, _sentinel)
+        if val is _sentinel:
+            val = self.wrapped(inst)
+            cache[self.name] = val
+        return val
 
     def __set__(self, inst, value):
         raise AttributeError("cached property is read-only")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Optimize cython cached_property implementation

## Are there changes in behavior for the user?

no

timeit: 0.0037811670918017626
before
<img width="436" alt="Screenshot 2024-09-07 at 11 54 48 AM" src="https://github.com/user-attachments/assets/32c8d8fc-d62f-402e-ba92-b536769e4d06">

timeit: 0.003146165981888771
after
<img width="462" alt="Screenshot 2024-09-07 at 11 54 36 AM" src="https://github.com/user-attachments/assets/50635db6-f573-4cf9-ad39-af995bd13e82">

