### PR TITLE
Speed up methods that create new URL objects

### DIFF
--- a/CHANGES/1226.misc.rst
+++ b/CHANGES/1226.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of all :class:`~yarl.URL` methods that create new :class:`~yarl.URL` objects -- by :user:`bdraco`.


### PR DESCRIPTION
Use the `_from_val` method when constructing from `SplitResult` since it has a fast path to construct new `URL` objects when the source is a `SplitResult`
