### PR TITLE
Align Python and C quoter to match type signature of not allowing None

### DIFF
--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -279,7 +279,8 @@ def test_unquoting_parts(unquoter):
 
 
 def test_quote_None(quoter):
-    assert quoter()(None) is None
+    with pytest.raises(TypeError, match="Argument should be str"):
+        quoter()(None)
 
 
 def test_unquote_None(unquoter):

--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -203,14 +203,14 @@ cdef class _Quoter:
 
     def __call__(self, val):
         cdef Writer writer
-        if val is None:
-            return None
         if type(val) is not str:
             if isinstance(val, str):
                 # derived from str
                 val = str(val)
             else:
                 raise TypeError("Argument should be str")
+        if not val:
+            return val
         _init_writer(&writer)
         try:
             return self._do_quote(<str>val, &writer)

--- a/yarl/_quoting_py.py
+++ b/yarl/_quoting_py.py
@@ -34,8 +34,6 @@ class _Quoter:
         self._requote = requote
 
     def __call__(self, val: str) -> str:
-        if val is None:
-            return None
         if not isinstance(val, str):
             raise TypeError("Argument should be str")
         if not val:


### PR DESCRIPTION
We never pass `None` to the quoters, they should not allow it.

The quoters are not public methods so this is an internal change only.