### PR TITLE
Improve performance of calling origin() for URLs with credentials

### DIFF
--- a/CHANGES/1275.misc.rst
+++ b/CHANGES/1275.misc.rst
@@ -1,1 +1,0 @@
-Improved performance of the :py:meth:`~yarl.URL.origin` method when credentials are present -- by :user:`bdraco`.

--- a/CHANGES/1275.misc.rst
+++ b/CHANGES/1275.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the :py:meth:`~yarl.URL.origin` method when credentials are present -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -584,12 +584,11 @@ class URL:
         user, password, path, query and fragment are removed.
         """
         v = self._val
-        netloc = v.netloc
-        if not netloc:
+        if not v.netloc:
             raise ValueError("URL should be absolute")
         if not v.scheme:
             raise ValueError("URL should have scheme")
-        if "@" not in netloc:
+        if "@" not in v.netloc:
             val = v._replace(path="", query="", fragment="")
         else:
             encoded_host = self.host_subcomponent

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -584,15 +584,16 @@ class URL:
         user, password, path, query and fragment are removed.
         """
         v = self._val
-        if not v.netloc:
+        netloc = v.netloc
+        if not netloc:
             raise ValueError("URL should be absolute")
         if not v.scheme:
             raise ValueError("URL should have scheme")
-        if "@" not in v.netloc:
+        if "@" not in netloc:
             val = v._replace(path="", query="", fragment="")
         else:
-            encoded_host = self._encode_host(v.hostname) if v.hostname else ""
-            netloc = self._make_netloc(None, None, encoded_host, v.port)
+            encoded_host = self.host_subcomponent
+            netloc = self._make_netloc(None, None, encoded_host, self.explicit_port)
             val = v._replace(netloc=netloc, path="", query="", fragment="")
         return self._from_val(val)
 


### PR DESCRIPTION
Calling `SplitResult.port` and `SplitResult.hostname` has to re-parse the net location.  Use our internal properties instead since its very likely to already be parsed.  The speed up is tiny but it removes another case where we call `_encode_host` which makes the flow a bit easier to manage because every time we call `_encode_host` we need to think about how its going to be mutated.

#1175 did not improve the credentials/auth case as much as it could

closes #1272

related issue #1174