### PR TITLE
Fix benchmarks including pytest overhead

### DIFF
--- a/tests/test_quoting_benchmarks.py
+++ b/tests/test_quoting_benchmarks.py
@@ -1,5 +1,3 @@
-import pytest
-
 from yarl._quoting import _Quoter, _Unquoter
 
 QUOTER_SLASH_SAFE = _Quoter(safe="/")
@@ -7,25 +5,29 @@ QUOTER = _Quoter()
 UNQUOTER = _Unquoter()
 
 
-@pytest.mark.benchmark
-def test_quoter_ascii():
-    for _ in range(100):
-        QUOTER_SLASH_SAFE("/path/to")
+def test_quoter_ascii(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            QUOTER_SLASH_SAFE("/path/to")
 
 
-@pytest.mark.benchmark
-def test_quoter_pct():
-    for _ in range(100):
-        QUOTER("abc%0a")
+def test_quoter_pct(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            QUOTER("abc%0a")
 
 
-@pytest.mark.benchmark
-def test_quoter_quote():
-    for _ in range(100):
-        QUOTER("/шлях/файл")
+def test_quoter_quote(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            QUOTER("/шлях/файл")
 
 
-@pytest.mark.benchmark
-def test_unquoter():
-    for _ in range(100):
-        UNQUOTER("/path/to")
+def test_unquoter(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            UNQUOTER("/path/to")

--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -1,5 +1,3 @@
-import pytest
-
 from yarl import URL
 
 MANY_HOSTS = [f"www.domain{i}.tld" for i in range(512)]
@@ -11,109 +9,127 @@ QUERY_SEQ = {str(i): tuple(str(j) for j in range(10)) for i in range(10)}
 SIMPLE_QUERY = {str(i): str(i) for i in range(10)}
 
 
-@pytest.mark.benchmark
-def test_url_build_with_host_and_port():
-    for _ in range(100):
-        URL.build(host="www.domain.tld", path="/req", port=1234)
+def test_url_build_with_host_and_port(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL.build(host="www.domain.tld", path="/req", port=1234)
 
 
-@pytest.mark.benchmark
-def test_url_build_encoded_with_host_and_port():
-    for _ in range(100):
-        URL.build(host="www.domain.tld", path="/req", port=1234, encoded=True)
+def test_url_build_encoded_with_host_and_port(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL.build(host="www.domain.tld", path="/req", port=1234, encoded=True)
 
 
-@pytest.mark.benchmark
-def test_url_build_with_host():
-    for _ in range(100):
-        URL.build(host="domain")
+def test_url_build_with_host(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL.build(host="domain")
 
 
-@pytest.mark.benchmark
-def test_url_build_with_different_hosts():
-    for host in MANY_HOSTS:
-        URL.build(host=host)
+def test_url_build_with_different_hosts(benchmark):
+    @benchmark
+    def _run():
+        for host in MANY_HOSTS:
+            URL.build(host=host)
 
 
-@pytest.mark.benchmark
-def test_url_build_with_host_path_and_port():
-    for _ in range(100):
-        URL.build(host="www.domain.tld", port=1234)
+def test_url_build_with_host_path_and_port(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL.build(host="www.domain.tld", port=1234)
 
 
-@pytest.mark.benchmark
-def test_url_make_with_host_path_and_port():
-    for _ in range(100):
-        URL("http://www.domain.tld:1234/req")
+def test_url_make_with_host_path_and_port(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL("http://www.domain.tld:1234/req")
 
 
-@pytest.mark.benchmark
-def test_url_make_encoded_with_host_path_and_port():
-    for _ in range(100):
-        URL("http://www.domain.tld:1234/req", encoded=True)
+def test_url_make_encoded_with_host_path_and_port(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL("http://www.domain.tld:1234/req", encoded=True)
 
 
-@pytest.mark.benchmark
-def test_url_make_with_host_and_path():
-    for _ in range(100):
-        URL("http://www.domain.tld")
+def test_url_make_with_host_and_path(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL("http://www.domain.tld")
 
 
-@pytest.mark.benchmark
-def test_url_make_with_many_hosts():
-    for url in MANY_URLS:
-        URL(url)
+def test_url_make_with_many_hosts(benchmark):
+    @benchmark
+    def _run():
+        for url in MANY_URLS:
+            URL(url)
 
 
-@pytest.mark.benchmark
-def test_url_make_with_ipv4_address_path_and_port():
-    for _ in range(100):
-        URL("http://127.0.0.1:1234/req")
+def test_url_make_with_ipv4_address_path_and_port(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL("http://127.0.0.1:1234/req")
 
 
-@pytest.mark.benchmark
-def test_url_make_with_ipv4_address_and_path():
-    for _ in range(100):
-        URL("http://127.0.0.1/req")
+def test_url_make_with_ipv4_address_and_path(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL("http://127.0.0.1/req")
 
 
-@pytest.mark.benchmark
-def test_url_make_with_ipv6_address_path_and_port():
-    for _ in range(100):
-        URL("http://[::1]:1234/req")
+def test_url_make_with_ipv6_address_path_and_port(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL("http://[::1]:1234/req")
 
 
-@pytest.mark.benchmark
-def test_url_make_with_ipv6_address_and_path():
-    for _ in range(100):
-        URL("http://[::1]/req")
+def test_url_make_with_ipv6_address_and_path(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            URL("http://[::1]/req")
 
 
-@pytest.mark.benchmark
-def test_url_make_with_query_mapping():
-    for _ in range(100):
-        BASE_URL.with_query(SIMPLE_QUERY)
+def test_url_make_with_query_mapping(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            BASE_URL.with_query(SIMPLE_QUERY)
 
 
-@pytest.mark.benchmark
-def test_url_make_with_query_sequence_mapping():
-    for _ in range(100):
-        BASE_URL.with_query(QUERY_SEQ)
+def test_url_make_with_query_sequence_mapping(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            BASE_URL.with_query(QUERY_SEQ)
 
 
-@pytest.mark.benchmark
-def test_url_to_string():
-    for _ in range(100):
-        str(BASE_URL)
+def test_url_to_string(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            str(BASE_URL)
 
 
-@pytest.mark.benchmark
-def test_url_with_path_to_string():
-    for _ in range(100):
-        str(URL_WITH_PATH)
+def test_url_with_path_to_string(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            str(URL_WITH_PATH)
 
 
-@pytest.mark.benchmark
-def test_url_with_query_to_string():
-    for _ in range(100):
-        str(QUERY_URL)
+def test_url_with_query_to_string(benchmark):
+    @benchmark
+    def _run():
+        for _ in range(100):
+            str(QUERY_URL)


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

The pytest mark is a bit nicer because it is less verbose, but it has the side effect of including the pytest overhead to set up the test which may change between versions.

