### PR TITLE
Restore unquoting of %2F in paths

### DIFF
--- a/CHANGES/1151.breaking.rst
+++ b/CHANGES/1151.breaking.rst
@@ -1,0 +1,3 @@
+Restore decoding ``%2F`` (``/``) in ``URL.path`` -- by :user:`bdraco`.
+
+This change restored the behavior before :issue:`1136`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -346,10 +346,10 @@ def test_path_with_spaces():
 
 
 def test_path_with_2F():
-    """Path should not decode %2F, otherwise it may look like a path separator."""
+    """Path should decode %2F."""
 
     url = URL("http://example.com/foo/bar%2fbaz")
-    assert url.path == "/foo/bar%2Fbaz"
+    assert url.path == "/foo/bar/baz"
 
 
 def test_raw_path_for_empty_url():

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -225,7 +225,7 @@ class URL:
     _FRAGMENT_REQUOTER = _Quoter(safe="?/:@")
 
     _UNQUOTER = _Unquoter()
-    _PATH_UNQUOTER = _Unquoter(ignore="/", unsafe="+")
+    _PATH_UNQUOTER = _Unquoter(unsafe="+")
     _QS_UNQUOTER = _Unquoter(qs=True)
 
     _val: SplitResult


### PR DESCRIPTION
This undones only the ignore part of #1057 in as we will instead add a new property called path_safe in #1150
