### PR TITLE
Remove redundant hypothesis pytest mark

### DIFF
--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -481,14 +481,12 @@ def test_unquoter_path_with_plus(unquoter):
 
 
 @given(safe=st.text(), protected=st.text(), qs=st.booleans(), requote=st.booleans())
-@pytest.mark.hypothesis
 def test_fuzz__PyQuoter(safe, protected, qs, requote):
     """Verify that _PyQuoter can be instantiated with any valid arguments."""
     assert _PyQuoter(safe=safe, protected=protected, qs=qs, requote=requote)
 
 
 @given(ignore=st.text(), unsafe=st.text(), qs=st.booleans())
-@pytest.mark.hypothesis
 def test_fuzz__PyUnquoter(ignore, unsafe, qs):
     """Verify that _PyUnquoter can be instantiated with any valid arguments."""
     assert _PyUnquoter(ignore=ignore, unsafe=unsafe, qs=qs)
@@ -500,7 +498,6 @@ def test_fuzz__PyUnquoter(ignore, unsafe, qs):
         alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
     ),
 )
-@pytest.mark.hypothesis
 @pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
 @pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
 def test_quote_unquote_parameter(
@@ -522,7 +519,6 @@ def test_quote_unquote_parameter(
         alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
     ),
 )
-@pytest.mark.hypothesis
 @pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
 @pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
 def test_quote_unquote_parameter_requote(
@@ -544,7 +540,6 @@ def test_quote_unquote_parameter_requote(
         alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
     ),
 )
-@pytest.mark.hypothesis
 @pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
 @pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
 def test_quote_unquote_parameter_path_safe(


### PR DESCRIPTION
The mark is already applied upstream so we do not need to apply it here


![Screenshot_2024-10-16-10-41-06-52_40deb401b9ffe8e1df2f1cc5ba480b12.jpg](https://github.com/user-attachments/assets/138fc6b2-15e3-4f8d-ba58-e0e17f6958cd)

*(https://hypothesis.rtfd.io/en/latest/details.html#the-hypothesis-pytest-plugin)*
https://github.com/aio-libs/yarl/pull/1280#discussion_r1802632116
