### PR TITLE
Fix with_scheme checks when passed scheme is not lowercase

### DIFF
--- a/CHANGES/1189.misc.rst
+++ b/CHANGES/1189.misc.rst
@@ -1,0 +1,1 @@
+Fixed validation with :py:meth:`~yarl.URL.with_scheme` when passed scheme is not lowercase -- by :user:`bdraco`.

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -26,8 +26,10 @@ def test_with_scheme_uppercased():
 def test_with_scheme_for_relative_url(scheme: str) -> None:
     """Test scheme can be set for relative URL."""
     lower_scheme = scheme.lower()
-    msg = "scheme replacement is not allowed for "
-    msg += f"relative URLs for the {lower_scheme} scheme"
+    msg = (
+        "scheme replacement is not allowed for "
+        f"relative URLs for the {lower_scheme} scheme"
+    )
     with pytest.raises(ValueError, match=msg):
         assert URL("path/to").with_scheme(scheme)
 

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -15,12 +15,25 @@ def test_with_scheme_uppercased():
     assert str(url.with_scheme("HTTPS")) == "https://example.com"
 
 
-def test_with_scheme_for_relative_url():
+@pytest.mark.parametrize(
+    ("scheme"),
+    [
+        ("http"),
+        ("https"),
+        ("HTTP"),
+    ],
+)
+def test_with_scheme_for_relative_url(scheme: str) -> None:
     """Test scheme can be set for relative URL."""
-    msg = "scheme replacement is not allowed for " "relative URLs for the http scheme"
+    lower_scheme = scheme.lower()
+    msg = "scheme replacement is not allowed for "
+    msg += f"relative URLs for the {lower_scheme} scheme"
     with pytest.raises(ValueError, match=msg):
-        assert URL("path/to").with_scheme("http")
+        assert URL("path/to").with_scheme(scheme)
 
+
+def test_with_scheme_for_relative_file_url() -> None:
+    """Test scheme can be set for relative file URL."""
     expected = URL("file:///absolute/path")
     assert expected.with_scheme("file") == expected
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1124,13 +1124,14 @@ class URL:
         # N.B. doesn't cleanup query/fragment
         if not isinstance(scheme, str):
             raise TypeError("Invalid scheme type")
-        if not self.absolute and scheme in SCHEME_REQUIRES_HOST:
+        lower_scheme = scheme.lower()
+        if not self.absolute and lower_scheme in SCHEME_REQUIRES_HOST:
             msg = (
                 "scheme replacement is not allowed for "
-                f"relative URLs for the {scheme} scheme"
+                f"relative URLs for the {lower_scheme} scheme"
             )
             raise ValueError(msg)
-        return URL(self._val._replace(scheme=scheme.lower()), encoded=True)
+        return URL(self._val._replace(scheme=lower_scheme), encoded=True)
 
     def with_user(self, user: Union[str, None]) -> "URL":
         """Return a new URL with user replaced.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix with_scheme checks when passed scheme is not lowercase

## Are there changes in behavior for the user?

bugfix
