### PR TITLE
Improve performance of `URL.relative`

### DIFF
--- a/CHANGES/1319.misc.rst
+++ b/CHANGES/1319.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the :py:meth:`~yarl.URL.relative` method -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -611,9 +611,10 @@ class URL:
         scheme, user, password, host and port are removed.
 
         """
-        if not self._val.netloc:
+        _, netloc, path, query, fragment = self._val
+        if not netloc:
             raise ValueError("URL should be absolute")
-        val = self._val._replace(scheme="", netloc="")
+        val = tuple.__new__(SplitResult, ("", "", path, query, fragment))
         return self._from_val(val)
 
     @cached_property


### PR DESCRIPTION
Avoid calling `SplitResult._replace` since its much slower, and instead replace with fast `NamedTuple` creation `tuple.__new__(Type, (...)`