### PR TITLE
Fix building musllinux wheels during release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -134,13 +134,13 @@ jobs:
         - windows
         - macos
         tag:
-        - manylinux
-        - musllinux
-        exclude:
-        - tag: >-
+        - ''
+        include:
+        - os: ubuntu
+          tag: >-
            ${{
            (github.event_name != 'push' || !contains(github.ref, 'refs/tags/'))
-           && 'musllinux' || ''
+           && '' || 'musllinux'
            }}
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
@@ -478,10 +478,10 @@ jobs:
         - s390x
         - armv7l
         tag:
-        - manylinux
+        - ''
         - musllinux
         exclude:
-        - tag: manylinux
+        - tag: ''
           qemu: armv7l
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -135,12 +135,17 @@ jobs:
         - macos
         tag:
         - ''
-        include:
+        - 'musllinux'
+        exclude:
+        - os: windows
+          tag: 'musllinux'
+        - os: macos
+          tag: 'musllinux'
         - os: ubuntu
           tag: >-
            ${{
            (github.event_name != 'push' || !contains(github.ref, 'refs/tags/'))
-           && '' || 'musllinux'
+           && 'musllinux' || ''
            }}
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -26,7 +26,7 @@ on:
         type: string
       tag:
         description: Build platform tag wheels
-        default: '0'
+        default: ''
         required: false
         type: string
       source-tarball-name:
@@ -48,7 +48,7 @@ jobs:
 
   build-wheel:
     name: >-
-     Build wheels on ${{ inputs.os }} ${{ inputs.qemu }} ${{ inputs.tag }}
+     Build ${{ inputs.tag }} wheels on ${{ inputs.os }} ${{ inputs.qemu }}
     runs-on: ${{ inputs.os }}-latest
     timeout-minutes: ${{ inputs.qemu && 60 || 20 }}
     steps:
@@ -91,7 +91,7 @@ jobs:
       shell: bash
 
     - name: Skip musllinux wheels
-      if: inputs.tag == 'manylinux'
+      if: inputs.tag == ''
       run: |
         echo "CIBW_SKIP=$CIBW_SKIP *musllinux*" >> "${GITHUB_ENV}"
       shell: bash


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

#1235 should have excluded musllinux from windows and macos since this tag does not make sense on these platforms

## Are there changes in behavior for the user?

no
