### PR TITLE
Improve performance of `URL.build` by avoiding operations

### DIFF
--- a/CHANGES/1297.misc.rst
+++ b/CHANGES/1297.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of calling :py:meth:`~yarl.URL.build` -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -326,6 +326,10 @@ class URL:
                 or val.query != query
                 or val.fragment != fragment
             ):
+                # Constructing the tuple directly to avoid the overhead of
+                # the lambda and arg processing since NamedTuples are constructed
+                # with a run time built lambda
+                # https://github.com/python/cpython/blob/d83fcf8371f2f33c7797bc8f5423a8bca8c46e5c/Lib/collections/__init__.py#L441
                 val = tuple.__new__(
                     SplitResult, (scheme, netloc, path, query, fragment)
                 )
@@ -422,6 +426,10 @@ class URL:
             query_string = cls._get_str_query(query) or ""
 
         url = object.__new__(cls)
+        # Constructing the tuple directly to avoid the overhead of the lambda and
+        # arg processing since NamedTuples are constructed with a run time built
+        # lambda
+        # https://github.com/python/cpython/blob/d83fcf8371f2f33c7797bc8f5423a8bca8c46e5c/Lib/collections/__init__.py#L441
         url._val = tuple.__new__(
             SplitResult, (scheme, netloc, path, query_string, fragment)
         )

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -418,12 +418,15 @@ class URL:
             )
             fragment = cls._FRAGMENT_QUOTER(fragment) if fragment else fragment
 
+        if query:
+            query_string = cls._get_str_query(query) or ""
+
         url = object.__new__(cls)
         url._val = tuple.__new__(
             SplitResult, (scheme, netloc, path, query_string, fragment)
         )
         url._cache = {}
-        return url.with_query(query) if query else url
+        return url
 
     @classmethod
     def _from_val(cls, val: SplitResult) -> "URL":
@@ -1261,8 +1264,9 @@ class URL:
             path = f"/{path}"
         return self._from_val(self._val._replace(path=path, query="", fragment=""))
 
+    @classmethod
     def _get_str_query_from_sequence_iterable(
-        self,
+        cls,
         items: Iterable[tuple[Union[str, istr], QueryVariable]],
     ) -> str:
         """Return a query string from a sequence of (key, value) pairs.
@@ -1271,9 +1275,9 @@ class URL:
 
         The sequence of values must be a list or tuple.
         """
-        quoter = self._QUERY_PART_QUOTER
+        quoter = cls._QUERY_PART_QUOTER
         pairs = [
-            f"{quoter(k)}={quoter(v if type(v) is str else self._query_var(v))}"
+            f"{quoter(k)}={quoter(v if type(v) is str else cls._query_var(v))}"
             for k, val in items
             for v in (
                 val
@@ -1308,8 +1312,9 @@ class URL:
             "of type {}".format(v, cls)
         )
 
+    @classmethod
     def _get_str_query_from_iterable(
-        self, items: Iterable[tuple[Union[str, istr], str]]
+        cls, items: Iterable[tuple[Union[str, istr], str]]
     ) -> str:
         """Return a query string from an iterable.
 
@@ -1318,16 +1323,17 @@ class URL:
         The values are not allowed to be sequences, only single values are
         allowed. For sequences, use `_get_str_query_from_sequence_iterable`.
         """
-        quoter = self._QUERY_PART_QUOTER
+        quoter = cls._QUERY_PART_QUOTER
         # A listcomp is used since listcomps are inlined on CPython 3.12+ and
         # they are a bit faster than a generator expression.
         pairs = [
-            f"{quoter(k)}={quoter(v if type(v) is str else self._query_var(v))}"
+            f"{quoter(k)}={quoter(v if type(v) is str else cls._query_var(v))}"
             for k, v in items
         ]
         return "&".join(pairs)
 
-    def _get_str_query(self, *args: Any, **kwargs: Any) -> Union[str, None]:
+    @classmethod
+    def _get_str_query(cls, *args: Any, **kwargs: Any) -> Union[str, None]:
         query: Union[str, Mapping[str, QueryVariable], None]
         if kwargs:
             if len(args) > 0:
@@ -1343,9 +1349,9 @@ class URL:
         if query is None:
             return None
         if isinstance(query, Mapping):
-            return self._get_str_query_from_sequence_iterable(query.items())
+            return cls._get_str_query_from_sequence_iterable(query.items())
         if isinstance(query, str):
-            return self._QUERY_QUOTER(query)
+            return cls._QUERY_QUOTER(query)
         if isinstance(query, (bytes, bytearray, memoryview)):
             raise TypeError(
                 "Invalid query type: bytes, bytearray and memoryview are forbidden"
@@ -1355,7 +1361,7 @@ class URL:
             # already; only mappings like builtin `dict` which can't have the
             # same key pointing to multiple values are allowed to use
             # `_query_seq_pairs`.
-            return self._get_str_query_from_iterable(query)
+            return cls._get_str_query_from_iterable(query)
 
         raise TypeError(
             "Invalid query type: only str, mapping or "

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -326,9 +326,8 @@ class URL:
                 or val.query != query
                 or val.fragment != fragment
             ):
-                val = SplitResult.__new__(  # type: ignore[type-var]
-                    SplitResult, scheme, netloc, path, query, fragment
-                )
+                _val = (scheme, netloc, path, query, fragment)
+                val = tuple.__new__(SplitResult, _val)
 
         self = object.__new__(cls)
         self._val = val
@@ -418,11 +417,8 @@ class URL:
             )
             fragment = cls._FRAGMENT_QUOTER(fragment) if fragment else fragment
 
-        url = cls._from_val(
-            SplitResult.__new__(  # type: ignore[type-var]
-                SplitResult, scheme, netloc, path, query_string, fragment
-            )
-        )
+        val = (scheme, netloc, path, query_string, fragment)
+        url = cls._from_val(tuple.__new__(SplitResult, val))
         if query:
             return url.with_query(query)
         return url

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -326,8 +326,9 @@ class URL:
                 or val.query != query
                 or val.fragment != fragment
             ):
