### PR TITLE
Start building armv7l wheels

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -383,6 +383,7 @@ jobs:
         - aarch64
         - ppc64le
         - s390x
+        - armv7l
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       qemu: ${{ matrix.qemu }}

--- a/CHANGES/1204.feature.rst
+++ b/CHANGES/1204.feature.rst
@@ -1,0 +1,1 @@
+Started building ``armv7l`` wheels -- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

https://github.com/pypa/cibuildwheel/releases/tag/v2.21.2 now supports armv7l on musl

same as https://github.com/aio-libs/propcache/pull/5


## Are there changes in behavior for the user?

armv7l wheels are now available on supported platforms


