### PR TITLE
Allow empty hosts for schemes that do not require them

### DIFF
--- a/CHANGES/1136.bugfix.rst
+++ b/CHANGES/1136.bugfix.rst
@@ -1,0 +1,1 @@
+Allow empty host for URL schemes other than the special schemes listed in the WHATWG URL spec -- by :user:`bdraco`.

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -210,19 +210,14 @@ class TestPort:
         assert u.query_string == ""
         assert u.fragment == ""
 
-    @pytest.mark.xfail(
-        # FIXME: remove "no cover" pragmas upon xfail marker deletion
-        reason="https://github.com/aio-libs/yarl/issues/821",
-        raises=ValueError,
-    )
     def test_no_host(self):
-        u = URL("//:80")
-        assert u.scheme == ""  # pragma: no cover
-        assert u.host == ""  # pragma: no cover
-        assert u.port == 80  # pragma: no cover
-        assert u.path == "/"  # pragma: no cover
-        assert u.query_string == ""  # pragma: no cover
-        assert u.fragment == ""  # pragma: no cover
+        u = URL("//:77")
+        assert u.scheme == ""
+        assert u.host == ""
+        assert u.port == 77
+        assert u.path == "/"
+        assert u.query_string == ""
+        assert u.fragment == ""
 
     def test_double_port(self):
         with pytest.raises(ValueError):
@@ -457,9 +452,19 @@ class TestFragment:
 
 
 class TestStripEmptyParts:
-    def test_all_empty(self):
+    def test_all_empty_http(self):
         with pytest.raises(ValueError):
-            URL("//@:?#")
+            URL("http://@:?#")
+
+    def test_all_empty(self):
+        u = URL("//@:?#")
+        assert u.scheme == ""
+        assert u.user is None
+        assert u.password is None
+        assert u.host == ""
+        assert u.path == ""
+        assert u.query_string == ""
+        assert u.fragment == ""
 
     def test_path_only(self):
         u = URL("///path")
@@ -580,3 +585,22 @@ class TestStripEmptyParts:
         assert u.path == ""
         assert u.query_string == ""
         assert u.fragment == ""
+
+
+@pytest.mark.parametrize(
+    ("scheme"),
+    [
+        ("http"),
+        ("https"),
+        ("ws"),
+        ("wss"),
+        ("ftp"),
+    ],
+)
+def test_schemes_that_require_host(scheme: str) -> None:
+    """Verify that schemes that require a host raise with empty host."""
+    expect = (
+        "Invalid URL: host is required for " f"absolute urls with the {scheme} scheme"
+    )
+    with pytest.raises(ValueError, match=expect):
+        URL(f"{scheme}://:1")

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -34,9 +34,10 @@ from multidict import MultiDict, MultiDictProxy, istr
 from ._helpers import cached_property
 from ._quoting import _Quoter, _Unquoter
 
-DEFAULT_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443}
+DEFAULT_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443, "ftp": 21}
 USES_AUTHORITY = frozenset(uses_netloc)
 USES_RELATIVE = frozenset(uses_relative)
+SCHEME_REQUIRES_HOST = frozenset(("http", "https", "ws", "wss", "ftp"))
 
 sentinel = object()
 
@@ -255,7 +256,14 @@ class URL:
             else:
                 username, password, host, port = cls._split_netloc(val[1])
                 if host is None:
-                    raise ValueError("Invalid URL: host is required for absolute urls")
+                    if scheme in SCHEME_REQUIRES_HOST:
+                        msg = (
+                            "Invalid URL: host is required for "
+                            f"absolute urls with the {scheme} scheme"
+                        )
+                        raise ValueError(msg)
+                    else:
+                        host = ""
                 host = cls._encode_host(host)
                 raw_user = None if username is None else cls._REQUOTER(username)
                 raw_password = None if password is None else cls._REQUOTER(password)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -37,6 +37,9 @@ from ._quoting import _Quoter, _Unquoter
 DEFAULT_PORTS = {"http": 80, "https": 443, "ws": 80, "wss": 443, "ftp": 21}
 USES_AUTHORITY = frozenset(uses_netloc)
 USES_RELATIVE = frozenset(uses_relative)
+
+# Special schemes https://url.spec.whatwg.org/#special-scheme
+# are not allowed to have an empty host https://url.spec.whatwg.org/#url-representation
 SCHEME_REQUIRES_HOST = frozenset(("http", "https", "ws", "wss", "ftp"))
 
 sentinel = object()


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Allow empty hosts for schemes that do not require them

## Are there changes in behavior for the user?

schemes other than `"http", "https", "ws", "wss", "ftp"` will not raise `ValueError` on empty host anymore

## Related issue number
fixes #821
