### PR TITLE
Improve performance of the `URL.with_path` method

### DIFF
--- a/CHANGES/1307.misc.rst
+++ b/CHANGES/1307.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the :py:meth:`~yarl.URL.with_path` method -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1264,13 +1264,16 @@ class URL:
 
     def with_path(self, path: str, *, encoded: bool = False) -> "URL":
         """Return a new URL with path replaced."""
+        scheme, netloc, _, _, _ = self._val
         if not encoded:
             path = self._PATH_QUOTER(path)
-            if self._val.netloc:
+            if netloc:
                 path = self._normalize_path(path) if "." in path else path
         if path and path[0] != "/":
             path = f"/{path}"
-        return self._from_val(self._val._replace(path=path, query="", fragment=""))
+        return self._from_val(
+            tuple.__new__(SplitResult, (scheme, netloc, path, "", ""))
+        )
 
     @classmethod
     def _get_str_query_from_sequence_iterable(


### PR DESCRIPTION
Most of the time here is spent rebuilding the URL. Getting rid of `_replace` makes this a lot faster