### PR TITLE
Improve performance of calculating the URL hash

### DIFF
--- a/CHANGES/1318.misc.rst
+++ b/CHANGES/1318.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of calculating the hash of :class:`~yarl.URL` objects -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -490,7 +490,8 @@ class URL:
 
     def __hash__(self) -> int:
         if (ret := self._cache.get("hash")) is None:
-            scheme, netloc, path, query, fragment = self._val
+            val = self._val
+            scheme, netloc, path, query, fragment = val
             if not path and netloc:
                 val = tuple.__new__(SplitResult, (scheme, netloc, "/", query, fragment))
             ret = self._cache["hash"] = hash(val)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -489,11 +489,10 @@ class URL:
         return val1 == val2
 
     def __hash__(self) -> int:
-        ret = self._cache.get("hash")
-        if ret is None:
-            val = self._val
-            if not val.path and val.netloc:
-                val = val._replace(path="/")
+        if (ret := self._cache.get("hash")) is None:
+            scheme, netloc, path, query, fragment = self._val
+            if not path and netloc:
+                val = tuple.__new__(SplitResult, (scheme, netloc, "/", query, fragment))
             ret = self._cache["hash"] = hash(val)
         return ret
 


### PR DESCRIPTION
Avoid calling `SplitResult._replace` since its much slower, and instead replace with fast `NamedTuple` creation `tuple.__new__(Type, (...)`