### PR TITLE
Adjust many url and many hosts benchmarks to reduce CI run time

### DIFF
--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -4,8 +4,8 @@ from pytest_codspeed import BenchmarkFixture  # type: ignore[import-untyped]
 
 from yarl import URL
 
-MANY_HOSTS = [f"www.domain{i}.tld" for i in range(512)]
-MANY_URLS = [f"https://www.domain{i}.tld" for i in range(512)]
+MANY_HOSTS = [f"www.domain{i}.tld" for i in range(256)]
+MANY_URLS = [f"https://www.domain{i}.tld" for i in range(256)]
 BASE_URL = URL("http://www.domain.tld")
 QUERY_URL = URL("http://www.domain.tld?query=1&query=2&query=3&query=4&query=5")
 URL_WITH_PATH = URL("http://www.domain.tld/req")


### PR DESCRIPTION
The last release failed because the tests took too long
https://github.com/aio-libs/yarl/actions/runs/11307702438/job/31449999361
