### PR TITLE
Small optimization to encoding hosts

### DIFF
--- a/CHANGES/1125.misc.rst
+++ b/CHANGES/1125.misc.rst
@@ -1,1 +1,1 @@
-Improve performance of encoding non IPv6 hosts -- by :user:`bdraco`.
+Improved performance of encoding non IPv6 hosts -- by :user:`bdraco`.

--- a/CHANGES/1125.misc.rst
+++ b/CHANGES/1125.misc.rst
@@ -1,0 +1,1 @@
+Improve performance of encoding non IPv6 hosts -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -906,7 +906,12 @@ class URL:
 
     @classmethod
     def _encode_host(cls, host: str, human: bool = False) -> str:
-        raw_ip, sep, zone = host.partition("%")
+        if "%" in host:
+            raw_ip, sep, zone = host.partition("%")
+        else:
+            raw_ip = host
+            sep = zone = ""
+
         if raw_ip and raw_ip[-1].isdigit() or ":" in raw_ip:
             # Might be an IP address, check it
             #


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Avoid a partition call for most cases since its rare that the host will have a IPv6 zone.  We guard all the other partitions but this one was missed, and its one of the most common in the hot path.

before total time = 0.040
   100000    0.040    0.000    0.068    0.000 _url.py:907(_encode_host)

after total time = 0.031
   100000    0.031    0.000    0.051    0.000 _url.py:907(_encode_host)

```
print(timeit.timeit('URL("http://user:pass@example.com?a+b=c+d").raw_host', globals=globals(), number=100000))
```


## Are there changes in behavior for the user?
no