### PR TITLE
Add extend_query method

### DIFF
--- a/CHANGES/1126.misc.rst
+++ b/CHANGES/1126.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of :meth:`URL.build() <yarl.URL.build>` when the path, query string, or fragment is an empty string -- by :user:`bdraco`.

--- a/CHANGES/1128.feature.rst
+++ b/CHANGES/1128.feature.rst
@@ -1,0 +1,3 @@
+Added :meth:`URL.extend_query() <yarl.URL.extend_query>` method, which can be used to extend parameters without replacing same named keys -- by :user:`bdraco`.
+
+This method was primarily added to replace the inefficient hand rolled method currently used in ``aiohttp``.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -659,6 +659,48 @@ section generates a new :class:`URL` instance.
       Support subclasses of :class:`int` (except :class:`bool`) and :class:`float`
       as a query parameter value.
 
+.. method:: URL.extend_query(query)
+            URL.extend_query(**kwargs)
+
+   Returns a new URL with *query* part extended.
+
+   Unlike :meth:`update_query` the method keeps duplicate keys.
+
+   Returned :class:`URL` object will contain query string which extends
+   parts from passed query parts (or parts of parsed query string).
+
+   Accepts any :class:`~collections.abc.Mapping` (e.g. :class:`dict`,
+   :class:`~multidict.MultiDict` instances) or :class:`str`,
+   auto-encode the argument if needed.
+
+   A sequence of ``(key, value)`` pairs is supported as well.
+
+   Also it can take an arbitrary number of keyword arguments.
+
+   Returns the same :class:`URL` if *query* of ``None`` is passed.
+
+   .. note::
+
+      The library accepts :class:`str`, :class:`float`, :class:`int` and their
+      subclasses except :class:`bool` as query argument values.
+
+      If a mapping such as :class:`dict` is used, the values may also be
+      :class:`list` or :class:`tuple` to represent a key has many values.
+
+      Please see :ref:`yarl-bools-support` for the reason why :class:`bool` is not
+      supported out-of-the-box.
+
+   .. doctest::
+
+      >>> URL('http://example.com/path?a=b&b=1').extend_query(b='2')
+      URL('http://example.com/path?a=b&b=1&b=2')
+      >>> URL('http://example.com/path?a=b&b=1').extend_query([('b', '2')])
+      URL('http://example.com/path?a=b&b=1&b=2')
+      >>> URL('http://example.com/path?a=b&c=e&c=f').extend_query(c='d')
+      URL('http://example.com/path?a=b&c=e&c=f&c=d')
+
+   .. versionadded:: 1.11.0
+
 .. method:: URL.update_query(query)
             URL.update_query(**kwargs)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -664,7 +664,7 @@ section generates a new :class:`URL` instance.
 
    Returns a new URL with *query* part extended.
 
-   Unlike :meth:`update_query` the method keeps duplicate keys.
+   Unlike :meth:`update_query`, this method keeps duplicate keys.
 
    Returned :class:`URL` object will contain query string which extends
    parts from passed query parts (or parts of parsed query string).

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -364,3 +364,60 @@ def test_update_query_with_mod_operator():
     assert str(url % {"a": "1"} % {"b": "2"}) == "http://example.com/?a=1&b=2"
     assert str(url % {"a": "1"} % {"a": "3", "b": "2"}) == "http://example.com/?a=3&b=2"
     assert str(url / "foo" % {"a": "1"}) == "http://example.com/foo?a=1"
