### PR TITLE
DNM: Avoid malloc if there is no thing to quote

### DIFF
--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -2,7 +2,13 @@
 
 from cpython.exc cimport PyErr_NoMemory
 from cpython.mem cimport PyMem_Free, PyMem_Malloc, PyMem_Realloc
-from cpython.unicode cimport PyUnicode_DecodeASCII, PyUnicode_DecodeUTF8Stateful
+from cpython.unicode cimport (
+    PyUnicode_DATA,
+    PyUnicode_DecodeASCII,
+    PyUnicode_DecodeUTF8Stateful,
+    PyUnicode_KIND,
+    PyUnicode_READ,
+)
 from libc.stdint cimport uint8_t, uint64_t
 from libc.string cimport memcpy, memset
 
@@ -218,9 +224,11 @@ cdef class _Quoter:
         cdef int idx = 0
         cdef bint must_quote = 0
         cdef Writer writer
+        cdef int kind = PyUnicode_KIND(val)
+        cdef const void *data = PyUnicode_DATA(val)
 
         while idx < length:
-            ch = val[idx]
+            ch = PyUnicode_READ(kind, data, idx)
             idx += 1
             if ch >= 128 or not bit_at(self._safe_table, ch):
                 must_quote = 1
@@ -239,9 +247,11 @@ cdef class _Quoter:
         cdef Py_UCS4 ch
         cdef int changed
         cdef int idx = 0
+        cdef int kind = PyUnicode_KIND(val)
+        cdef const void *data = PyUnicode_DATA(val)
 
         while idx < length:
-            ch = val[idx]
+            ch = PyUnicode_READ(kind, data, idx)
             idx += 1
             if ch == '%' and self._requote and idx <= length - 2:
                 ch = _restore_ch(val[idx], val[idx + 1])

--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -56,11 +56,11 @@ cdef uint8_t ALLOWED_TABLE[16]
 cdef uint8_t ALLOWED_NOTQS_TABLE[16]
 
 
-cdef inline bint bit_at(uint8_t array[], uint64_t ch):
+cdef inline bint bit_at(uint8_t array[], uint64_t ch) noexcept:
     return array[ch >> 3] & (1 << (ch & 7))
 
 
-cdef inline void set_bit(uint8_t array[], uint64_t ch):
+cdef inline void set_bit(uint8_t array[], uint64_t ch) noexcept:
     array[ch >> 3] |= (1 << (ch & 7))
 
 


### PR DESCRIPTION
Probably quite a bit faster if there is nothing to quote

But a bit slower if there is because we have it iterate twice
