### PR TITLE
Improve performance of handling empty query strings

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -820,7 +820,8 @@ class URL:
     @cached_property
     def _parsed_query(self) -> list[tuple[str, str]]:
         """Parse query part of URL."""
-        return parse_qsl(self._val.query, keep_blank_values=True)
+        qs = self._val.query
+        return parse_qsl(qs, keep_blank_values=True) if qs else []
 
     @cached_property
     def query(self) -> "MultiDictProxy[str]":
@@ -848,12 +849,13 @@ class URL:
         Empty string if query is missing.
 
         """
-        return self._QS_UNQUOTER(self._val.query)
+        query_string = self._val.query
+        return self._QS_UNQUOTER(query_string) if query_string else ""
 
     @cached_property
     def path_qs(self) -> str:
         """Decoded path of URL with query."""
-        if not self.query_string:
+        if not self._val.query:
             return self.path
         return f"{self.path}?{self.query_string}"
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -40,6 +40,7 @@ USES_RELATIVE = frozenset(uses_relative)
 SCHEME_REQUIRES_HOST = frozenset(("http", "https", "ws", "wss", "ftp"))
 
 sentinel = object()
+_EMPTY_MULTI_DICT_PROXY: MultiDictProxy[str] = MultiDictProxy(MultiDict())
 
 # reg-name: unreserved / pct-encoded / sub-delims
 # this pattern matches anything that is *not* in those classes. and is only used
@@ -831,7 +832,9 @@ class URL:
         Empty value if URL has no query part.
 
         """
-        return MultiDictProxy(MultiDict(self._parsed_query))
+        if parsed_query := self._parsed_query:
+            return MultiDictProxy(MultiDict(parsed_query))
+        return _EMPTY_MULTI_DICT_PROXY
 
     @cached_property
     def raw_query_string(self) -> str:


### PR DESCRIPTION
Its rather common to call `URL.query` or `URL.query_string` to see if a key exists when there is no actual query string. Avoid doing the work to construct objects and unquote the query string if there is no query string.
