### PR TITLE
Allow scheme replacement for relative URLs if the target scheme does not require a host

### DIFF
--- a/CHANGES/1138.bugfix.rst
+++ b/CHANGES/1138.bugfix.rst
@@ -1,0 +1,1 @@
+Allow scheme replacement for relative urls if the scheme does not require a host -- by :user:`bdraco`.

--- a/CHANGES/1138.bugfix.rst
+++ b/CHANGES/1138.bugfix.rst
@@ -1,1 +1,1 @@
-Allow scheme replacement for relative urls if the scheme does not require a host -- by :user:`bdraco`.
+Allow scheme replacement for relative URLs if the scheme does not require a host -- by :user:`bdraco`.

--- a/CHANGES/280.bugfix.rst
+++ b/CHANGES/280.bugfix.rst
@@ -1,0 +1,1 @@
+1138.bugfix.rst

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -16,8 +16,13 @@ def test_with_scheme_uppercased():
 
 
 def test_with_scheme_for_relative_url():
-    with pytest.raises(ValueError):
-        URL("path/to").with_scheme("http")
+    """Test scheme can be set for relative URL."""
+    msg = "scheme replacement is not allowed for " "relative URLs for the http scheme"
+    with pytest.raises(ValueError, match=msg):
+        assert URL("path/to").with_scheme("http")
+
+    expected = URL("file:///absolute/path")
+    assert expected.with_scheme("file") == expected
 
 
 def test_with_scheme_invalid_type():

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1048,8 +1048,12 @@ class URL:
         # N.B. doesn't cleanup query/fragment
         if not isinstance(scheme, str):
             raise TypeError("Invalid scheme type")
-        if not self.absolute:
-            raise ValueError("scheme replacement is not allowed for relative URLs")
+        if not self.absolute and scheme in SCHEME_REQUIRES_HOST:
+            msg = (
+                "scheme replacement is not allowed for "
+                f"relative URLs for the {scheme} scheme"
+            )
+            raise ValueError(msg)
         return URL(self._val._replace(scheme=scheme.lower()), encoded=True)
 
     def with_user(self, user: Union[str, None]) -> "URL":


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

`with_scheme` will now allow scheme replacement for relative urls if scheme does not require a host

## Are there changes in behavior for the user?

bugfix
## Related issue number
fixes #280