### PR TITLE
Optimize building query strings with MultiDict

### DIFF
--- a/CHANGES/1256.misc.rst
+++ b/CHANGES/1256.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of constructing query strings from :class:`~multidict.MultiDict` -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1263,7 +1263,7 @@ class URL:
         """
         quoter = self._QUERY_PART_QUOTER
         pairs = [
-            f"{quoter(k)}={quoter(self._query_var(v))}"
+            f"{quoter(k)}={quoter(v if type(v) is str else self._query_var(v))}"
             for k, val in items
             for v in (
                 val
@@ -1309,7 +1309,11 @@ class URL:
         quoter = self._QUERY_PART_QUOTER
         # A listcomp is used since listcomps are inlined on CPython 3.12+ and
         # they are a bit faster than a generator expression.
-        return "&".join([f"{quoter(k)}={quoter(self._query_var(v))}" for k, v in items])
+        pairs = [
+            f"{quoter(k)}={quoter(v if type(v) is str else self._query_var(v))}"
+            for k, v in items
+        ]
+        return "&".join(pairs)
 
     def _get_str_query(self, *args: Any, **kwargs: Any) -> Union[str, None]:
         query: Union[str, Mapping[str, QueryVariable], None]

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1265,7 +1265,11 @@ class URL:
         pairs = [
             f"{quoter(k)}={quoter(self._query_var(v))}"
             for k, val in items
-            for v in (val if isinstance(val, (list, tuple)) else (val,))
+            for v in (
+                val
+                if type(val) is not str and isinstance(val, (list, tuple))
+                else (val,)
+            )
         ]
         return "&".join(pairs)
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1276,7 +1276,7 @@ class URL:
     @staticmethod
     def _query_var(v: QueryVariable) -> str:
         cls = type(v)
-        if cls is str or issubclass(cls, str):
+        if issubclass(cls, str):
             if TYPE_CHECKING:
                 assert isinstance(v, str)
             return v


### PR DESCRIPTION
Most of the time aiohttp is passing in a MulitDict here.  This will also help a bit for `dict` without Sequence, but as not a common of a case

For historical reasons we have support for sequences inside of MulitDict even though it shouldn't happen and it would be a breaking change to remove it
