### PR TITLE
Fix query benchmarks to avoid testing property cache hits

### DIFF
--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -6,11 +6,13 @@ from yarl import URL
 
 MANY_HOSTS = [f"www.domain{i}.tld" for i in range(256)]
 MANY_URLS = [f"https://www.domain{i}.tld" for i in range(256)]
-BASE_URL = URL("http://www.domain.tld")
+BASE_URL_STR = "http://www.domain.tld"
+BASE_URL = URL(BASE_URL_STR)
 URL_WITH_USER_PASS = URL("http://user:password@www.domain.tld")
 IPV6_QUERY_URL = URL("http://[::1]/req?query=1&query=2&query=3&query=4&query=5")
 URL_WITH_NOT_DEFAULT_PORT = URL("http://www.domain.tld:1234")
-QUERY_URL = URL("http://www.domain.tld?query=1&query=2&query=3&query=4&query=5")
+QUERY_URL_STR = "http://www.domain.tld?query=1&query=2&query=3&query=4&query=5"
+QUERY_URL = URL(QUERY_URL_STR)
 URL_WITH_PATH = URL("http://www.domain.tld/req")
 REL_URL = URL("/req")
 QUERY_SEQ = {str(i): tuple(str(j) for j in range(10)) for i in range(10)}
@@ -389,28 +391,36 @@ def test_human_repr(benchmark: BenchmarkFixture) -> None:
 
 
 def test_query_string(benchmark: BenchmarkFixture) -> None:
+    urls = [URL(QUERY_URL_STR) for _ in range(100)]
+
     @benchmark
     def _run() -> None:
-        for _ in range(100):
-            QUERY_URL.query_string
+        for url in urls:
+            url.query_string
 
 
 def test_empty_query_string(benchmark: BenchmarkFixture) -> None:
+    urls = [URL(BASE_URL_STR) for _ in range(100)]
+
     @benchmark
     def _run() -> None:
-        for _ in range(100):
-            BASE_URL.query_string
+        for url in urls:
+            url.query_string
 
 
 def test_query(benchmark: BenchmarkFixture) -> None:
+    urls = [URL(QUERY_URL_STR) for _ in range(100)]
+
     @benchmark
     def _run() -> None:
-        for _ in range(100):
-            QUERY_URL.query
+        for url in urls:
+            url.query
 
 
 def test_empty_query(benchmark: BenchmarkFixture) -> None:
+    urls = [URL(BASE_URL_STR) for _ in range(100)]
+
     @benchmark
     def _run() -> None:
-        for _ in range(100):
-            BASE_URL.query
+        for url in urls:
+            url.query


### PR DESCRIPTION
Ideally we would look at `__wrapped__` but its not exposed on `under_cached_property,` but this is fine as it will give us a baseline to know when it changes since every call will be a cache miss.

Will give us a better idea on the actual performance impact of #1296