### PR TITLE
Support using the subtraction operator to get the relative path between URLs

### DIFF
--- a/CHANGES/1340.feature.rst
+++ b/CHANGES/1340.feature.rst
@@ -1,0 +1,2 @@
+Added support for using the :meth:`subtraction operator <yarl.URL.__sub__>`
+to get the relative path between URLs.

--- a/CHANGES/1340.feature.rst
+++ b/CHANGES/1340.feature.rst
@@ -1,2 +1,2 @@
 Added support for using the :meth:`subtraction operator <yarl.URL.__sub__>`
-to get the relative path between URLs.
+to get the relative path between URLs -- by :user:`oleksbabieiev`.

--- a/CHANGES/1340.feature.rst
+++ b/CHANGES/1340.feature.rst
@@ -1,7 +1,7 @@
 Added support for using the :meth:`subtraction operator <yarl.URL.__sub__>`
 to get the relative path between URLs.
 
-Note that both URLs must have the same scheme and netloc:
+Note that both URLs must have the same scheme, user, password, host and port:
 
 .. code-block:: pycon
 
@@ -10,7 +10,7 @@ Note that both URLs must have the same scheme and netloc:
    >>> target - base
    URL('path/index.html')
 
-URLs can also be relative and have no scheme or netloc at all:
+URLs can also be relative:
 
 .. code-block:: pycon
 

--- a/CHANGES/1340.feature.rst
+++ b/CHANGES/1340.feature.rst
@@ -1,2 +1,22 @@
 Added support for using the :meth:`subtraction operator <yarl.URL.__sub__>`
-to get the relative path between URLs -- by :user:`oleksbabieiev`.
+to get the relative path between URLs.
+
+Note that both URLs must have the same scheme and netloc:
+
+.. code-block:: pycon
+
+   >>> target = URL("http://example.com/path/index.html")
+   >>> base = URL("http://example.com/")
+   >>> target - base
+   URL('path/index.html')
+
+URLs can also be relative and have no scheme or netloc at all:
+
+.. code-block:: pycon
+
+  >>> target = URL("/")
+  >>> base = URL("/path/index.html")
+  >>> target - base
+  URL('..')
+
+-- by :user:`oleksbabieiev`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -976,7 +976,7 @@ The path is encoded if needed.
 
 The subtraction (``-``) operator creates a new URL with
 a relative *path* to the target URL from the given base URL.
-*scheme*, *user*, *password*, *host* and *port* are removed.
+*scheme*, *user*, *password*, *host*, *port*, *query* and *fragment* are removed.
 
 .. method:: URL.__sub__(url)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -974,6 +974,21 @@ The path is encoded if needed.
          >>> base.join(URL('//python.org/page.html'))
          URL('http://python.org/page.html')
 
+The subtraction (``-``) operator creates a new URL with
+a relative *path* to the target URL from the given base URL.
+*scheme*, *user*, *password*, *host* and *port* are removed.
+
+.. method:: URL.__sub__(url)
+
+   Returns a new URL with a relative *path* between two other URL objects.
+
+   .. doctest::
+
+      >>> target = URL('http://example.com/path/index.html')
+      >>> base = URL('http://example.com/')
+      >>> target - base
+      URL('path/index.html')
+
 Human readable representation
 -----------------------------
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -70,6 +70,14 @@ def test_str():
         ("http://example.com/path", "http://example.com/path/to/", ".."),
         ("http://example.com/", "http://example.com/", "."),
         ("http://example.com", "http://example.com", "."),
+        ("http://example.com/", "http://example.com", "."),
+        ("http://example.com", "http://example.com/", "."),
+        ("//example.com", "//example.com", "."),
+        ("/path/to", "/spam/", "../path/to"),
+        ("path/to", "spam/", "../path/to"),
+        ("path/to", "spam", "path/to"),
+        ("..", ".", ".."),
+        (".", "..", "."),
     ],
 )
 def test_sub(target: str, base: str, expected: str):

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -53,6 +53,33 @@ def test_str():
     assert str(url) == "http://example.com:8888/path/to?a=1&b=2"
 
 
