### PR TITLE
Avoid splitting the netloc for simple cases when constructing URL

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -273,7 +273,12 @@ class URL:
             if not netloc:  # netloc
                 host = ""
             else:
-                username, password, host, port = cls._split_netloc(netloc)
+                if ":" in netloc or "@" in netloc or "[" in netloc:
+                    # Complex netloc
+                    username, password, host, port = cls._split_netloc(netloc)
+                else:
+                    username = password = port = None
+                    host = netloc
                 if host is None:
                     if scheme in SCHEME_REQUIRES_HOST:
                         msg = (


### PR DESCRIPTION
The split is generally cheap because most of the time its cached, but its still better to avoid filling the cache with simple cases which make the LRU less effective.  This will speed up the many different hosts case.