### PR TITLE
Add typing to benchmark tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -120,6 +120,7 @@ repos:
     - pytest
     - tomli  # requirement of packaging/pep517_backend/
     - types-setuptools  # requirement of packaging/pep517_backend/
+    - pytest_codspeed
     args:
     - --python-version=3.13
     - --txt-report=.tox/.tmp/.mypy/python-3.13
@@ -137,6 +138,7 @@ repos:
     - pytest
     - tomli  # requirement of packaging/pep517_backend/
     - types-setuptools  # requirement of packaging/pep517_backend/
+    - pytest_codspeed
     args:
     - --python-version=3.12
     - --txt-report=.tox/.tmp/.mypy/python-3.12
@@ -156,6 +158,7 @@ repos:
     - types-setuptools  # requirement of packaging/pep517_backend/
     - types-Pygments
     - types-colorama
+    - pytest_codspeed
     args:
     - --python-version=3.10
     - --txt-report=.tox/.tmp/.mypy/python-3.10
@@ -175,6 +178,7 @@ repos:
     - types-setuptools  # requirement of packaging/pep517_backend/
     - types-Pygments
     - types-colorama
+    - pytest_codspeed
     args:
     - --python-version=3.8
     - --txt-report=.tox/.tmp/.mypy/python-3.8

--- a/tests/test_quoting_benchmarks.py
+++ b/tests/test_quoting_benchmarks.py
@@ -1,3 +1,7 @@
+"""codspeed benchmark for yarl._quoting module."""
+
+from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
+
 from yarl._quoting import _Quoter, _Unquoter
 
 QUOTER_SLASH_SAFE = _Quoter(safe="/")
@@ -5,29 +9,29 @@ QUOTER = _Quoter()
 UNQUOTER = _Unquoter()
 
 
-def test_quoter_ascii(benchmark):
+def test_quoter_ascii(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             QUOTER_SLASH_SAFE("/path/to")
 
 
-def test_quoter_pct(benchmark):
+def test_quoter_pct(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             QUOTER("abc%0a")
 
 
-def test_quoter_quote(benchmark):
+def test_quoter_quote(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             QUOTER("/шлях/файл")
 
 
-def test_unquoter(benchmark):
+def test_unquoter(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             UNQUOTER("/path/to")

--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -1,3 +1,7 @@
+"""codspeed benchmarks for yarl.URL."""
+
+from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
+
 from yarl import URL
 
 MANY_HOSTS = [f"www.domain{i}.tld" for i in range(512)]
@@ -9,193 +13,193 @@ QUERY_SEQ = {str(i): tuple(str(j) for j in range(10)) for i in range(10)}
 SIMPLE_QUERY = {str(i): str(i) for i in range(10)}
 
 
-def test_url_build_with_host_and_port(benchmark):
+def test_url_build_with_host_and_port(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL.build(host="www.domain.tld", path="/req", port=1234)
 
 
-def test_url_build_encoded_with_host_and_port(benchmark):
+def test_url_build_encoded_with_host_and_port(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL.build(host="www.domain.tld", path="/req", port=1234, encoded=True)
 
 
-def test_url_build_with_host(benchmark):
+def test_url_build_with_host(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL.build(host="domain")
 
 
-def test_url_build_access_username_password(benchmark):
+def test_url_build_access_username_password(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             url = URL.build(host="www.domain.tld", user="user", password="password")
             url.raw_user
             url.raw_password
 
 
-def test_url_build_access_raw_host(benchmark):
+def test_url_build_access_raw_host(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             url = URL.build(host="www.domain.tld")
             url.raw_host
 
 
-def test_url_build_access_fragment(benchmark):
+def test_url_build_access_fragment(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             url = URL.build(host="www.domain.tld")
             url.fragment
 
 
-def test_url_build_access_raw_path(benchmark):
+def test_url_build_access_raw_path(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             url = URL.build(host="www.domain.tld", path="/req")
             url.raw_path
 
 
-def test_url_build_with_different_hosts(benchmark):
+def test_url_build_with_different_hosts(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for host in MANY_HOSTS:
             URL.build(host=host)
 
 
-def test_url_build_with_host_path_and_port(benchmark):
+def test_url_build_with_host_path_and_port(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL.build(host="www.domain.tld", port=1234)
 
 
-def test_url_make_with_host_path_and_port(benchmark):
+def test_url_make_with_host_path_and_port(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL("http://www.domain.tld:1234/req")
 
 
-def test_url_make_encoded_with_host_path_and_port(benchmark):
+def test_url_make_encoded_with_host_path_and_port(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL("http://www.domain.tld:1234/req", encoded=True)
 
 
-def test_url_make_with_host_and_path(benchmark):
+def test_url_make_with_host_and_path(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL("http://www.domain.tld")
 
 
-def test_url_make_with_many_hosts(benchmark):
+def test_url_make_with_many_hosts(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for url in MANY_URLS:
             URL(url)
 
 
-def test_url_make_access_raw_host(benchmark):
+def test_url_make_access_raw_host(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             url = URL("http://www.domain.tld")
             url.raw_host
 
 
-def test_url_make_access_fragment(benchmark):
+def test_url_make_access_fragment(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             url = URL("http://www.domain.tld")
             url.fragment
 
 
-def test_url_make_access_raw_path(benchmark):
+def test_url_make_access_raw_path(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             url = URL("http://www.domain.tld/req")
             url.raw_path
 
 
-def test_url_make_access_username_password(benchmark):
+def test_url_make_access_username_password(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             url = URL("http://user:password@www.domain.tld")
             url.raw_user
             url.raw_password
 
 
-def test_url_make_with_ipv4_address_path_and_port(benchmark):
+def test_url_make_with_ipv4_address_path_and_port(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL("http://127.0.0.1:1234/req")
 
 
-def test_url_make_with_ipv4_address_and_path(benchmark):
+def test_url_make_with_ipv4_address_and_path(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL("http://127.0.0.1/req")
 
 
-def test_url_make_with_ipv6_address_path_and_port(benchmark):
+def test_url_make_with_ipv6_address_path_and_port(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL("http://[::1]:1234/req")
 
 
-def test_url_make_with_ipv6_address_and_path(benchmark):
+def test_url_make_with_ipv6_address_and_path(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             URL("http://[::1]/req")
 
 
-def test_url_make_with_query_mapping(benchmark):
+def test_url_make_with_query_mapping(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             BASE_URL.with_query(SIMPLE_QUERY)
 
 
-def test_url_make_with_query_sequence_mapping(benchmark):
+def test_url_make_with_query_sequence_mapping(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             BASE_URL.with_query(QUERY_SEQ)
 
 
-def test_url_to_string(benchmark):
+def test_url_to_string(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             str(BASE_URL)
 
 
-def test_url_with_path_to_string(benchmark):
+def test_url_with_path_to_string(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             str(URL_WITH_PATH)
 
 
-def test_url_with_query_to_string(benchmark):
+def test_url_with_query_to_string(benchmark: BenchmarkFixture) -> None:
     @benchmark
-    def _run():
+    def _run() -> None:
         for _ in range(100):
             str(QUERY_URL)


### PR DESCRIPTION
Note that pytest_codspeed is missing `py.typed` so its still going to be `Any` for its imports