+
+
+def test_extend_query():
+    url = URL("http://example.com/")
+    assert str(url.extend_query({"a": "1"})) == "http://example.com/?a=1"
+    assert str(URL("test").extend_query(a=1)) == "test?a=1"
+
+    url = URL("http://example.com/?foo=bar")
+    expected_url = URL("http://example.com/?foo=bar&baz=foo")
+
+    assert url.extend_query({"baz": "foo"}) == expected_url
+    assert url.extend_query(baz="foo") == expected_url
+    assert url.extend_query("baz=foo") == expected_url
+
+
+def test_extend_query_with_args_and_kwargs():
+    url = URL("http://example.com/")
+
+    with pytest.raises(ValueError):
+        url.extend_query("a", foo="bar")
+
+
+def test_extend_query_with_multiple_args():
+    url = URL("http://example.com/")
+
+    with pytest.raises(ValueError):
+        url.extend_query("a", "b")
+
+
+def test_extend_query_with_none_arg():
+    url = URL("http://example.com/?foo=bar&baz=foo")
+    assert url.extend_query(None) == url
+
+
+def test_extend_query_with_empty_dict():
+    url = URL("http://example.com/?foo=bar&baz=foo")
+    assert url.extend_query({}) == url
+
+
+def test_extend_query_existing_keys():
+    url = URL("http://example.com/?a=2")
+    assert str(url.extend_query({"a": "1"})) == "http://example.com/?a=2&a=1"
+    assert str(URL("test").extend_query(a=1)) == "test?a=1"
+
+    url = URL("http://example.com/?foo=bar&baz=original")
+    expected_url = URL("http://example.com/?foo=bar&baz=original&baz=foo")
+
+    assert url.extend_query({"baz": "foo"}) == expected_url
+    assert url.extend_query(baz="foo") == expected_url
+    assert url.extend_query("baz=foo") == expected_url
+
+
+def test_extend_query_with_args_and_kwargs_with_existing():
+    url = URL("http://example.com/?a=original")
+
+    with pytest.raises(ValueError):
+        url.extend_query("a", foo="bar")

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -353,6 +353,16 @@ def test_update_query_multiple_keys():
     assert str(u2) == "http://example.com/path?a=3&a=4"
 
 
+def test_update_query_with_non_ascii():
+    url = URL("http://example.com/?foo=bar&baz=foo&%F0%9D%95%A6=%F0%9D%95%A6")
+    assert url.update_query({"𝕦": "𝕦"}) == url
+
+
+def test_update_query_with_non_ascii_as_str():
+    url = URL("http://example.com/?foo=bar&baz=foo&%F0%9D%95%A6=%F0%9D%95%A6")
+    assert url.update_query("𝕦=𝕦") == url
+
+
 # mod operator
 
 
@@ -421,3 +431,24 @@ def test_extend_query_with_args_and_kwargs_with_existing():
 
     with pytest.raises(ValueError):
         url.extend_query("a", foo="bar")
+
+
+def test_extend_query_with_non_ascii():
+    url = URL("http://example.com/?foo=bar&baz=foo")
+    expected = URL("http://example.com/?foo=bar&baz=foo&%F0%9D%95%A6=%F0%9D%95%A6")
+    assert url.extend_query({"𝕦": "𝕦"}) == expected
+
+
+def test_extend_query_with_non_ascii_as_str():
+    url = URL("http://example.com/?foo=bar&baz=foo&")
+    expected = URL("http://example.com/?foo=bar&baz=foo&%F0%9D%95%A6=%F0%9D%95%A6")
+    assert url.extend_query("𝕦=𝕦") == expected
+
+
+def test_extend_query_with_non_ascii_same_key():
+    url = URL("http://example.com/?foo=bar&baz=foo&%F0%9D%95%A6=%F0%9D%95%A6")
+    expected = URL(
+        "http://example.com/?foo=bar&baz=foo"
+        "&%F0%9D%95%A6=%F0%9D%95%A6&%F0%9D%95%A6=%F0%9D%95%A6"
+    )
+    assert url.extend_query({"𝕦": "𝕦"}) == expected

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1267,6 +1267,8 @@ class URL:
         URL('http://example.com/?a=1&b=2&a=3&c=4')
         """
         s = self._get_str_query(*args, **kwargs)
+        if s is None:
+            return self
         return self._merge_query(s, update=False)
 
     @overload
@@ -1286,13 +1288,12 @@ class URL:
         URL('http://example.com/?a=3&b=2&c=4')
         """
         s = self._get_str_query(*args, **kwargs)
+        if s is None:
+            return URL(self._val._replace(query=""), encoded=True)
         return self._merge_query(s, update=True)
 
     def _merge_query(self, to_add: Union[str, None], update: bool) -> "URL":
         """Return a new URL with query part merged or extended."""
-        if to_add is None:
-            return URL(self._val._replace(query=""), encoded=True)
-
         old_parsed = self._parsed_query
         new_parsed = parse_qsl(to_add, keep_blank_values=True)
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1163,7 +1163,7 @@ class URL:
             if TYPE_CHECKING:
                 assert isinstance(v, str)
             return v
-        if issubclass(cls, float):
+        if cls is float or issubclass(cls, float):
             if TYPE_CHECKING:
                 assert isinstance(v, float)
             if math.isinf(v):
@@ -1171,7 +1171,7 @@ class URL:
             if math.isnan(v):
                 raise ValueError("float('nan') is not supported")
             return str(float(v))
