### PR TITLE
Split wheel builds into manylinux and musllinux groups to speed up CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -133,9 +133,13 @@ jobs:
         - ubuntu
         - windows
         - macos
+        tag:
+        - 'manylinux'
+        - 'musllinux'
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       os: ${{ matrix.os }}
+      tag: ${{ matrix.tag }}
       wheel-tags-to-skip: >-
         ${{
         (github.event_name != 'push' || !contains(github.ref, 'refs/tags/'))
@@ -467,9 +471,13 @@ jobs:
         - ppc64le
         - s390x
         - armv7l
+        tag:
+        - 'manylinux'
+        - 'musllinux'
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       qemu: ${{ matrix.qemu }}
+      tag: ${{ matrix.tag }}
       source-tarball-name: >-
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
       dists-artifact-name: ${{ needs.pre-setup.outputs.dists-artifact-name }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -134,8 +134,14 @@ jobs:
         - windows
         - macos
         tag:
-        - 'manylinux'
-        - 'musllinux'
+        - manylinux
+        - musllinux
+        exclude:
+        - tag: >-
+           ${{
+           (github.event_name != 'push' || !contains(github.ref, 'refs/tags/'))
+           && 'musllinux' || ''
+           }}
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       os: ${{ matrix.os }}
@@ -472,8 +478,11 @@ jobs:
         - s390x
         - armv7l
         tag:
-        - 'manylinux'
-        - 'musllinux'
+        - manylinux
+        - musllinux
+        exclude:
+        - tag: manylinux
+          qemu: armv7l
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       qemu: ${{ matrix.qemu }}

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -24,6 +24,11 @@ on:
         default: ''
         required: false
         type: string
+      tag:
+        description: Build platform tag wheels
+        default: '0'
+        required: false
+        type: string
       source-tarball-name:
         description: Sdist filename wildcard
         required: true
@@ -42,7 +47,8 @@ env:
 jobs:
 
   build-wheel:
-    name: Build wheels on ${{ inputs.os }} ${{ inputs.qemu }}
+    name: >-
+     Build wheels on ${{ inputs.os }} ${{ inputs.qemu }} ${{ inputs.tag }}
     runs-on: ${{ inputs.os }}-latest
     timeout-minutes: ${{ inputs.qemu && 60 || 20 }}
     steps:
@@ -72,6 +78,18 @@ jobs:
         echo "CIBW_SKIP=${{ inputs.wheel-tags-to-skip }}" >> "${GITHUB_ENV}"
       shell: bash
 
+    - name: Skip manylinux wheels
+      if: inputs.tag == 'musllinux'
+      run: |
+        echo "CIBW_SKIP=$CIBW_SKIP *manylinux*" >> "${GITHUB_ENV}"
+      shell: bash
+
+    - name: Skip musllinux wheels
+      if: inputs.tag == 'manylinux'
+      run: |
+        echo "CIBW_SKIP=$CIBW_SKIP *musllinux*" >> "${GITHUB_ENV}"
+      shell: bash
+
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.21.3
       env:
@@ -83,8 +101,10 @@ jobs:
     - name: Upload built artifacts for testing and publishing
       uses: actions/upload-artifact@v4
       with:
-        name: >-
-          ${{ inputs.dists-artifact-name }}-${{ inputs.os }}-${{ inputs.qemu }}
+        name: ${{ inputs.dists-artifact-name }}-
+          ${{ inputs.os }}-
+          ${{ inputs.qemu }}-
+          ${{ inputs.tag }}
         path: ./wheelhouse/*.whl
 
 ...


### PR DESCRIPTION
Release [failed](https://github.com/aio-libs/yarl/actions/runs/11307702438) due to timeout waiting for wheels to build

- One group for musl
- One group for non-musl
