### PR TITLE
Integrate codspeed benchmarking

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -421,6 +421,9 @@ jobs:
       shell: bash
     - name: Self-install
       run: python -Im pip install '${{ steps.wheel-file.outputs.path }}'
+    - name: Fix git owner
+      # https://github.com/CodSpeedHQ/action/issues/104
+      run: git config --global --add safe.directory "*"
     - name: Run benchmarks
       uses: CodSpeedHQ/action@v3
       with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -346,6 +346,87 @@ jobs:
           Py-${{ steps.python-install.outputs.python-version }}
         fail_ci_if_error: false
 
+  benchmark:
+    name: Benchmark
+    needs:
+    - build-pure-python-dists  # transitive, for accessing settings
+    - build-wheels-for-tested-arches
+    - pre-setup  # transitive, for accessing settings
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Retrieve the project source from an sdist inside the GHA artifact
+      uses: re-actors/checkout-python-sdist@release/v2
+      with:
+        source-tarball-name: >-
+          ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
+        workflow-artifact-name: >-
+          ${{ needs.pre-setup.outputs.dists-artifact-name }}
+    - name: Download distributions
+      uses: actions/download-artifact@v4
+      with:
+        path: dist
+        pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
+        merge-multiple: true
+
+    - name: Setup Python 3.12
+      id: python-install
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+        cache: pip
+        cache-dependency-path: requirements/*.txt
+    - name: Install dependencies
+      uses: py-actions/py-dependency-install@v4
+      with:
+        path: requirements/test.txt
+    - name: Determine pre-compiled compatible wheel
+      env:
+        # NOTE: When `pip` is forced to colorize output piped into `jq`,
+        # NOTE: the latter can't parse it. So we're overriding the color
+        # NOTE: preference here via https://no-color.org.
+        # NOTE: Setting `FORCE_COLOR` to any value (including 0, an empty
+        # NOTE: string, or a "YAML null" `~`) doesn't have any effect and
+        # NOTE: `pip` (through its verndored copy of `rich`) treats the
+        # NOTE: presence of the variable as "force-color" regardless.
+        #
+        # NOTE: This doesn't actually work either, so we'll resort to unsetting
+        # NOTE: in the Bash script.
+        # NOTE: Ref: https://github.com/Textualize/rich/issues/2622
+        NO_COLOR: 1
+      id: wheel-file
+      run: >
+        echo -n path= | tee -a "${GITHUB_OUTPUT}"
+
+
+        unset FORCE_COLOR
+
+
+        python
+        -X utf8
+        -u -I
+        -m pip install
+        --find-links=./dist
+        --no-index
+        '${{ env.PROJECT_NAME }}'
+        --force-reinstall
+        --no-color
+        --no-deps
+        --only-binary=:all:
+        --dry-run
+        --report=-
+        --quiet
+        | jq --raw-output .install[].download_info.url
+        | tee -a "${GITHUB_OUTPUT}"
+      shell: bash
+    - name: Self-install
+      run: python -Im pip install '${{ steps.wheel-file.outputs.path }}'
+    - name: Run benchmarks
+      uses: CodSpeedHQ/action@v3
+      with:
+        token: ${{ secrets.CODSPEED_TOKEN }}
+        run: python -Im pytest --no-cov -vvvvv --codspeed
+
   test-summary:
     name: Test matrix status
     if: always()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -355,6 +355,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+    - name: Checkout project
+      uses: actions/checkout@v4
     - name: Retrieve the project source from an sdist inside the GHA artifact
       uses: re-actors/checkout-python-sdist@release/v2
       with:
@@ -421,9 +423,6 @@ jobs:
       shell: bash
     - name: Self-install
       run: python -Im pip install '${{ steps.wheel-file.outputs.path }}'
-    - name: Fix git owner
-      # https://github.com/CodSpeedHQ/action/issues/104
-      run: git config --global --add safe.directory "*"
     - name: Run benchmarks
       uses: CodSpeedHQ/action@v3
       with:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,6 @@ idna==3.10
 multidict==6.1.0
 propcache==0.2.0
 pytest==8.3.3
-pytest-codspeed=2.2.1
+pytest-codspeed==2.2.1
 pytest-cov>=2.3.1
 pytest-xdist

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,5 +5,6 @@ idna==3.10
 multidict==6.1.0
 propcache==0.2.0
 pytest==8.3.3
+pytest-codspeed=2.2.1
 pytest-cov>=2.3.1
 pytest-xdist

--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -7,6 +7,8 @@ MANY_URLS = [f"https://www.domain{i}.tld" for i in range(512)]
 BASE_URL = URL("http://www.domain.tld")
 QUERY_URL = URL("http://www.domain.tld?query=1&query=2&query=3&query=4&query=5")
 URL_WITH_PATH = URL("http://www.domain.tld/req")
+_QUERY_SEQ = {str(i): (str(j) for j in range(10)) for i in range(10)}
+_SIMPLE_QUERY = {str(i): str(i) for i in range(10)}
 
 
 @pytest.mark.benchmark
@@ -78,38 +80,12 @@ def test_url_make_with_ipv6_address_and_path_performance():
 
 @pytest.mark.benchmark
 def test_url_make_with_query_mapping_performance():
-    BASE_URL.with_query(
-        {
-            "a": "1",
-            "b": "2",
-            "c": "3",
-            "d": "4",
-            "e": "5",
-            "f": "6",
-            "g": "7",
-            "h": "8",
-            "i": "9",
-            "j": "10",
-        }
-    )
+    BASE_URL.with_query(_SIMPLE_QUERY)
 
 
 @pytest.mark.benchmark
 def test_url_make_with_query_sequence_mapping_performance():
-    BASE_URL.with_query(
-        {
-            "0": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-            "1": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-            "2": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-            "3": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-            "4": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-            "5": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-            "6": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-            "7": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-            "8": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-            "9": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
-        }
-    )
+    BASE_URL.with_query(_QUERY_SEQ)
 
 
 @pytest.mark.benchmark

--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -7,8 +7,8 @@ MANY_URLS = [f"https://www.domain{i}.tld" for i in range(512)]
 BASE_URL = URL("http://www.domain.tld")
 QUERY_URL = URL("http://www.domain.tld?query=1&query=2&query=3&query=4&query=5")
 URL_WITH_PATH = URL("http://www.domain.tld/req")
-_QUERY_SEQ = {str(i): (str(j) for j in range(10)) for i in range(10)}
-_SIMPLE_QUERY = {str(i): str(i) for i in range(10)}
+QUERY_SEQ = {str(i): tuple(str(j) for j in range(10)) for i in range(10)}
+SIMPLE_QUERY = {str(i): str(i) for i in range(10)}
 
 
 @pytest.mark.benchmark
@@ -80,12 +80,12 @@ def test_url_make_with_ipv6_address_and_path_performance():
 
 @pytest.mark.benchmark
 def test_url_make_with_query_mapping_performance():
-    BASE_URL.with_query(_SIMPLE_QUERY)
+    BASE_URL.with_query(SIMPLE_QUERY)
 
 
 @pytest.mark.benchmark
 def test_url_make_with_query_sequence_mapping_performance():
-    BASE_URL.with_query(_QUERY_SEQ)
+    BASE_URL.with_query(QUERY_SEQ)
 
 
 @pytest.mark.benchmark

--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -2,8 +2,8 @@ import pytest
 
 from yarl import URL
 
-MANY_HOSTS = [f"www.domain{i}.tld" for i in range(10000)]
-MANY_URLS = [f"https://www.domain{i}.tld" for i in range(10000)]
+MANY_HOSTS = [f"www.domain{i}.tld" for i in range(512)]
+MANY_URLS = [f"https://www.domain{i}.tld" for i in range(512)]
 BASE_URL = URL("http://www.domain.tld")
 QUERY_URL = URL("http://www.domain.tld?query=1&query=2&query=3&query=4&query=5")
 URL_WITH_PATH = URL("http://www.domain.tld/req")

--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -1,0 +1,127 @@
+import pytest
+
+from yarl import URL
+
+MANY_HOSTS = [f"www.domain{i}.tld" for i in range(10000)]
+MANY_URLS = [f"https://www.domain{i}.tld" for i in range(10000)]
+BASE_URL = URL("http://www.domain.tld")
+QUERY_URL = URL("http://www.domain.tld?query=1&query=2&query=3&query=4&query=5")
+URL_WITH_PATH = URL("http://www.domain.tld/req")
+
+
+@pytest.mark.benchmark
+def test_url_build_with_host_and_port_performance():
+    URL.build(host="www.domain.tld", path="/req", port=1234)
+
+
+@pytest.mark.benchmark
+def test_url_build_encoded_with_host_and_port_performance():
+    URL.build(host="www.domain.tld", path="/req", port=1234, encoded=True)
+
+
+@pytest.mark.benchmark
+def test_url_build_with_host_performance():
+    URL.build(host="domain")
+
+
+@pytest.mark.benchmark
+def test_url_build_with_different_hosts_performance():
+    for host in MANY_HOSTS:
+        URL.build(host=host)
+
+
+@pytest.mark.benchmark
+def test_url_build_with_host_path_and_port_performance():
+    URL.build(host="www.domain.tld", port=1234)
+
+
+@pytest.mark.benchmark
+def test_url_make_with_host_path_and_port_performance():
+    URL("http://www.domain.tld:1234/req")
+
+
+@pytest.mark.benchmark
+def test_url_make_encoded_with_host_path_and_port_performance():
+    URL("http://www.domain.tld:1234/req", encoded=True)
+
+
+@pytest.mark.benchmark
+def test_url_make_with_host_and_path_performance():
+    URL("http://www.domain.tld")
+
+
+@pytest.mark.benchmark
+def test_url_make_with_many_hosts_performance():
+    for url in MANY_URLS:
+        URL(url)
+
+
+@pytest.mark.benchmark
+def test_url_make_with_ipv4_address_path_and_port_performance():
+    URL("http://127.0.0.1:1234/req")
+
+
+@pytest.mark.benchmark
+def test_url_make_with_ipv4_address_and_path_performance():
+    URL("http://127.0.0.1/req")
+
+
+@pytest.mark.benchmark
+def test_url_make_with_ipv6_address_path_and_port_performance():
+    URL("http://[::1]:1234/req")
+
+
+@pytest.mark.benchmark
+def test_url_make_with_ipv6_address_and_path_performance():
+    URL("http://[::1]/req")
+
+
+@pytest.mark.benchmark
+def test_url_make_with_query_mapping_performance():
+    BASE_URL.with_query(
+        {
+            "a": "1",
+            "b": "2",
+            "c": "3",
+            "d": "4",
+            "e": "5",
+            "f": "6",
+            "g": "7",
+            "h": "8",
+            "i": "9",
+            "j": "10",
+        }
+    )
+
+
+@pytest.mark.benchmark
+def test_url_make_with_query_sequence_mapping_performance():
+    BASE_URL.with_query(
+        {
+            "0": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+            "1": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+            "2": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+            "3": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+            "4": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+            "5": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+            "6": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+            "7": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+            "8": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+            "9": ("1", "2", "3", "4", "5", "6", "7", "8", "9", "10"),
+        }
+    )
+
+
+@pytest.mark.benchmark
+def test_url_to_string_performance():
+    str(BASE_URL)
+
+
+@pytest.mark.benchmark
+def test_url_with_path_to_string_performance():
+    str(URL_WITH_PATH)
+
+
+@pytest.mark.benchmark
+def test_url_with_query_to_string_performance():
+    str(QUERY_URL)


### PR DESCRIPTION
Add URL benchmarks to [codspeed](https://codspeed.io/aio-libs/yarl/benchmarks)

A followup PR will integration the quoting benchmarks

The goal is to tell us when a performance regression is introduced early before it makes it to production and hopefully catch any blocking I/O