### PR TITLE
Remove useless path replacement in with_query

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1239,9 +1239,7 @@ class URL:
         # N.B. doesn't cleanup query/fragment
 
         new_query = self._get_str_query(*args, **kwargs) or ""
-        return URL(
-            self._val._replace(path=self._val.path, query=new_query), encoded=True
-        )
+        return URL(self._val._replace(query=new_query), encoded=True)
 
     @overload
     def update_query(self, query: Query) -> "URL": ...


### PR DESCRIPTION
The path being passed to replace() was always the same value that already existed
