### PR TITLE
Release 1.12.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,18 @@ Changelog
 
 .. towncrier release notes start
 
+1.12.1
+======
+
+*(2024-09-23)*
+
+
+No significant changes.
+
+
+----
+
+
 1.12.0
 ======
 

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -8,7 +8,7 @@ from ._url import (
     cache_info,
 )
 
-__version__ = "1.12.0"
+__version__ = "1.12.1"
 
 __all__ = (
     "URL",


### PR DESCRIPTION
https://github.com/aio-libs/yarl/actions/runs/11002449369

This is a no change release of 1.12.0 since the signatures failure to upload because the release process hit the timeout.  The timeout has now been increased to 14 minutes from 7 minutes to ensure this does not happen again.