### PR TITLE
Add benchmark script for URLs

### DIFF
--- a/url_benchmark.py
+++ b/url_benchmark.py
@@ -1,0 +1,104 @@
+import timeit
+
+from yarl import URL
+
+MANY_HOSTS = [f"localhost.{i}" for i in range(10000)]
+MANY_URLS = [f"https://localhost.{i}" for i in range(10000)]
+
+print(
+    "Build URL with host and path and port: {:.3f} sec".format(
+        timeit.timeit(
+            "URL.build(host='localhost', path='/req', port=1234)",
+            globals={"URL": URL},
+            number=100000,
+        )
+    )
+)
+
+print(
+    "Build URL with host: {:.3f} sec".format(
+        timeit.timeit(
+            "URL.build(host='localhost')", globals={"URL": URL}, number=100000
+        )
+    )
+)
+
+print(
+    "Build URL with different hosts: {:.3f} sec".format(
+        timeit.timeit(
+            "for host in hosts: URL.build(host=host)",
+            globals={"URL": URL, "hosts": MANY_HOSTS},
+            number=10,
+        )
+    )
+)
+
+print(
+    "Build URL with host and port: {:.3f} sec".format(
+        timeit.timeit(
+            "URL.build(host='localhost', port=1234)",
+            globals={"URL": URL},
+            number=100000,
+        )
+    )
+)
+
+print(
+    "Make URL with host and path and port: {:.3f} sec".format(
+        timeit.timeit(
+            "URL('http://localhost:1234/req')", globals={"URL": URL}, number=100000
+        )
+    )
+)
+
+print(
+    "Make URL with host and path: {:.3f} sec".format(
+        timeit.timeit(
+            "URL('http://localhost/req')", globals={"URL": URL}, number=100000
+        )
+    )
+)
+
+print(
+    "Make URL with many hosts: {:.3f} sec".format(
+        timeit.timeit(
+            "for url in urls: URL(url)",
+            globals={"URL": URL, "urls": MANY_URLS},
+            number=10,
+        )
+    )
+)
+
+
+print(
+    "Make URL with IPv4 Address and path and port: {:.3f} sec".format(
+        timeit.timeit(
+            "URL('http://127.0.0.1:1234/req')", globals={"URL": URL}, number=100000
+        )
+    )
+)
+
+
+print(
+    "Make URL with IPv4 Address and path: {:.3f} sec".format(
+        timeit.timeit(
+            "URL('http://127.0.0.1/req')", globals={"URL": URL}, number=100000
+        )
+    )
+)
+
+
+print(
+    "Make URL with IPv6 Address and path and port: {:.3f} sec".format(
+        timeit.timeit(
+            "URL('http://[::1]:1234/req')", globals={"URL": URL}, number=100000
+        )
+    )
+)
+
+
+print(
+    "Make URL with IPv6 Address and path: {:.3f} sec".format(
+        timeit.timeit("URL('http://[::1]/req')", globals={"URL": URL}, number=100000)
+    )
+)

--- a/url_benchmark.py
+++ b/url_benchmark.py
@@ -16,6 +16,16 @@ print(
 )
 
 print(
+    "Build encoded URL with host and path and port: {:.3f} sec".format(
+        timeit.timeit(
+            "URL.build(host='localhost', path='/req', port=1234, encoded=True)",
+            globals={"URL": URL},
+            number=100000,
+        )
+    )
+)
+
+print(
     "Build URL with host: {:.3f} sec".format(
         timeit.timeit(
             "URL.build(host='localhost')", globals={"URL": URL}, number=100000
@@ -47,6 +57,16 @@ print(
     "Make URL with host and path and port: {:.3f} sec".format(
         timeit.timeit(
             "URL('http://localhost:1234/req')", globals={"URL": URL}, number=100000
+        )
+    )
+)
+
+print(
+    "Make encoded URL with host and path and port: {:.3f} sec".format(
+        timeit.timeit(
+            "URL('http://localhost:1234/req', encoded=True)",
+            globals={"URL": URL},
+            number=100000,
         )
     )
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add benchmark script for URLs

Right now this has the same design as `benchmark.py` which benchmarks the quoter. While this is a good starting point, ideally we use [codspeed](https://codspeed.io/) to keep track of this in the CI

## Are there changes in behavior for the user?

no
