### PR TITLE
Add a fast path for URL construction when the netloc is the host

### DIFF
--- a/CHANGES/1271.misc.rst
+++ b/CHANGES/1271.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of constructing :class:`~yarl.URL` when the net location is only the host -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -284,9 +284,15 @@ class URL:
                     else:
                         host = ""
                 host = cls._encode_host(host, validate_host=False)
-                raw_user = cls._REQUOTER(username) if username else username
-                raw_password = cls._REQUOTER(password) if password else password
-                netloc = cls._make_netloc(raw_user, raw_password, host, port)
+                if port is None and password is None and not username:
+                    # Fast path for URLs without user, password and port
+                    netloc = host
+                    raw_user = username
+                    raw_password = None
+                else:
+                    raw_user = cls._REQUOTER(username) if username else username
+                    raw_password = cls._REQUOTER(password) if password else password
+                    netloc = cls._make_netloc(raw_user, raw_password, host, port)
                 # Remove brackets as host encoder adds back brackets for IPv6 addresses
                 cache["raw_host"] = host[1:-1] if "[" in host else host
                 cache["raw_user"] = raw_user

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -284,11 +284,11 @@ class URL:
                     else:
                         host = ""
                 host = cls._encode_host(host, validate_host=False)
-                if port is None and password is None and not username:
+                if port is None and password is None and username is None:
                     # Fast path for URLs without user, password and port
-                    netloc = host
-                    raw_user = username
+                    raw_user = None
                     raw_password = None
+                    netloc = host
                 else:
                     raw_user = cls._REQUOTER(username) if username else username
                     raw_password = cls._REQUOTER(password) if password else password

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -289,9 +289,9 @@ class URL:
                 cache["explicit_port"] = port
                 if port is None and password is None and username is None:
                     # Fast path for URLs without user, password and port
+                    netloc = host
                     cache["raw_user"] = None
                     cache["raw_password"] = None
-                    netloc = host
                 else:
                     raw_user = cls._REQUOTER(username) if username else username
                     raw_password = cls._REQUOTER(password) if password else password

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -284,6 +284,9 @@ class URL:
                     else:
                         host = ""
                 host = cls._encode_host(host, validate_host=False)
+                # Remove brackets as host encoder adds back brackets for IPv6 addresses
+                cache["raw_host"] = host[1:-1] if "[" in host else host
+                cache["explicit_port"] = port
                 if port is None and password is None and username is None:
                     # Fast path for URLs without user, password and port
                     cache["raw_user"] = None
@@ -295,9 +298,6 @@ class URL:
                     netloc = cls._make_netloc(raw_user, raw_password, host, port)
                     cache["raw_user"] = raw_user
                     cache["raw_password"] = raw_password
-                # Remove brackets as host encoder adds back brackets for IPv6 addresses
-                cache["raw_host"] = host[1:-1] if "[" in host else host
-                cache["explicit_port"] = port
 
             if path:
                 path = cls._PATH_REQUOTER(path)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -286,17 +286,17 @@ class URL:
                 host = cls._encode_host(host, validate_host=False)
                 if port is None and password is None and username is None:
                     # Fast path for URLs without user, password and port
-                    raw_user = None
-                    raw_password = None
+                    cache["raw_user"] = None
+                    cache["raw_password"] = None
                     netloc = host
                 else:
                     raw_user = cls._REQUOTER(username) if username else username
                     raw_password = cls._REQUOTER(password) if password else password
                     netloc = cls._make_netloc(raw_user, raw_password, host, port)
+                    cache["raw_user"] = raw_user
+                    cache["raw_password"] = raw_password
                 # Remove brackets as host encoder adds back brackets for IPv6 addresses
                 cache["raw_host"] = host[1:-1] if "[" in host else host
-                cache["raw_user"] = raw_user
-                cache["raw_password"] = raw_password
                 cache["explicit_port"] = port
 
             if path:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -374,7 +374,10 @@ class URL:
             elif host:
                 if port is not None:
                     port = None if port == DEFAULT_PORTS.get(scheme) else port
-                netloc = cls._make_netloc(user, password, host, port)
+                if port is None and user is None and password is None:
+                    netloc = host
+                else:
+                    netloc = cls._make_netloc(user, password, host, port)
             else:
                 netloc = ""
         else:  # not encoded
@@ -390,7 +393,10 @@ class URL:
             if _host is not None:
                 if port is not None:
                     port = None if port == DEFAULT_PORTS.get(scheme) else port
-                netloc = cls._make_netloc(user, password, _host, port, True)
+                if port is None and user is None and password is None:
+                    netloc = _host
+                else:
+                    netloc = cls._make_netloc(user, password, _host, port, True)
 
             path = cls._PATH_QUOTER(path) if path else path
             if path and netloc:


### PR DESCRIPTION
Connecting to a non-default port, providing a username, or password in the URL is a less likely case. Optimize for the common case.