### PR TITLE
Include port in the fast path for building the network location

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -380,8 +380,8 @@ class URL:
             elif host:
                 if port is not None:
                     port = None if port == DEFAULT_PORTS.get(scheme) else port
-                if port is None and user is None and password is None:
-                    netloc = host
+                if user is None and password is None:
+                    netloc = host if port is None else f"{host}:{port}"
                 else:
                     netloc = cls._make_netloc(user, password, host, port)
             else:
@@ -399,8 +399,8 @@ class URL:
             if _host is not None:
                 if port is not None:
                     port = None if port == DEFAULT_PORTS.get(scheme) else port
-                if port is None and user is None and password is None:
-                    netloc = _host
+                if user is None and password is None:
+                    netloc = _host if port is None else f"{_host}:{port}"
                 else:
                     netloc = cls._make_netloc(user, password, _host, port, True)
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -292,9 +292,9 @@ class URL:
                 # Remove brackets as host encoder adds back brackets for IPv6 addresses
                 cache["raw_host"] = host[1:-1] if "[" in host else host
                 cache["explicit_port"] = port
-                if port is None and password is None and username is None:
-                    # Fast path for URLs without user, password and port
-                    netloc = host
+                if password is None and username is None:
+                    # Fast path for URLs without user, password
+                    netloc = host if port is None else f"{host}:{port}"
                     cache["raw_user"] = None
                     cache["raw_password"] = None
                 else:


### PR DESCRIPTION
Followup to #1271 

We can include port in the fast path as well do avoid doing a full netloc assemble when we know the username and password are None