### PR TITLE
Reduce iterations of query string benchmarks

### DIFF
--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -174,14 +174,14 @@ def test_url_make_with_ipv6_address_and_path(benchmark: BenchmarkFixture) -> Non
 def test_url_make_with_query_mapping(benchmark: BenchmarkFixture) -> None:
     @benchmark
     def _run() -> None:
-        for _ in range(100):
+        for _ in range(10):
             BASE_URL.with_query(SIMPLE_QUERY)
 
 
 def test_url_make_with_query_sequence_mapping(benchmark: BenchmarkFixture) -> None:
     @benchmark
     def _run() -> None:
-        for _ in range(100):
+        for _ in range(10):
             BASE_URL.with_query(QUERY_SEQ)
 
 

--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -174,14 +174,14 @@ def test_url_make_with_ipv6_address_and_path(benchmark: BenchmarkFixture) -> Non
 def test_url_make_with_query_mapping(benchmark: BenchmarkFixture) -> None:
     @benchmark
     def _run() -> None:
-        for _ in range(10):
+        for _ in range(25):
             BASE_URL.with_query(SIMPLE_QUERY)
 
 
 def test_url_make_with_query_sequence_mapping(benchmark: BenchmarkFixture) -> None:
     @benchmark
     def _run() -> None:
-        for _ in range(10):
+        for _ in range(25):
             BASE_URL.with_query(QUERY_SEQ)
 
 


### PR DESCRIPTION
The iterations did not need to be as high to get a good repeatable test

https://codspeed.io/aio-libs/yarl/benchmarks