### PR TITLE
Optimize _query_var for ``str`` objects

### DIFF
--- a/CHANGES/1131.misc.rst
+++ b/CHANGES/1131.misc.rst
@@ -1,1 +1,1 @@
-Improved performance of processing query string changes when arguments are type ``str``  -- by :user:`bdraco`.
+Improved performance of processing query string changes when arguments are :class:`str`  -- by :user:`bdraco`.

--- a/CHANGES/1131.misc.rst
+++ b/CHANGES/1131.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of processing query string changes when arguments are built-in types that are not subclassed -- by :user:`bdraco`.

--- a/CHANGES/1131.misc.rst
+++ b/CHANGES/1131.misc.rst
@@ -1,1 +1,1 @@
-Improved performance of processing query string changes when arguments are built-in types that are not subclassed -- by :user:`bdraco`.
+Improved performance of processing query string changes when arguments are type ``str``  -- by :user:`bdraco`.

--- a/CHANGES/1131.misc.rst
+++ b/CHANGES/1131.misc.rst
@@ -1,1 +1,1 @@
-Improved performance of processing query string changes when arguments are :class:`str`  -- by :user:`bdraco`.
+Improved performance of processing query string changes when arguments are :class:`str` -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -29,7 +29,7 @@ from urllib.parse import (
 )
 
 import idna
-from multidict import MultiDict, MultiDictProxy
+from multidict import MultiDict, MultiDictProxy, istr
 
 from ._helpers import cached_property
 from ._quoting import _Quoter, _Unquoter
@@ -1154,11 +1154,11 @@ class URL:
     @staticmethod
     def _query_var(v: QueryVariable) -> str:
         cls = type(v)
-        if issubclass(cls, str):
+        if cls is str or cls is istr or issubclass(cls, str):
             if TYPE_CHECKING:
                 assert isinstance(v, str)
             return v
-        if issubclass(cls, float):
+        if cls is float or issubclass(cls, float):
             if TYPE_CHECKING:
                 assert isinstance(v, float)
             if math.isinf(v):
@@ -1166,7 +1166,7 @@ class URL:
             if math.isnan(v):
                 raise ValueError("float('nan') is not supported")
             return str(float(v))
-        if issubclass(cls, int) and cls is not bool:
+        if cls is int or (cls is not bool and issubclass(cls, int)):
             if TYPE_CHECKING:
                 assert isinstance(v, int)
             return str(int(v))

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1166,7 +1166,7 @@ class URL:
             if math.isnan(v):
                 raise ValueError("float('nan') is not supported")
             return str(float(v))
-        if cls is int or (cls is not bool and issubclass(cls, int)):
+        if cls is not bool and issubclass(cls, int):
             if TYPE_CHECKING:
                 assert isinstance(v, int)
             return str(int(v))

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1158,7 +1158,7 @@ class URL:
             if TYPE_CHECKING:
                 assert isinstance(v, str)
             return v
-        if cls is float or issubclass(cls, float):
+        if issubclass(cls, float):
             if TYPE_CHECKING:
                 assert isinstance(v, float)
             if math.isinf(v):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`_query_var` is almost never called with subclassed values, and almost everything is `str`.  All the `issubclass` calls add up with large query strings
```
0.0006691671442240477 <- is
0.0010826669167727232 <- issubclass
```
## Are there changes in behavior for the user?

No
