### PR TITLE
Remove missed Python 3.8 test branching

### DIFF
--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from yarl import URL
@@ -40,15 +38,9 @@ class TestScheme:
 
     def test_no_scheme1(self):
         u = URL("google.com:80")
-        # See: https://bugs.python.org/issue27657
-        if sys.version_info[:3] == (3, 8, 1) or sys.version_info >= (3, 9, 0):
-            assert u.scheme == "google.com"
-            assert u.host is None
-            assert u.path == "80"
-        else:
-            assert u.scheme == ""
-            assert u.host is None
-            assert u.path == "google.com:80"
+        assert u.scheme == "google.com"
+        assert u.host is None
+        assert u.path == "80"
         assert u.query_string == ""
         assert u.fragment == ""
 


### PR DESCRIPTION
This code is no longer needed since we no longer support Python 3.8
