### PR TITLE
Fix manylinux wheels not building on release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -145,7 +145,7 @@ jobs:
           tag: >-
            ${{
            (github.event_name != 'push' || !contains(github.ref, 'refs/tags/'))
-           && 'musllinux' || ''
+           && 'musllinux' || 'none'
            }}
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:


### PR DESCRIPTION
#1239 reversed the condition but did not account
for manylinux wheels use an empty tag
