### PR TITLE
Use comparison chain for validating port numbers

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1229,7 +1229,7 @@ class URL:
         if port is not None:
             if isinstance(port, bool) or not isinstance(port, int):
                 raise TypeError(f"port should be int or None, got {type(port)}")
-            if port < 0 or port > 65535:
+            if not (0 <= port <= 65535):
                 raise ValueError(f"port must be between 0 and 65535, got {port}")
         if not self.absolute:
             raise ValueError("port replacement is not allowed for relative URLs")


### PR DESCRIPTION
The `or` can be combined into a single expression