### PR TITLE
Fix `URL.build` not validating that `path` has a leading slash when passing `authority`

### DIFF
--- a/CHANGES/1265.bugfix.rst
+++ b/CHANGES/1265.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed :py:meth:`~yarl.URL.build` failing to validate paths must start with a / when passing ``authority`` -- by :user:`bdraco`.
+
+The validation only worked correctly when passing ``host``.

--- a/CHANGES/1265.bugfix.rst
+++ b/CHANGES/1265.bugfix.rst
@@ -1,3 +1,3 @@
-Fixed :py:meth:`~yarl.URL.build` failing to validate paths must start with a / when passing ``authority`` -- by :user:`bdraco`.
+Fixed :py:meth:`~yarl.URL.build` failing to validate paths must start with a ``/`` when passing ``authority`` -- by :user:`bdraco`.
 
 The validation only worked correctly when passing ``host``.

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -140,10 +140,16 @@ def test_build_with_invalid_host(host: str, is_authority: bool):
 
 
 def test_build_with_authority():
-    url = URL.build(scheme="http", authority="степан:bar@host.com:8000", path="path")
+    url = URL.build(scheme="http", authority="степан:bar@host.com:8000", path="/path")
     assert (
         str(url) == "http://%D1%81%D1%82%D0%B5%D0%BF%D0%B0%D0%BD:bar@host.com:8000/path"
     )
+
+
+def test_build_with_authority_no_leading_flash():
+    msg = r"Path in a URL with authority should start with a slash \('/'\) if set"
+    with pytest.raises(ValueError, match=msg):
+        URL.build(scheme="http", authority="степан:bar@host.com:8000", path="path")
 
 
 def test_build_with_authority_without_encoding():

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -309,7 +309,8 @@ class URL:
                 if netloc:
                     if "." in path:
                         path = cls._normalize_path(path)
-                    cls._validate_authority_uri_abs_path(host, path)
+                    if path[0] != "/":
+                        cls._raise_for_authority_missing_abs_path()
 
             query = cls._QUERY_REQUOTER(query) if query else query
             fragment = cls._FRAGMENT_REQUOTER(fragment) if fragment else fragment
@@ -407,7 +408,8 @@ class URL:
             if path and netloc:
                 if "." in path:
                     path = cls._normalize_path(path)
-                cls._validate_authority_uri_abs_path(host, path)
+                if path[0] != "/":
+                    cls._raise_for_authority_missing_abs_path()
 
             query_string = (
                 cls._QUERY_QUOTER(query_string) if query_string else query_string
@@ -947,15 +949,10 @@ class URL:
         return tuple(self._UNQUOTER(suffix) for suffix in self.raw_suffixes)
 
     @staticmethod
-    def _validate_authority_uri_abs_path(host: str, path: str) -> None:
-        """Ensure that path in URL with authority starts with a leading slash.
-
-        Raise ValueError if not.
-        """
-        if host and path and path[0] != "/":
-            raise ValueError(
-                "Path in a URL with authority should start with a slash ('/') if set"
-            )
+    def _raise_for_authority_missing_abs_path() -> None:
+        """Raise when he path in URL with authority starts lacks a leading slash."""
+        msg = "Path in a URL with authority should start with a slash ('/') if set"
+        raise ValueError(msg)
 
     def _make_child(self, paths: "Sequence[str]", encoded: bool = False) -> "URL":
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix `URL.build` not validating that path has a leading slash when passing `authority`
The validation only worked when `host` was passed


## Are there changes in behavior for the user?

Validation of leading `/` in path now works for `authority` instead of just `host` as intended
