### PR TITLE
Optimize branching _encode_host for common case

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1053,9 +1053,6 @@ class URL:
                     return f"[{host}%{zone}]" if sep else f"[{host}]"
                 return f"{host}%{zone}" if sep else host
 
-        if human:
-            return lower_host
-
         # IDNA encoding is slow,
         # skip it for ASCII-only strings
         # Don't move the check into _idna_encode() helper
@@ -1067,7 +1064,7 @@ class URL:
                 _host_validate(lower_host)
             return lower_host
 
-        return _idna_encode(lower_host)
+        return lower_host if human else _idna_encode(lower_host)
 
     @classmethod
     @lru_cache  # match the same size as urlsplit

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1042,13 +1042,12 @@ class URL:
             #
             # IP parsing is slow, so its wrapped in an LRU
             try:
-                ip_compressed_version = _ip_compressed_version(raw_ip)
+                host, version = _ip_compressed_version(raw_ip)
             except ValueError:
                 pass
             else:
                 # These checks should not happen in the
                 # LRU to keep the cache size small
-                host, version = ip_compressed_version
                 if version == 6:
                     return f"[{host}%{zone}]" if sep else f"[{host}]"
                 return f"{host}%{zone}" if sep else host


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Calling _encode_host with human is quite rare and we only need to check it to avoid the idna call

This is a ~4% speed up to the common case (note that codspeed reporting threshold if 8%)


## Are there changes in behavior for the user?

no
