### PR TITLE
Improve performance of building non-encoded URLs

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -386,7 +386,7 @@ class URL:
             if _host is not None:
                 if port is not None:
                     port = None if port == DEFAULT_PORTS.get(scheme) else port
-                netloc = cls._make_netloc(user, password, _host, port, encode=True)
+                netloc = cls._make_netloc(user, password, _host, port, True)
 
             path = cls._PATH_QUOTER(path) if path else path
             if path and netloc:


### PR DESCRIPTION
The LRU is a lot more expensive with a kwarg, and since this is the only place we encode its unlikely to ever be used anywhere else in the future. This have all of the speed up in https://github.com/aio-libs/yarl/pull/1220 and have none of the regression.