### PR TITLE
Improve performance of URL.update_query

### DIFF
--- a/CHANGES/1126.misc.rst
+++ b/CHANGES/1126.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of :meth:`URL.build() <yarl.URL.build>` when the path, query string, or fragment is an empty string -- by :user:`bdraco`.

--- a/CHANGES/1130.misc.rst
+++ b/CHANGES/1130.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the :meth:`URL.update_query() <yarl.URL.update_query>` method -- by :user:`bdraco`.

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -353,6 +353,16 @@ def test_update_query_multiple_keys():
     assert str(u2) == "http://example.com/path?a=3&a=4"
 
 
+def test_update_query_with_non_ascii():
+    url = URL("http://example.com/?foo=bar&baz=foo&%F0%9D%95%A6=%F0%9D%95%A6")
+    assert url.update_query({"𝕦": "𝕦"}) == url
+
+
+def test_update_query_with_non_ascii_as_str():
+    url = URL("http://example.com/?foo=bar&baz=foo&%F0%9D%95%A6=%F0%9D%95%A6")
+    assert url.update_query("𝕦=𝕦") == url
+
+
 # mod operator
 
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -349,13 +349,15 @@ class URL:
                 user, password, host, port, encode=not encoded, encode_host=not encoded
             )
         if not encoded:
-            path = cls._PATH_QUOTER(path)
-            if netloc:
+            path = cls._PATH_QUOTER(path) if path else path
+            if path and netloc:
                 path = cls._normalize_path(path)
 
             cls._validate_authority_uri_abs_path(host=host, path=path)
-            query_string = cls._QUERY_QUOTER(query_string)
-            fragment = cls._FRAGMENT_QUOTER(fragment)
+            query_string = (
+                cls._QUERY_QUOTER(query_string) if query_string else query_string
+            )
+            fragment = cls._FRAGMENT_QUOTER(fragment) if fragment else fragment
 
         url = cls(
             SplitResult(scheme, netloc, path, query_string, fragment), encoded=True
@@ -363,8 +365,7 @@ class URL:
 
         if query:
             return url.with_query(query)
-        else:
-            return url
+        return url
 
     def __init_subclass__(cls):
         raise TypeError(f"Inheriting a class {cls!r} from URL is forbidden")

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1257,11 +1257,11 @@ class URL:
     def update_query(self, *args: Any, **kwargs: Any) -> "URL":
         """Return a new URL with query part updated."""
         s = self._get_str_query(*args, **kwargs)
-        query = None
-        if s is not None:
-            query = MultiDict(self._parsed_query)
-            query.update(parse_qsl(s, keep_blank_values=True))
+        if s is None:
+            return URL(self._val._replace(query=""), encoded=True)
 
+        query = MultiDict(self._parsed_query)
+        query.update(parse_qsl(s, keep_blank_values=True))
         return URL(
             self._val._replace(query=self._get_str_query(query) or ""), encoded=True
         )

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1182,7 +1182,7 @@ class URL:
         )
 
     def _get_str_query_from_iterable(
-        self, items: "Iterable[Tuple[Union[str, istr], str]]"
+        self, items: Iterable[Tuple[Union[str, istr], str]]
     ) -> str:
         """Return a query string from an iterable."""
         quoter = self._QUERY_PART_QUOTER


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

- Avoid reparsing the query string into a MultiDict
- Avoid creation of many intermediate MultiDict and MultiDictProxy objects
- Build the final string with iterable helper since there will never be `QueryVariable`

## Are there changes in behavior for the user?

no
