### PR TITLE
Add missing type for host_subcomponent to the internal cache

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -105,6 +105,7 @@ class _InternalURLCache(TypedDict, total=False):
     password: Union[str, None]
     raw_host: Union[str, None]
     host: Union[str, None]
+    host_subcomponent: Union[str, None]
     port: Union[int, None]
     explicit_port: Union[int, None]
     raw_path: str


### PR DESCRIPTION

## What do these changes do?

Add missing type for host_subcomponent to the internal cache

## Are there changes in behavior for the user?

no


It happens that we never set this one manually so it was not noticed