### PR TITLE
DNM: Run benchmarks on Python 3.8

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -371,11 +371,11 @@ jobs:
         pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         merge-multiple: true
 
-    - name: Setup Python 3.12
+    - name: Setup Python 3.8
       id: python-install
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.8
         cache: pip
         cache-dependency-path: requirements/*.txt
     - name: Install dependencies


### PR DESCRIPTION
This is to get a baseline before we remove 3.8 support
