### PR TITLE
Improve performance of converting of converting URLs to strings

### DIFF
--- a/CHANGES/1198.misc.rst
+++ b/CHANGES/1198.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of converting :class:`~yarl.URL` objects to strings -- by :user:`bdraco`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -309,14 +309,12 @@ def test_port_for_implicit_port():
 def test_port_for_relative_url():
     url = URL("/path/to")
     assert url.port is None
-    assert url._port_not_default is None
     assert url.explicit_port is None
 
 
 def test_port_for_unknown_scheme():
     url = URL("unknown://example.com")
     assert url.port is None
-    assert url._port_not_default is None
     assert url.explicit_port is None
 
 
@@ -324,28 +322,24 @@ def test_explicit_port_for_explicit_port():
     url = URL("http://example.com:8888")
     assert 8888 == url.explicit_port
     assert url.explicit_port == url._val.port
-    assert url._port_not_default == 8888
 
 
 def test_explicit_port_for_implicit_port():
     url = URL("http://example.com")
     assert url.explicit_port is None
     assert url.explicit_port == url._val.port
-    assert url._port_not_default is None
 
 
 def test_explicit_port_for_relative_url():
     url = URL("/path/to")
     assert url.explicit_port is None
     assert url.explicit_port == url._val.port
-    assert url._port_not_default is None
 
 
 def test_explicit_port_for_unknown_scheme():
     url = URL("unknown://example.com")
     assert url.explicit_port is None
     assert url.explicit_port == url._val.port
-    assert url._port_not_default is None
 
 
 def test_raw_path_string_empty():
@@ -1490,7 +1484,6 @@ def test_handling_port_zero():
     url = URL("http://example.com:0")
     assert url.explicit_port == 0
     assert url.explicit_port == url._val.port
-    assert url._port_not_default == 0
     assert str(url) == "http://example.com:0"
     assert not url.is_default_port()
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -98,7 +98,6 @@ class _InternalURLCache(TypedDict, total=False):
     scheme: str
     raw_authority: str
     _default_port: Union[int, None]
-    _port_not_default: Union[int, None]
     authority: str
     raw_user: Union[str, None]
     user: Union[str, None]
@@ -414,11 +413,13 @@ class URL:
         val = self._val
         if not val.path and self.absolute and (val.query or val.fragment):
             val = val._replace(path="/")
-        if (port := self._port_not_default) is None:
+        if (
+            explicit_port := self.explicit_port
+        ) is not None and explicit_port == self._default_port:
             # port normalization - using None for default ports to remove from rendering
             # https://datatracker.ietf.org/doc/html/rfc3986.html#section-6.2.3
             netloc = self._make_netloc(
-                self.raw_user, self.raw_password, self.host_subcomponent, port
+                self.raw_user, self.raw_password, self.host_subcomponent, None
             )
             val = val._replace(netloc=netloc)
         return urlunsplit(val)
@@ -609,14 +610,6 @@ class URL:
     def _default_port(self) -> Union[int, None]:
         """Default port for the scheme or None if not known."""
         return DEFAULT_PORTS.get(self._val.scheme)
-
-    @cached_property
-    def _port_not_default(self) -> Union[int, None]:
-        """The port part of URL normalized to None if its the default port."""
-        explicit_port = self.explicit_port
-        if explicit_port is None or explicit_port == self._default_port:
-            return None
-        return explicit_port
 
     @cached_property
     def authority(self) -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Improve performance of converting of converting URLs to strings
There was a performance regression here as shown by the benchmarks in #1197

before
```
Convert URL to string: 0.097 sec
Convert URL with path to string: 0.097 sec
Convert URL with query to string: 0.145 sec
```
after
```
Convert URL to string: 0.045 sec
Convert URL with path to string: 0.045 sec
Convert URL with query to string: 0.091 sec
```

1.9.4
```
Convert URL to string: 0.064 sec
Convert URL with path to string: 0.042 sec
Convert URL with query to string: 0.113 sec
```