### PR TITLE
Add benchmarks to converting URLs to strings

### DIFF
--- a/url_benchmark.py
+++ b/url_benchmark.py
@@ -5,6 +5,8 @@ from yarl import URL
 MANY_HOSTS = [f"www.domain{i}.tld" for i in range(10000)]
 MANY_URLS = [f"https://www.domain{i}.tld" for i in range(10000)]
 BASE_URL = URL("http://www.domain.tld")
+QUERY_URL = URL("http://www.domain.tld?query=1&query=2&query=3&query=4&query=5")
+URL_WITH_PATH = URL("http://www.domain.tld/req")
 
 print(
     "Build URL with host and path and port: {:.3f} sec".format(
@@ -151,6 +153,39 @@ print(
                 ]
             ),
             globals={"base_url": BASE_URL, "URL": URL},
+            number=100000,
+        )
+    )
+)
+
+
+print(
+    "Convert URL to string: {:.3f} sec".format(
+        timeit.timeit(
+            "str(base_url)",
+            globals={"base_url": BASE_URL, "URL": URL},
+            number=100000,
+        )
+    )
+)
+
+
+print(
+    "Convert URL with path to string: {:.3f} sec".format(
+        timeit.timeit(
+            "str(url_with_path)",
+            globals={"url_with_path": URL_WITH_PATH, "URL": URL},
+            number=100000,
+        )
+    )
+)
+
+
+print(
+    "Convert URL with query to string: {:.3f} sec".format(
+        timeit.timeit(
+            "str(query_url)",
+            globals={"query_url": QUERY_URL, "URL": URL},
             number=100000,
         )
     )


### PR DESCRIPTION
SSIA

master
```
Convert URL to string: 0.094 sec
Convert URL with path to string: 0.096 sec
Convert URL with query to string: 0.141 sec
```

1.9.4
```
Convert URL to string: 0.064 sec
Convert URL with path to string: 0.042 sec
Convert URL with query to string: 0.113 sec
```

1.9.5 -- fails -- this release should probably be yanked
```
^CTraceback (most recent call last):
  File "/opt/homebrew/lib/python3.12/site-packages/yarl/_url.py", line 470, in _default_port
    return socket.getservbyname(scheme)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: service/proto not found
```

1.9.6
```
Convert URL to string: 0.168 sec
Convert URL with path to string: 0.160 sec
Convert URL with query to string: 0.216 sec
```


