### PR TITLE
Avoid normalizing child paths when there are no dots in the path

### DIFF
--- a/CHANGES/1248.misc.rst
+++ b/CHANGES/1248.misc.rst
@@ -1,1 +1,1 @@
-Improved performance of :meth:`URL.joinpath() <yarl.URL.joinpath> -- by :user:`bdraco`.
+Improved performance of :py:meth:`~yarl.URL.joinpath` -- by :user:`bdraco`.

--- a/CHANGES/1248.misc.rst
+++ b/CHANGES/1248.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of :meth:`URL.joinpath() <yarl.URL.joinpath> -- by :user:`bdraco`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -955,6 +955,16 @@ def test_joinpath(base, to_join, expected):
         pytest.param("path", "a/", "path/a/", id="default_trailing-empty-segment"),
         pytest.param("path", "a//", "path/a//", id="default_trailing-empty-segments"),
         pytest.param("path", "a//b", "path/a//b", id="default_embedded-empty-segment"),
+        pytest.param(
+            "path/a/b/c/d/e", "a/../../../../../../c", "path/c", id="long-backtrack"
+        ),
+        pytest.param(
+            "path/a/b/c/d/e",
+            "a/../../../././../../../c",
+            "path/c",
+            id="long-backtrack-with-dots",
+        ),
+        pytest.param("path/a/../../d/e", "a/../c", "d/e/c", id="backtrack-in-both"),
     ],
 )
 def test_joinpath_empty_segments(base, to_join, expected):
@@ -963,6 +973,14 @@ def test_joinpath_empty_segments(base, to_join, expected):
         f"http://example.com/{expected}" == str(url.joinpath(to_join))
         and str(url / to_join) == f"http://example.com/{expected}"
     )
+
+
+def test_joinpath_backtrack_to_base():
+    url = URL("http://example.com/../../c")
+    new_url = url.joinpath("../../..")
+    assert str(new_url) == "http://example.com"
+    assert new_url.path == "/"
+    assert new_url.raw_path == "/"
 
 
 def test_joinpath_single_empty_segments():

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -949,6 +949,7 @@ class URL:
         keep existing, but do not create new, empty segments
         """
         parsed: List[str] = []
+        needs_normalize: bool = False
         for idx, path in enumerate(reversed(paths)):
             # empty segment of last is not removed
             last = idx == 0
@@ -957,6 +958,7 @@ class URL:
                     f"Appending path {path!r} starting from slash is forbidden"
                 )
             path = path if encoded else self._PATH_QUOTER(path)
+            needs_normalize |= "." in path
             segments = list(reversed(path.split("/")))
             # remove trailing empty segment for all but the last path
             segment_slice_start = int(not last and segments[0] == "")
@@ -968,7 +970,7 @@ class URL:
             parsed = [*old_path_segments[:old_path_cutoff], *parsed]
 
         if self.absolute:
-            parsed = _normalize_path_segments(parsed)
+            parsed = _normalize_path_segments(parsed) if needs_normalize else parsed
             if parsed and parsed[0] != "":
                 # inject a leading slash when adding a path to an absolute URL
                 # where there was none before


### PR DESCRIPTION
Avoid normalizing child paths when there are no dots in the path

This one will need quite a few more tests if benchmarks shows its worth working on