### PR TITLE
Avoid quoting empty strings when building URLs

### DIFF
--- a/CHANGES/1126.misc.rst
+++ b/CHANGES/1126.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of building URLs when the path, query string, or fragment is an empty string -- by :user:`bdraco`.

--- a/CHANGES/1126.misc.rst
+++ b/CHANGES/1126.misc.rst
@@ -1,1 +1,1 @@
-Improved performance of building URLs when the path, query string, or fragment is an empty string -- by :user:`bdraco`.
+Improved performance of :meth:`URL.build() <yarl.URL.build>` when the path, query string, or fragment is an empty string -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -349,13 +349,15 @@ class URL:
                 user, password, host, port, encode=not encoded, encode_host=not encoded
             )
         if not encoded:
-            path = cls._PATH_QUOTER(path)
-            if netloc:
+            path = cls._PATH_QUOTER(path) if path else path
+            if path and netloc:
                 path = cls._normalize_path(path)
 
             cls._validate_authority_uri_abs_path(host=host, path=path)
-            query_string = cls._QUERY_QUOTER(query_string)
-            fragment = cls._FRAGMENT_QUOTER(fragment)
+            query_string = (
+                cls._QUERY_QUOTER(query_string) if query_string else query_string
+            )
+            fragment = cls._FRAGMENT_QUOTER(fragment) if fragment else fragment
 
         url = cls(
             SplitResult(scheme, netloc, path, query_string, fragment), encoded=True
@@ -363,8 +365,7 @@ class URL:
 
         if query:
             return url.with_query(query)
-        else:
-            return url
+        return url
 
     def __init_subclass__(cls):
         raise TypeError(f"Inheriting a class {cls!r} from URL is forbidden")


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

We guard against quoting empty strings in __new__ but not in build

Quoting is the most expensive operation besides parsing IPs

## Are there changes in behavior for the user?

no
