### PR TITLE
Small speed up to normalizing the path

### DIFF
--- a/CHANGES/1137.misc.rst
+++ b/CHANGES/1137.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of normalizing paths -- by :user:`bdraco`.

--- a/tests/test_normalize_path.py
+++ b/tests/test_normalize_path.py
@@ -8,6 +8,7 @@ PATHS = [
     ("/", "/"),
     ("//", "//"),
     ("///", "///"),
+    ("path", "path"),
     # Single-dot
     ("path/to", "path/to"),
     ("././path/to", "path/to"),
@@ -15,6 +16,7 @@ PATHS = [
     ("path/././to", "path/to"),
     ("path/to/.", "path/to/"),
     ("path/to/./.", "path/to/"),
+    ("/path/to/.", "/path/to/"),
     # Double-dots
     ("../path/to", "path/to"),
     ("path/../to", "to"),

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -993,6 +993,35 @@ def test_joinpath_path_starting_from_slash_is_forbidden():
         assert url.joinpath("/to/others")
 
 
+PATHS = [
+    # No dots
+    ("", ""),
+    ("path", "path"),
+    # Single-dot
+    ("path/to", "path/to"),
+    ("././path/to", "path/to"),
+    ("path/./to", "path/to"),
+    ("path/././to", "path/to"),
+    ("path/to/.", "path/to/"),
+    ("path/to/./.", "path/to/"),
+    # Double-dots
+    ("../path/to", "path/to"),
+    ("path/../to", "to"),
+    ("path/../../to", "to"),
+    # Non-ASCII characters
+    ("μονοπάτι/../../να/ᴜɴɪ/ᴄᴏᴅᴇ", "να/ᴜɴɪ/ᴄᴏᴅᴇ"),
+    ("μονοπάτι/../../να/𝕦𝕟𝕚/𝕔𝕠𝕕𝕖/.", "να/𝕦𝕟𝕚/𝕔𝕠𝕕𝕖/"),
+]
+
+
+@pytest.mark.parametrize("original,expected", PATHS)
+def test_join_path_normalized(original: str, expected: str) -> None:
+    """Test that joinpath normalizes paths."""
+    base_url = URL("http://example.com")
+    new_url = base_url.joinpath(original)
+    assert new_url.path == f"/{expected}"
+
+
 # with_path
 
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -886,7 +886,7 @@ class URL:
             parsed = [*old_path_segments[:old_path_cutoff], *parsed]
 
         if self.absolute:
-            parsed = _normalize_path_segments(parsed) if "." in parsed else parsed
+            parsed = _normalize_path_segments(parsed)
             if parsed and parsed[0] != "":
                 # inject a leading slash when adding a path to an absolute URL
                 # where there was none before

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -901,7 +901,7 @@ class URL:
         # Drop '.' and '..' from str path
 
         prefix = ""
-        if path.startswith("/"):
+        if path and path[0] == "/":
             # preserve the "/" root element of absolute paths, copying it to the
             # normalised output as per sections 5.2.4 and 6.2.2.3 of rfc3986.
             prefix = "/"

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -886,7 +886,7 @@ class URL:
             parsed = [*old_path_segments[:old_path_cutoff], *parsed]
 
         if self.absolute:
-            parsed = _normalize_path_segments(parsed)
+            parsed = _normalize_path_segments(parsed) if "." in parsed else parsed
             if parsed and parsed[0] != "":
                 # inject a leading slash when adding a path to an absolute URL
                 # where there was none before
@@ -899,6 +899,9 @@ class URL:
     @classmethod
     def _normalize_path(cls, path: str) -> str:
         # Drop '.' and '..' from str path
+        if "." not in path:
+            # No need to normalize if there are no '.' or '..' segments
+            return path
 
         prefix = ""
         if path and path[0] == "/":


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

- Replace `startswith` with a single char check. `startswith` is a good choice for multiple chars, but its much slower for single chars
- If there are no `.` in the path, don't normalize them as there is nothing to do.  In testing 80% of paths did not have a `.` so we would needless normalize them

## Are there changes in behavior for the user?

no

timeit
startswith: 0.005655332934111357
single char check: 0.0019642498809844255

before
![before_normalize_path](https://github.com/user-attachments/assets/baedff39-0efe-4f82-8789-14e8ac07fc7c)

after
![after_normalize_path](https://github.com/user-attachments/assets/d31f8e27-84f4-4ad4-ba6c-154c99761096)