-        if issubclass(cls, int) and cls is not bool:
+        if cls is int or (issubclass(cls, int) and cls is not bool):
             if TYPE_CHECKING:
                 assert isinstance(v, int)
             return str(int(v))

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1181,13 +1181,13 @@ class URL:
             "of type {}".format(v, cls)
         )
 
-    def _get_str_query_from_mapping(self, query: Mapping[str, QueryVariable]) -> str:
+    def _get_str_query_from_mapping(self, query: "Mapping[str, QueryVariable]") -> str:
         """Return a query string from a mapping."""
         quoter = self._QUERY_PART_QUOTER
         return "&".join(self._query_seq_pairs(quoter, query.items()))
 
     def _get_str_query(self, *args: Any, **kwargs: Any) -> Union[str, None]:
-        query: Union[str, Mapping[str, QueryVariable], None]
+        query: Union[str, "Mapping[str, QueryVariable]", None]
         if kwargs:
             if len(args) > 0:
                 raise ValueError(

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -349,13 +349,15 @@ class URL:
                 user, password, host, port, encode=not encoded, encode_host=not encoded
             )
         if not encoded:
-            path = cls._PATH_QUOTER(path)
-            if netloc:
+            path = cls._PATH_QUOTER(path) if path else path
+            if path and netloc:
                 path = cls._normalize_path(path)
 
             cls._validate_authority_uri_abs_path(host=host, path=path)
-            query_string = cls._QUERY_QUOTER(query_string)
-            fragment = cls._FRAGMENT_QUOTER(fragment)
+            query_string = (
+                cls._QUERY_QUOTER(query_string) if query_string else query_string
+            )
+            fragment = cls._FRAGMENT_QUOTER(fragment) if fragment else fragment
 
         url = cls(
             SplitResult(scheme, netloc, path, query_string, fragment), encoded=True
@@ -363,8 +365,7 @@ class URL:
 
         if query:
             return url.with_query(query)
-        else:
-            return url
+        return url
 
     def __init_subclass__(cls):
         raise TypeError(f"Inheriting a class {cls!r} from URL is forbidden")

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1203,7 +1203,7 @@ class URL:
 
         if query is None:
             return None
-        if isinstance(query, MultiDict):
+        if isinstance(query, (MultiDict, MultiDictProxy)):
             return self._get_str_query_from_iterable(query.items())
         if isinstance(query, Mapping):
             quoter = self._QUERY_PART_QUOTER

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1266,10 +1266,10 @@ class URL:
         >>> url.extend_query(a=3, c=4)
         URL('http://example.com/?a=1&b=2&a=3&c=4')
         """
-        s = self._get_str_query(*args, **kwargs)
-        if s is None:
+        new_query_string = self._get_str_query(*args, **kwargs)
+        if new_query_string is None:
             return self
-        return self._merge_query(s, update=False)
+        return self._merge_query(new_query_string, update=False)
 
     @overload
     def update_query(self, query: Query) -> "URL": ...
@@ -1287,14 +1287,14 @@ class URL:
         >>> url.update_query(a=3, c=4)
         URL('http://example.com/?a=3&b=2&c=4')
         """
-        s = self._get_str_query(*args, **kwargs)
-        if s is None:
+        new_query_string = self._get_str_query(*args, **kwargs)
+        if new_query_string is None:
             return URL(self._val._replace(query=""), encoded=True)
-        return self._merge_query(s, update=True)
+        return self._merge_query(new_query_string, update=True)
 
-    def _merge_query(self, to_add: Union[str, None], update: bool) -> "URL":
+    def _merge_query(self, new_query_string: Union[str, None], update: bool) -> "URL":
         """Return a new URL with query part merged or extended."""
-        new_parsed = parse_qsl(to_add, keep_blank_values=True)
+        new_parsed = parse_qsl(new_query_string, keep_blank_values=True)
 
         if update:
             new_query = MultiDict(self._parsed_query)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1186,6 +1186,8 @@ class URL:
     ) -> str:
         """Return a query string from an iterable."""
         quoter = self._QUERY_PART_QUOTER
+        # A listcomp is used since listcomps are inlined on CPython 3.12+ and
+        # they are a bit faster than a generator expression.
         return "&".join([f"{quoter(k)}={quoter(self._query_var(v))}" for k, v in items])
 
     def _get_str_query(self, *args: Any, **kwargs: Any) -> Union[str, None]:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1246,9 +1246,7 @@ class URL:
         # N.B. doesn't cleanup query/fragment
 
         new_query = self._get_str_query(*args, **kwargs) or ""
