### PR TITLE
Improve performance of `URL.parent`

### DIFF
--- a/CHANGES/1321.misc.rst
+++ b/CHANGES/1321.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of :attr:`~yarl.URL.parent` -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -904,7 +904,6 @@ class URL:
         fragment.
 
         """
-        path = self.raw_path
         scheme, netloc, path, query, fragment = self._val
         if not path or path == "/":
             if fragment or query:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -905,12 +905,14 @@ class URL:
 
         """
         path = self.raw_path
+        scheme, netloc, path, query, fragment = self._val
         if not path or path == "/":
-            if self._val.fragment or self._val.query:
-                return self._from_val(self._val._replace(query="", fragment=""))
+            if fragment or query:
+                val = tuple.__new__(SplitResult, (scheme, netloc, path, "", ""))
+                return self._from_val(val)
             return self
         parts = path.split("/")
-        val = self._val._replace(path="/".join(parts[:-1]), query="", fragment="")
+        val = tuple.__new__(SplitResult, (scheme, netloc, "/".join(parts[:-1]), "", ""))
         return self._from_val(val)
 
     @cached_property


### PR DESCRIPTION
Avoid calling `SplitResult._replace` since its much slower, and instead replace with fast `NamedTuple` creation `tuple.__new__(Type, (...)`