### PR TITLE
Improve performance of the `URL.with_query` method

### DIFF
--- a/CHANGES/1308.misc.rst
+++ b/CHANGES/1308.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the :py:meth:`~yarl.URL.with_query` method -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1411,9 +1411,11 @@ class URL:
 
         """
         # N.B. doesn't cleanup query/fragment
-
-        new_query = self._get_str_query(*args, **kwargs) or ""
-        return self._from_val(self._val._replace(query=new_query))
+        query = self._get_str_query(*args, **kwargs) or ""
+        scheme, netloc, path, _, fragment = self._val
+        return self._from_val(
+            tuple.__new__(SplitResult, (scheme, netloc, path, query, fragment))
+        )
 
     @overload
     def extend_query(self, query: Query) -> "URL": ...


### PR DESCRIPTION
This will help a bit reassembling the URL, but not as good as `joinpath` because parsing the query string is still relatively more expensive.