### PR TITLE
Improve performance of URL equality checks

### DIFF
--- a/CHANGES/1315.misc.rst
+++ b/CHANGES/1315.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of :class:`~yarl.URL` equality checks -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -478,11 +478,13 @@ class URL:
 
         val1 = self._val
         if not val1.path and val1.netloc:
-            val1 = val1._replace(path="/")
+            scheme, netloc, _, query, fragment = val1
+            val1 = tuple.__new__(SplitResult, (scheme, netloc, "/", query, fragment))
 
         val2 = other._val
         if not val2.path and val2.netloc:
-            val2 = val2._replace(path="/")
+            scheme, netloc, _, query, fragment = val2
+            val2 = tuple.__new__(SplitResult, (scheme, netloc, "/", query, fragment))
 
         return val1 == val2
 


### PR DESCRIPTION
Avoid calling `SplitResult._replace` since its much slower