### PR TITLE
Improve performance of building URLs with authority

### DIFF
--- a/CHANGES/1163.misc.rst
+++ b/CHANGES/1163.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of calling :py:meth:`~yarl.URL.build` with ``authority`` -- by :user:`bdraco`.

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -153,6 +153,31 @@ def test_build_with_authority_without_encoding():
     assert str(url) == "http://foo:bar@host.com:8000/path"
 
 
+def test_build_with_authority_empty_host_no_scheme():
+    url = URL.build(authority="", path="path")
+    assert str(url) == "path"
+
+
+def test_build_with_authority_and_only_user():
+    url = URL.build(scheme="https", authority="user:@foo.com", path="/path")
+    assert str(url) == "https://user:@foo.com/path"
+
+
+def test_build_with_authority_with_port():
+    url = URL.build(scheme="https", authority="foo.com:8080", path="/path")
+    assert str(url) == "https://foo.com:8080/path"
+
+
+def test_build_with_authority_with_ipv6():
+    url = URL.build(scheme="https", authority="[::1]", path="/path")
+    assert str(url) == "https://[::1]/path"
+
+
+def test_build_with_authority_with_ipv6_and_port():
+    url = URL.build(scheme="https", authority="[::1]:81", path="/path")
+    assert str(url) == "https://[::1]:81/path"
+
+
 def test_query_str():
     u = URL.build(scheme="http", host="127.0.0.1", path="/", query_string="arg=value1")
     assert str(u) == "http://127.0.0.1/?arg=value1"

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -368,10 +368,22 @@ class URL:
             if encoded:
                 netloc = authority
             else:
-                tmp = SplitResult("", authority, "", "", "")
-                port = None if tmp.port == DEFAULT_PORTS.get(scheme) else tmp.port
+                tmp_username, tmp_password, tmp_host, tmp_port = cls._split_netloc(
+                    authority
+                )
+                port = None if tmp_port == DEFAULT_PORTS.get(scheme) else tmp_port
+                tmp_host = (
+                    ""
+                    if tmp_host is None
+                    else cls._encode_host(tmp_host, validate_host=False)
+                )
                 netloc = cls._make_netloc(
-                    tmp.username, tmp.password, tmp.hostname, port, encode=True
+                    tmp_username,
+                    tmp_password,
+                    tmp_host,
+                    port,
+                    encode=True,
+                    encode_host=False,
                 )
         elif not user and not password and not host and not port:
             netloc = ""

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -372,11 +372,10 @@ class URL:
                     authority
                 )
                 port = None if tmp_port == DEFAULT_PORTS.get(scheme) else tmp_port
-                tmp_host = (
-                    ""
-                    if tmp_host is None
-                    else cls._encode_host(tmp_host, validate_host=False)
-                )
+                if tmp_host is None:
+                    tmp_host = ""
+                else:
+                    tmp_host = cls._encode_host(tmp_host, validate_host=False)
                 netloc = cls._make_netloc(
                     tmp_username,
                     tmp_password,

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -368,21 +368,15 @@ class URL:
             if encoded:
                 netloc = authority
             else:
-                tmp_username, tmp_password, tmp_host, tmp_port = cls._split_netloc(
-                    authority
+                _user, _password, _host, _port = cls._split_netloc(authority)
+                port = None if _port == DEFAULT_PORTS.get(scheme) else _port
+                _host = (
+                    ""
+                    if _host is None
+                    else cls._encode_host(_host, validate_host=False)
                 )
-                port = None if tmp_port == DEFAULT_PORTS.get(scheme) else tmp_port
-                if tmp_host is None:
-                    tmp_host = ""
-                else:
-                    tmp_host = cls._encode_host(tmp_host, validate_host=False)
                 netloc = cls._make_netloc(
-                    tmp_username,
-                    tmp_password,
-                    tmp_host,
-                    port,
-                    encode=True,
-                    encode_host=False,
+                    _user, _password, _host, port, encode=True, encode_host=False
                 )
         elif not user and not password and not host and not port:
             netloc = ""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Use the fast `_split_netloc` method so we do not have to reparse the netloc for every property.

Previously we called each `SplitResult` property, and each property call has to reparse the netloc every time. Only do it once

## Are there changes in behavior for the user?

no

## Related issue number
https://github.com/aio-libs/aiohttp/pull/9309#discussion_r1778760440 will call `URL.build` with `authority` much more often in a performance sensitive path. 