### PR TITLE
Fix building wheels during release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -159,7 +159,8 @@ jobs:
         *-musllinux_*
         *-win32
         pp*'
-        || ''
+        || (matrix.tag == 'musllinux') && '*-manylinux_*'
+        || '*-musllinux_*'
         }}
       source-tarball-name: >-
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
@@ -493,6 +494,12 @@ jobs:
     with:
       qemu: ${{ matrix.qemu }}
       tag: ${{ matrix.tag }}
+      wheel-tags-to-skip: >-
+        ${{
+        (matrix.tag == 'musllinux')
+        && '*-manylinux_*'
+        || '*-musllinux_*'
+        }}
       source-tarball-name: >-
         ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
       dists-artifact-name: ${{ needs.pre-setup.outputs.dists-artifact-name }}

--- a/.github/workflows/reusable-build-wheel.yml
+++ b/.github/workflows/reusable-build-wheel.yml
@@ -64,7 +64,6 @@ jobs:
       with:
         platforms: all
       id: qemu
-
     - name: Prepare emulation
       if: inputs.qemu
       run: |
@@ -77,18 +76,6 @@ jobs:
       if: inputs.wheel-tags-to-skip
       run: |
         echo "CIBW_SKIP=${{ inputs.wheel-tags-to-skip }}" >> "${GITHUB_ENV}"
-      shell: bash
-
-    - name: Skip manylinux wheels
-      if: inputs.tag == 'musllinux'
-      run: |
-        echo "CIBW_SKIP=$CIBW_SKIP *manylinux*" >> "${GITHUB_ENV}"
-      shell: bash
-
-    - name: Skip musllinux wheels
-      if: inputs.tag == ''
-      run: |
-        echo "CIBW_SKIP=$CIBW_SKIP *musllinux*" >> "${GITHUB_ENV}"
       shell: bash
 
     - name: Build wheels


### PR DESCRIPTION
Reverts most of the changes to the reusable wheels workflow except one to ensure we do not duplicate the artifact name.

Moves the selection of release wheels to be done by sending wheel-tags-to-skip based on the matrix tag

