### PR TITLE
Accept objects that support __int__ for query vars

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -12,6 +12,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    SupportsInt,
     Tuple,
     TypedDict,
     TypeVar,
@@ -1177,7 +1178,7 @@ class URL:
             if TYPE_CHECKING:
                 assert isinstance(v, str)
             return v
-        if issubclass(cls, float):
+        if cls is float or issubclass(cls, float):
             if TYPE_CHECKING:
                 assert isinstance(v, float)
             if math.isinf(v):
@@ -1185,9 +1186,7 @@ class URL:
             if math.isnan(v):
                 raise ValueError("float('nan') is not supported")
             return str(float(v))
-        if cls is not bool and issubclass(cls, int):
-            if TYPE_CHECKING:
-                assert isinstance(v, int)
+        if cls is not bool and isinstance(cls, SupportsInt):
             return str(int(v))
         raise TypeError(
             "Invalid variable type: value "


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

Previously we would only accept subclasses of int, we will now accept any object that implements __int__ and has the correct protocol.

## Are there changes in behavior for the user?

`np.int16` will now be accepted

## Related issue number
closes #945