### PR TITLE
Improve performance of constructing URLs from unencoded string

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -273,7 +273,7 @@ class URL:
             if not netloc:  # netloc
                 host = ""
             else:
-                username, password, host, port = cls._split_netloc(val[1])
+                username, password, host, port = cls._split_netloc(netloc)
                 if host is None:
                     if scheme in SCHEME_REQUIRES_HOST:
                         msg = (
@@ -298,7 +298,8 @@ class URL:
                 if netloc:
                     if "." in path:
                         path = cls._normalize_path(path)
-                    cls._validate_authority_uri_abs_path(host, path)
+                    if path[-1] != "/":
+                        cls._raise_for_authority_missing_abs_path()
 
             query = cls._QUERY_REQUOTER(query) if query else query
             fragment = cls._FRAGMENT_REQUOTER(fragment) if fragment else fragment
@@ -390,7 +391,8 @@ class URL:
             if path and netloc:
                 if "." in path:
                     path = cls._normalize_path(path)
-                cls._validate_authority_uri_abs_path(host, path)
+                if path[-1] != "/":
+                    cls._raise_for_authority_missing_abs_path()
 
             query_string = (
                 cls._QUERY_QUOTER(query_string) if query_string else query_string
@@ -930,15 +932,10 @@ class URL:
         return tuple(self._UNQUOTER(suffix) for suffix in self.raw_suffixes)
 
     @staticmethod
-    def _validate_authority_uri_abs_path(host: str, path: str) -> None:
-        """Ensure that path in URL with authority starts with a leading slash.
-
-        Raise ValueError if not.
-        """
-        if host and path and path[0] != "/":
-            raise ValueError(
-                "Path in a URL with authority should start with a slash ('/') if set"
-            )
+    def _raise_for_authority_missing_abs_path() -> None:
+        """Raise when he path in URL with authority starts lacks a leading slash."""
+        msg = "Path in a URL with authority should start with a slash ('/') if set"
+        raise ValueError(msg)
 
     def _make_child(self, paths: "Sequence[str]", encoded: bool = False) -> "URL":
         """

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -298,8 +298,7 @@ class URL:
                 if netloc:
                     if "." in path:
                         path = cls._normalize_path(path)
-                    if path[0] != "/":
-                        cls._raise_for_authority_missing_abs_path()
+                    cls._validate_authority_uri_abs_path(host, path)
 
             query = cls._QUERY_REQUOTER(query) if query else query
             fragment = cls._FRAGMENT_REQUOTER(fragment) if fragment else fragment
@@ -391,8 +390,7 @@ class URL:
             if path and netloc:
                 if "." in path:
                     path = cls._normalize_path(path)
-                if path[0] != "/":
-                    cls._raise_for_authority_missing_abs_path()
+                cls._validate_authority_uri_abs_path(host, path)
 
             query_string = (
                 cls._QUERY_QUOTER(query_string) if query_string else query_string
@@ -932,10 +930,15 @@ class URL:
         return tuple(self._UNQUOTER(suffix) for suffix in self.raw_suffixes)
 
     @staticmethod
-    def _raise_for_authority_missing_abs_path() -> None:
-        """Raise when he path in URL with authority starts lacks a leading slash."""
-        msg = "Path in a URL with authority should start with a slash ('/') if set"
-        raise ValueError(msg)
+    def _validate_authority_uri_abs_path(host: str, path: str) -> None:
+        """Ensure that path in URL with authority starts with a leading slash.
+
+        Raise ValueError if not.
+        """
+        if host and path and path[0] != "/":
+            raise ValueError(
+                "Path in a URL with authority should start with a slash ('/') if set"
+            )
 
     def _make_child(self, paths: "Sequence[str]", encoded: bool = False) -> "URL":
         """

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -254,10 +254,10 @@ class URL:
     ) -> Self:
         if strict is not None:  # pragma: no cover
             warnings.warn("strict parameter is ignored")
-        if type(val) is cls:
-            return val
         if type(val) is str:
             val = urlsplit(val)
+        elif type(val) is cls:
+            return val
         elif type(val) is SplitResult:
             if not encoded:
                 raise ValueError("Cannot apply decoding to SplitResult")
@@ -298,7 +298,7 @@ class URL:
                 if netloc:
                     if "." in path:
                         path = cls._normalize_path(path)
-                    if path[-1] != "/":
+                    if path[0] != "/":
                         cls._raise_for_authority_missing_abs_path()
 
             query = cls._QUERY_REQUOTER(query) if query else query
@@ -391,7 +391,7 @@ class URL:
             if path and netloc:
                 if "." in path:
                     path = cls._normalize_path(path)
-                if path[-1] != "/":
+                if path[0] != "/":
                     cls._raise_for_authority_missing_abs_path()
 
             query_string = (


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Improve performance of constructing URLs with a netloc

This is a ~3% speed up to the common case (note that codspeed reporting threshold if 8%)

## Are there changes in behavior for the user?

no

So much of the request itself is constructing the URL, however I'm running out of thoughts on how to improve the performance here.

<img width="468" alt="Screenshot 2024-10-14 at 10 38 15 PM" src="https://github.com/user-attachments/assets/41c7ea1d-6e48-4837-b0d1-ff105c860f2d">

![new](https://github.com/user-attachments/assets/4853c175-06d2-471e-a2ff-119115dd6502)

