### PR TITLE
Disable running hypothesis tests under cibuildwheel

### DIFF
--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -64,6 +64,12 @@ jobs:
       with:
         platforms: all
       id: qemu
+
+    - name: Add wheel type to environment
+      run: |
+        echo "CIBW_TYPE=${{ inputs.os }}-${{ inputs.qemu }}" >> "${GITHUB_ENV}"
+      shell: bash
+
     - name: Prepare emulation
       if: inputs.qemu
       run: |

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -1,3 +1,4 @@
+import os
 from typing import Type
 
 import pytest
@@ -7,6 +8,8 @@ from hypothesis import strategies as st
 from yarl._quoting import NO_EXTENSIONS
 from yarl._quoting_py import _Quoter as _PyQuoter
 from yarl._quoting_py import _Unquoter as _PyUnquoter
+
+IS_CIBUILDWHEEL = bool(os.getenv("CIBW_TYPE"))
 
 if not NO_EXTENSIONS:
     from yarl._quoting_c import _Quoter as _CQuoter
@@ -471,12 +474,14 @@ def test_unquoter_path_with_plus(unquoter):
 
 
 @given(safe=st.text(), protected=st.text(), qs=st.booleans(), requote=st.booleans())
+@pytest.mark.skipif(IS_CIBUILDWHEEL, reason="This test is too slow for cibuildwheel.")
 def test_fuzz__PyQuoter(safe, protected, qs, requote):
     """Verify that _PyQuoter can be instantiated with any valid arguments."""
     assert _PyQuoter(safe=safe, protected=protected, qs=qs, requote=requote)
 
 
 @given(ignore=st.text(), unsafe=st.text(), qs=st.booleans())
+@pytest.mark.skipif(IS_CIBUILDWHEEL, reason="This test is too slow for cibuildwheel.")
 def test_fuzz__PyUnquoter(ignore, unsafe, qs):
     """Verify that _PyUnquoter can be instantiated with any valid arguments."""
     assert _PyUnquoter(ignore=ignore, unsafe=unsafe, qs=qs)
@@ -488,6 +493,7 @@ def test_fuzz__PyUnquoter(ignore, unsafe, qs):
         alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
     ),
 )
+@pytest.mark.skipif(IS_CIBUILDWHEEL, reason="This test is too slow for cibuildwheel.")
 @pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
 @pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
 def test_quote_unquote_parameter(
@@ -509,6 +515,7 @@ def test_quote_unquote_parameter(
         alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
     ),
 )
+@pytest.mark.skipif(IS_CIBUILDWHEEL, reason="This test is too slow for cibuildwheel.")
 @pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
 @pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
 def test_quote_unquote_parameter_requote(
@@ -530,6 +537,7 @@ def test_quote_unquote_parameter_requote(
         alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
     ),
 )
+@pytest.mark.skipif(IS_CIBUILDWHEEL, reason="This test is too slow for cibuildwheel.")
 @pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
 @pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
 def test_quote_unquote_parameter_path_safe(


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Some of these tests take more than 25s+ when building wheels and the test times were getting to be significantly longer than the build times (almost an order of magnitude under qemu)

fixes #1237

Previous build failed due to timeout https://github.com/aio-libs/yarl/actions/runs/11307702438

## Are there changes in behavior for the user?

no
