### PR TITLE
Increase release timeout from 7 to 14 minutes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -398,7 +398,7 @@ jobs:
     - build-wheels-for-tested-arches
     - pre-setup  # transitive, for accessing settings
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 14
 
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases


### PR DESCRIPTION
The previous release hit the timeout of 7 minutes so the signatures did not upload.  Double the timeout to 14 minutes so this does not happen again.