### PR TITLE
Release 1.15.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,57 @@ Changelog
 
 .. towncrier release notes start
 
+1.15.0
+======
+
+*(2024-10-11)*
+
+
+Bug fixes
+---------
+
+- Fixed validation with :py:meth:`~yarl.URL.with_scheme` when passed scheme is not lowercase -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1189`.
+
+
+Features
+--------
+
+- Started building ``armv7l`` wheels -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1204`.
+
+
+Miscellaneous internal changes
+------------------------------
+
+- Improved performance of constructing unencoded :class:`~yarl.URL` objects -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1188`.
+
+- Added a cache for parsing hosts to reduce overhead of encoding :class:`~yarl.URL` -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1190`.
+
+- Improved performance of constructing query strings from :class:`~collections.abc.Mapping` -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1193`.
+
+- Improved performance of converting :class:`~yarl.URL` objects to strings -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1198`.
+
+
+----
+
+
 1.14.0
 ======
 

--- a/CHANGES/1188.misc.rst
+++ b/CHANGES/1188.misc.rst
@@ -1,1 +1,0 @@
-Improved performance of constructing unencoded :class:`~yarl.URL` objects -- by :user:`bdraco`.

--- a/CHANGES/1189.bugfix.rst
+++ b/CHANGES/1189.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed validation with :py:meth:`~yarl.URL.with_scheme` when passed scheme is not lowercase -- by :user:`bdraco`.

--- a/CHANGES/1190.misc.rst
+++ b/CHANGES/1190.misc.rst
@@ -1,1 +1,0 @@
-Added a cache for parsing hosts to reduce overhead of encoding :class:`~yarl.URL` -- by :user:`bdraco`.

--- a/CHANGES/1193.misc.rst
+++ b/CHANGES/1193.misc.rst
@@ -1,1 +1,0 @@
-Improved performance of constructing query strings from :class:`~collections.abc.Mapping` -- by :user:`bdraco`.

--- a/CHANGES/1198.misc.rst
+++ b/CHANGES/1198.misc.rst
@@ -1,1 +1,0 @@
-Improved performance of converting :class:`~yarl.URL` objects to strings -- by :user:`bdraco`.

--- a/CHANGES/1204.feature.rst
+++ b/CHANGES/1204.feature.rst
@@ -1,1 +1,0 @@
-Started building ``armv7l`` wheels -- by :user:`bdraco`.

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -8,7 +8,7 @@ from ._url import (
     cache_info,
 )
 
-__version__ = "1.14.1.dev0"
+__version__ = "1.15.0"
 
 __all__ = (
     "URL",


### PR DESCRIPTION
Expected to be the last release to support Python 3.8 (see https://github.com/aio-libs/yarl/pull/1203)

<img width="518" alt="Screenshot 2024-10-11 at 7 22 54 PM" src="https://github.com/user-attachments/assets/7860587d-77c1-47cc-a25d-04a8480dd84c">
