### PR TITLE
Improve performance of constructing query strings with ``int`` values

### DIFF
--- a/CHANGES/1259.misc.rst
+++ b/CHANGES/1259.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of constructing query strings with ``int`` values -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1280,6 +1280,8 @@ class URL:
             if TYPE_CHECKING:
                 assert isinstance(v, str)
             return v
+        if cls is int:  # Fast path for non-subclassed int
+            return str(v)
         if issubclass(cls, float):
             if TYPE_CHECKING:
                 assert isinstance(v, float)
@@ -1288,8 +1290,6 @@ class URL:
             if math.isnan(v):
                 raise ValueError("float('nan') is not supported")
             return str(float(v))
-        if cls is int:
-            return str(v)
         if cls is not bool and isinstance(cls, SupportsInt):
             return str(int(v))
         raise TypeError(

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1288,6 +1288,8 @@ class URL:
             if math.isnan(v):
                 raise ValueError("float('nan') is not supported")
             return str(float(v))
+        if cls is int:
+            return str(v)
         if cls is not bool and isinstance(cls, SupportsInt):
             return str(int(v))
         raise TypeError(


### PR DESCRIPTION
`int` was a lot more common than I expected in production.

Performance regressed in #1139 to answer feature request #945 as we didn't have performance measurements in place when that PR was made