-        return URL(
-            self._val._replace(path=self._val.path, query=new_query), encoded=True
-        )
+        return URL(self._val._replace(query=new_query), encoded=True)
 
     @overload
     def extend_query(self, query: Query) -> "URL": ...

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1302,9 +1302,6 @@ class URL:
         new_parsed = parse_qsl(new_query_string, keep_blank_values=True)
         new_query = MultiDict(self._parsed_query)
         new_query.update(new_parsed)
-        # We can use the faster _get_str_query_from_iterable here because
-        # we constructed the MultiDict ourselves and we know there are
-        # no QueryVariable as the values in this case.
         combined_query = self._get_str_query_from_iterable(new_query.items()) or ""
         return URL(self._val._replace(query=combined_query), encoded=True)
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1302,6 +1302,9 @@ class URL:
         else:
             new_query = MultiDict(self._parsed_query + new_parsed)
 
+        # We can use the faster _get_str_query_from_sequence here because
+        # we constructed the MultiDict ourselves and we know there are
+        # no QueryVariable as the values in this case.
         combined_query = self._get_str_query_from_sequence(new_query.items()) or ""
         return URL(self._val._replace(query=combined_query), encoded=True)
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1205,8 +1205,6 @@ class URL:
 
         if query is None:
             return None
-        if isinstance(query, (MultiDict, MultiDictProxy)):
-            return self._get_str_query_from_iterable(query.items())
         if isinstance(query, Mapping):
             quoter = self._QUERY_PART_QUOTER
             return "&".join(self._query_seq_pairs(quoter, query.items()))

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1294,14 +1294,13 @@ class URL:
 
     def _merge_query(self, to_add: Union[str, None], update: bool) -> "URL":
         """Return a new URL with query part merged or extended."""
-        old_parsed = self._parsed_query
         new_parsed = parse_qsl(to_add, keep_blank_values=True)
 
         if update:
-            new_query = MultiDict(old_parsed)
+            new_query = MultiDict(self._parsed_query)
             new_query.update(new_parsed)
         else:
-            new_query = MultiDict(old_parsed + new_parsed)
+            new_query = MultiDict(self._parsed_query + new_parsed)
 
         combined_query = self._get_str_query_from_mapping(new_query) or ""
         return URL(self._val._replace(query=combined_query), encoded=True)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1270,6 +1270,8 @@ class URL:
         if not new_query_string:
             return self
         if current_query := self.raw_query_string:
+            # both strings are already encoded so we can use a simple
+            # string join
             if current_query[-1] == "&":
                 combined_query = f"{current_query}{new_query_string}"
             else:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1163,7 +1163,7 @@ class URL:
             if TYPE_CHECKING:
                 assert isinstance(v, str)
             return v
-        if cls is float or issubclass(cls, float):
+        if issubclass(cls, float):
             if TYPE_CHECKING:
                 assert isinstance(v, float)
             if math.isinf(v):

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1291,7 +1291,7 @@ class URL:
     def _merge_query(self, to_add: Union[str, None], update: bool) -> "URL":
         """Return a new URL with query part merged or extended."""
         if to_add is None:
-            return self
+            return URL(self._val._replace(query=""), encoded=True)
 
         old_parsed = self._parsed_query
         new_parsed = parse_qsl(to_add, keep_blank_values=True)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1159,7 +1159,7 @@ class URL:
     @staticmethod
     def _query_var(v: QueryVariable) -> str:
         cls = type(v)
-        if issubclass(cls, str):
+        if cls is str or issubclass(cls, str):
             if TYPE_CHECKING:
                 assert isinstance(v, str)
             return v

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1191,7 +1191,7 @@ class URL:
         return "&".join([f"{quoter(k)}={quoter(self._query_var(v))}" for k, v in items])
 
     def _get_str_query(self, *args: Any, **kwargs: Any) -> Union[str, None]:
-        query: Union[str, "Mapping[str, QueryVariable]", None]
+        query: Union[str, Mapping[str, QueryVariable], None]
         if kwargs:
             if len(args) > 0:
                 raise ValueError(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds a new method called `extend_query` that will add additional keys instead of replacing them like `update_query`.  [The goal is to replace the hand rolled version in `aiohttp`](https://github.com/aio-libs/aiohttp/blob/11a96fcc7b62b33f0088640a05237e262cac5691/aiohttp/client_reqrep.py#L231)

## Are there changes in behavior for the user?

no

## Related issue number
#1127