+@pytest.mark.parametrize(
+    "target,base,expected",
+    [
+        ("http://example.com/path/to", "http://example.com/", "path/to"),
+        ("http://example.com/path/to", "http://example.com/spam", "path/to"),
+        ("http://example.com/path/to", "http://example.com/spam/", "../path/to"),
+        ("http://example.com/path", "http://example.com/path/to/", ".."),
+        ("http://example.com/", "http://example.com/", "."),
+        ("http://example.com", "http://example.com", "."),
+    ],
+)
+def test_sub(target: str, base: str, expected: str):
+    assert URL(target) - URL(base) == URL(expected)
+
+
+def test_sub_with_different_schemes():
+    with pytest.raises(ValueError) as ctx:
+        URL("http://example.com/") - URL("https://example.com/")
+    assert "Both URLs should have the same scheme" == str(ctx.value)
+
+
+def test_sub_with_different_netlocs():
+    with pytest.raises(ValueError) as ctx:
+        URL("https://spam.com/") - URL("https://ham.com/")
+    assert "Both URLs should have the same netloc" == str(ctx.value)
+
+
 def test_repr():
     url = URL("http://example.com")
     assert "URL('http://example.com')" == repr(url)

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -62,7 +62,7 @@ def test_str():
 
 
 @pytest.mark.parametrize(
-    "target,base,expected",
+    ("target", "base", "expected"),
     [
         ("http://example.com/path/to", "http://example.com/", "path/to"),
         ("http://example.com/path/to", "http://example.com/spam", "path/to"),
@@ -85,26 +85,24 @@ def test_sub(target: str, base: str, expected: str):
 
 
 def test_sub_with_different_schemes():
-    with pytest.raises(ValueError) as ctx:
+    expected_error_msg = "Both URLs should have the same scheme"
+    with pytest.raises(ValueError, match=expected_error_msg):
         URL("http://example.com/") - URL("https://example.com/")
-    assert "Both URLs should have the same scheme" == str(ctx.value)
 
 
 def test_sub_with_different_netlocs():
-    with pytest.raises(ValueError) as ctx:
+    expected_error_msg = "Both URLs should have the same netloc"
+    with pytest.raises(ValueError, match=expected_error_msg):
         URL("https://spam.com/") - URL("https://ham.com/")
-    assert "Both URLs should have the same netloc" == str(ctx.value)
 
 
 def test_sub_with_abs_and_rel_paths():
-    with pytest.raises(ValueError) as ctx:
-        URL("path/to") - URL("/path/from")
-    assert (
-        "It is forbidden to get the path "
-        "between the absolute and relative paths "
-        "because it is impossible "
-        "to get the current working directory." == str(ctx.value)
+    expected_error_msg = (
+        "It is forbidden to get the path between the absolute and relative paths "
+        "because it is impossible to get the current working directory."
     )
+    with pytest.raises(ValueError, match=expected_error_msg):
+        URL("path/to") - URL("/path/from")
 
 
 def test_repr():

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -96,6 +96,17 @@ def test_sub_with_different_netlocs():
     assert "Both URLs should have the same netloc" == str(ctx.value)
 
 
+def test_sub_with_abs_and_rel_paths():
+    with pytest.raises(ValueError) as ctx:
+        URL("path/to") - URL("/path/from")
+    assert (
+        "It is forbidden to get the path "
+        "between the absolute and relative paths "
+        "because it is impossible "
+        "to get the current working directory." == str(ctx.value)
+    )
+
+
 def test_repr():
     url = URL("http://example.com")
     assert "URL('http://example.com')" == repr(url)

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -96,13 +96,16 @@ def test_sub_with_different_netlocs():
         URL("https://spam.com/") - URL("https://ham.com/")
 
 
-def test_sub_with_abs_and_rel_paths():
-    expected_error_msg = (
-        "It is forbidden to get the path between the absolute and relative paths "
-        "because it is impossible to get the current working directory."
-    )
+def test_sub_with_different_anchors():
+    expected_error_msg = "'path/to' and '/path' have different anchors"
     with pytest.raises(ValueError, match=expected_error_msg):
         URL("path/to") - URL("/path/from")
+
+
+def test_sub_with_two_dots_in_base():
+    expected_error_msg = "'..' segment in '/path/..' cannot be walked"
+    with pytest.raises(ValueError, match=expected_error_msg):
+        URL("path/to") - URL("/path/../from")
 
 
 def test_repr():

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -66,5 +66,6 @@ def calculate_relative_path(target: str, base: str) -> str:
         raise ValueError(
             f"{str(target_path)!r} and {str(base_path)!r} have different anchors"
         )
-    parts = [".."] * step + list(target_path.parts)[len(path.parts) :]
+    offset = len(path.parts)
+    parts = [".."] * step + list(target_path.parts)[offset:]
     return str(PurePath(*parts))

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -4,6 +4,8 @@ from collections.abc import Sequence
 from contextlib import suppress
 from os.path import dirname, relpath
 
+SEPARATOR = "/"
+
 
 def normalize_path_segments(segments: Sequence[str]) -> list[str]:
     """Drop '.' and '..' from a sequence of str segments"""
@@ -32,24 +34,24 @@ def normalize_path_segments(segments: Sequence[str]) -> list[str]:
 def normalize_path(path: str) -> str:
     # Drop '.' and '..' from str path
     prefix = ""
-    if path and path[0] == "/":
+    if path and path[0] == SEPARATOR:
         # preserve the "/" root element of absolute paths, copying it to the
         # normalised output as per sections 5.2.4 and 6.2.2.3 of rfc3986.
-        prefix = "/"
+        prefix = SEPARATOR
         path = path[1:]
 
-    segments = path.split("/")
-    return prefix + "/".join(normalize_path_segments(segments))
+    segments = path.split(SEPARATOR)
+    return prefix + SEPARATOR.join(normalize_path_segments(segments))
 
 
 def relative_path(path: str, start: str) -> str:
     """A wrapper over os.path.relpath()"""
 
     if not path:
-        path = "/"
+        path = SEPARATOR
     if not start:
-        start = "/"
-    if not start.endswith("/"):
+        start = SEPARATOR
+    if not start.endswith(SEPARATOR):
         start = dirname(start)
 
     return relpath(path, start)

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Sequence
 from contextlib import suppress
+from os.path import dirname, relpath
 
 
 def normalize_path_segments(segments: Sequence[str]) -> list[str]:
@@ -39,3 +40,16 @@ def normalize_path(path: str) -> str:
 
     segments = path.split("/")
     return prefix + "/".join(normalize_path_segments(segments))
+
+
+def relative_path(path: str, start: str) -> str:
+    """A wrapper over os.path.relpath()"""
+
+    if not path:
+        path = "/"
+    if not start:
+        start = "/"
+    if not start.endswith("/"):
+        start = dirname(start)
+
+    return relpath(path, start)

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from contextlib import suppress
-from pathlib import PurePath
+from pathlib import PurePosixPath
 
 
 def normalize_path_segments(segments: Sequence[str]) -> list[str]:
@@ -51,8 +51,8 @@ def calculate_relative_path(target: str, base: str) -> str:
     target = target or "/"
     base = base or "/"
 
-    target_path = PurePath(target)
-    base_path = PurePath(base)
+    target_path = PurePosixPath(target)
+    base_path = PurePosixPath(base)
 
     if not base.endswith("/"):
         base_path = base_path.parent
@@ -68,4 +68,4 @@ def calculate_relative_path(target: str, base: str) -> str:
         )
     offset = len(path.parts)
     parts = [".."] * step + list(target_path.parts)[offset:]
-    return str(PurePath(*parts))
+    return str(PurePosixPath(*parts))

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -42,7 +42,7 @@ def normalize_path(path: str) -> str:
     return prefix + "/".join(normalize_path_segments(segments))
 
 
-def relative_path(path: str, start: str) -> str:
+def calculate_relative_path(path: str, start: str) -> str:
     """A wrapper over os.path.relpath()"""
 
     if not path:

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -52,9 +52,13 @@ def calculate_relative_path(path: str, start: str) -> str:
     if not start.endswith("/"):
         start = dirname(start)
 
-    if (path.startswith("/") and not start.startswith("/")) or (
-        not path.startswith("/") and start.startswith("/")
-    ):
+    path_has_leading_slash = path.startswith("/")
+    start_has_leading_slash = start.startswith("/")
+    both_have_leading_slash = all((path_has_leading_slash, start_has_leading_slash))
+    none_have_leading_slash = all(
+        (not path_has_leading_slash, not start_has_leading_slash)
+    )
+    if not both_have_leading_slash and not none_have_leading_slash:
         raise ValueError(
             "It is forbidden to get the path between the absolute and relative paths "
             "because it is impossible to get the current working directory."

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -4,8 +4,6 @@ from collections.abc import Sequence
 from contextlib import suppress
 from os.path import dirname, relpath
 
-SEPARATOR = "/"
-
 
 def normalize_path_segments(segments: Sequence[str]) -> list[str]:
     """Drop '.' and '..' from a sequence of str segments"""
@@ -34,28 +32,28 @@ def normalize_path_segments(segments: Sequence[str]) -> list[str]:
 def normalize_path(path: str) -> str:
     # Drop '.' and '..' from str path
     prefix = ""
-    if path and path[0] == SEPARATOR:
+    if path and path[0] == "/":
         # preserve the "/" root element of absolute paths, copying it to the
         # normalised output as per sections 5.2.4 and 6.2.2.3 of rfc3986.
-        prefix = SEPARATOR
+        prefix = "/"
         path = path[1:]
 
-    segments = path.split(SEPARATOR)
-    return prefix + SEPARATOR.join(normalize_path_segments(segments))
+    segments = path.split("/")
+    return prefix + "/".join(normalize_path_segments(segments))
 
 
 def relative_path(path: str, start: str) -> str:
     """A wrapper over os.path.relpath()"""
 
     if not path:
-        path = SEPARATOR
+        path = "/"
     if not start:
-        start = SEPARATOR
-    if not start.endswith(SEPARATOR):
+        start = "/"
+    if not start.endswith("/"):
         start = dirname(start)
 
-    if (path.startswith(SEPARATOR) and not start.startswith(SEPARATOR)) or (
-        not path.startswith(SEPARATOR) and start.startswith(SEPARATOR)
+    if (path.startswith("/") and not start.startswith("/")) or (
+        not path.startswith("/") and start.startswith("/")
     ):
         raise ValueError(
             "It is forbidden to get the path between the absolute and relative paths "

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -54,4 +54,12 @@ def relative_path(path: str, start: str) -> str:
     if not start.endswith(SEPARATOR):
         start = dirname(start)
 
+    if (path.startswith(SEPARATOR) and not start.startswith(SEPARATOR)) or (
+        not path.startswith(SEPARATOR) and start.startswith(SEPARATOR)
+    ):
+        raise ValueError(
+            "It is forbidden to get the path between the absolute and relative paths "
+            "because it is impossible to get the current working directory."
+        )
+
     return relpath(path, start)

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -67,5 +67,4 @@ def calculate_relative_path(target: str, base: str) -> str:
             f"{str(target_path)!r} and {str(base_path)!r} have different anchors"
         )
     offset = len(path.parts)
-    parts = [".."] * step + list(target_path.parts)[offset:]
-    return str(PurePosixPath(*parts))
+    return str(PurePosixPath(*("..",) * step, *target_path.parts[offset:]))

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -6,24 +6,8 @@ from contextlib import suppress
 from functools import _CacheInfo, lru_cache
 from ipaddress import ip_address
 from os.path import dirname, relpath
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    SupportsInt,
-    Tuple,
-    TypedDict,
-    TypeVar,
-    Union,
-    overload,
-)
-from urllib.parse import (
-    SplitResult,
-    parse_qsl,
-    quote,
-    scheme_chars,
-    uses_netloc,
-    uses_relative,
-)
+from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, Union, overload
+from urllib.parse import SplitResult, parse_qsl, quote, uses_relative
 
 import idna
 from multidict import MultiDict, MultiDictProxy

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -24,8 +24,6 @@ from urllib.parse import (
     uses_netloc,
     uses_relative,
 )
-from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, Union, overload
-from urllib.parse import SplitResult, parse_qsl, quote, uses_relative
 
 import idna
 from multidict import MultiDict, MultiDictProxy

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -17,7 +17,6 @@ from typing import (
     Union,
     overload,
 )
-from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, Union, overload
 from urllib.parse import (
     SplitResult,
     parse_qsl,

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -4,7 +4,6 @@ import warnings
 from collections.abc import Mapping, Sequence
 from functools import _CacheInfo, lru_cache
 from ipaddress import ip_address
-from os.path import dirname, relpath
 from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, Union, overload
 from urllib.parse import SplitResult, parse_qsl, uses_relative
 
@@ -13,7 +12,7 @@ from multidict import MultiDict, MultiDictProxy
 from propcache.api import under_cached_property as cached_property
 
 from ._parse import USES_AUTHORITY, make_netloc, split_netloc, split_url, unsplit_result
-from ._path import normalize_path, normalize_path_segments
+from ._path import normalize_path, normalize_path_segments, relative_path
 from ._query import (
     Query,
     QueryVariable,
@@ -488,21 +487,8 @@ class URL:
         if target.netloc != base.netloc:
             raise ValueError("Both URLs should have the same netloc")
 
-        path = self._relpath(target.path, base.path)
+        path = relative_path(target.path, base.path)
         return self._from_tup(("", "", path, "", ""))
-
-    @staticmethod
-    def _relpath(path: str, start: str) -> str:
-        """A wrapper over os.path.relpath()"""
-
-        if not path:
-            path = "/"
-        if not start:
-            start = "/"
-        if not start.endswith("/"):
-            start = dirname(start)
-
-        return relpath(path, start)
 
     def __mod__(self, query: Query) -> "URL":
         return self.update_query(query)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -476,6 +476,19 @@ class URL:
         return self._make_child((str(name),))
 
     def __sub__(self, other: object) -> "URL":
+        """Return a new URL with a relative path between two other URL objects.
+
+        Note that both URLs must have the same scheme and netloc.
+        The new relative URL has only path:
+        scheme, user, password, host, port, query and fragment are removed.
+
+        Example:
+        >>> target = URL("http://example.com/path/index.html")
+        >>> base = URL("http://example.com/")
+        >>> target - base
+        URL('path/index.html')
+        """
+
         if type(other) is not URL:
             return NotImplemented
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -12,7 +12,7 @@ from multidict import MultiDict, MultiDictProxy
 from propcache.api import under_cached_property as cached_property
 
 from ._parse import USES_AUTHORITY, make_netloc, split_netloc, split_url, unsplit_result
-from ._path import normalize_path, normalize_path_segments, relative_path
+from ._path import calculate_relative_path, normalize_path, normalize_path_segments
 from ._query import (
     Query,
     QueryVariable,
@@ -487,7 +487,7 @@ class URL:
         if target.netloc != base.netloc:
             raise ValueError("Both URLs should have the same netloc")
 
-        path = relative_path(target.path, base.path)
+        path = calculate_relative_path(target.path, base.path)
         return self._from_tup(("", "", path, "", ""))
 
     def __mod__(self, query: Query) -> "URL":


### PR DESCRIPTION
## What do these changes do?

Support for using the subtraction operator to calculate the difference between the *paths* of two URLs. A new URL with the relative path is returned to the user.

Usage:
```py
from yarl import URL

target = URL("http://example.com/path/index.html")
base = URL("http://example.com/path/")

rel = target - base

print(rel)  # output: "index.html"
```

## Are there changes in behavior for the user?

Now the user can easily calculate the relative path between two URLs!

## Related issue number

Resolves #1183

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
