### PR TITLE
Improve performance of _encode_host

### DIFF
--- a/CHANGES/1176.misc.rst
+++ b/CHANGES/1176.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of encoding hosts -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1048,7 +1048,6 @@ class URL:
             if validate_host:
                 _host_validate(host)
             return host
-
         return _idna_encode(host)
 
     @classmethod

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1030,9 +1030,9 @@ class URL:
                 # These checks should not happen in the
                 # LRU to keep the cache size small
                 host, version = ip_compressed_version
-                if version != 6:
-                    return host
-                return f"[{host}%{zone}]" if sep else f"[{host}]"
+                if version == 6:
+                    return f"[{host}%{zone}]" if sep else f"[{host}]"
+                return f"{host}%{zone}" if sep else host
 
         host = host.lower()
         if human:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Improve performance of _encode_host

- If we are not running the potential ip address path, avoid checking for IPv6 zone
- If the parsed address is not IPv6, avoid trying to join the IPv6 zone back to it

This one is very small, I only noticed it because I was looking over `_encode_host`
and wondering why we were looking for an IP zone outside of the ip address block


## Are there changes in behavior for the user?

no


before
![__new__before](https://github.com/user-attachments/assets/913a80bf-5896-4d4a-81c5-ebd87d3ba99d)


after
![__new__after](https://github.com/user-attachments/assets/8e124611-d713-4b32-8858-efe3b16cef6c)