-                _val = (scheme, netloc, path, query, fragment)
-                val = tuple.__new__(SplitResult, _val)
+                val = tuple.__new__(
+                    SplitResult, (scheme, netloc, path, query, fragment)
+                )
 
         self = object.__new__(cls)
         self._val = val
@@ -417,8 +418,12 @@ class URL:
             )
             fragment = cls._FRAGMENT_QUOTER(fragment) if fragment else fragment
 
-        val = (scheme, netloc, path, query_string, fragment)
-        url = cls._from_val(tuple.__new__(SplitResult, val))
+        url = object.__new__(cls)
+        url._val = tuple.__new__(
+            SplitResult, (scheme, netloc, path, query_string, fragment)
+        )
+        url._cache = {}
+
         if query:
             return url.with_query(query)
         return url

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -326,7 +326,9 @@ class URL:
                 or val.query != query
                 or val.fragment != fragment
             ):
-                val = SplitResult(scheme, netloc, path, query, fragment)
+                val = SplitResult.__new__(  # type: ignore[type-var]
+                    SplitResult, scheme, netloc, path, query, fragment
+                )
 
         self = object.__new__(cls)
         self._val = val
@@ -416,7 +418,11 @@ class URL:
             )
             fragment = cls._FRAGMENT_QUOTER(fragment) if fragment else fragment
 
-        url = cls._from_val(SplitResult(scheme, netloc, path, query_string, fragment))
+        url = cls._from_val(
+            SplitResult.__new__(  # type: ignore[type-var]
+                SplitResult, scheme, netloc, path, query_string, fragment
+            )
+        )
         if query:
             return url.with_query(query)
         return url

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -423,10 +423,7 @@ class URL:
             SplitResult, (scheme, netloc, path, query_string, fragment)
         )
         url._cache = {}
-
-        if query:
-            return url.with_query(query)
-        return url
+        return url.with_query(query) if query else url
 
     @classmethod
     def _from_val(cls, val: SplitResult) -> "URL":


### PR DESCRIPTION
`URL.build` had a few places left where performance could be improved

- Avoid evaluating the run time lambda created at https://github.com/python/cpython/blob/d83fcf8371f2f33c7797bc8f5423a8bca8c46e5c/Lib/collections/__init__.py#L441 
- Avoid creating the `URL` object twice when passing `query` as we already had a method to convert `query` to string, and we shouldn't make two objects to build a URL