### PR TITLE
Add test coverage for handling port 0

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -334,14 +334,6 @@ def test_explicit_port_for_implicit_port():
     assert url._port_not_default is None
 
 
-def test_handling_port_zero():
-    url = URL("http://example.com:0")
-    assert url.explicit_port == 0
-    assert url.explicit_port == url._val.port
-    assert url._port_not_default == 0
-    assert str(url) == "http://example.com:0"
-
-
 def test_explicit_port_for_relative_url():
     url = URL("/path/to")
     assert url.explicit_port is None
@@ -1491,6 +1483,15 @@ def test_is_default_port_for_absolute_url_with_nondefault_port():
 
 def test_is_default_port_for_unknown_scheme():
     url = URL("unknown://example.com:8080")
+    assert not url.is_default_port()
+
+
+def test_handling_port_zero():
+    url = URL("http://example.com:0")
+    assert url.explicit_port == 0
+    assert url.explicit_port == url._val.port
+    assert url._port_not_default == 0
+    assert str(url) == "http://example.com:0"
     assert not url.is_default_port()
 
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -334,6 +334,14 @@ def test_explicit_port_for_implicit_port():
     assert url._port_not_default is None
 
 
+def test_handling_port_zero():
+    url = URL("http://example.com:0")
+    assert url.explicit_port == 0
+    assert url.explicit_port == url._val.port
+    assert url._port_not_default == 0
+    assert str(url) == "http://example.com:0"
+
+
 def test_explicit_port_for_relative_url():
     url = URL("/path/to")
     assert url.explicit_port is None


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

This was wrong in previous yarl releases, but fixed by one of the cleanups in 1.14.0. Add coverage to make sure it continues to work as 0 is not a default port

The problem:

`str(URL("http://example.com:0/"))` should be `http://example.com:0/` because `0` is not the default port for `http`

yarl 1.9.5 - 1.13.1 produced it as `http://example.com/` 

<!-- Outline any notable behaviour for the end users. -->
