### PR TITLE
Break out functions that do not need decorated methods

### DIFF
--- a/CHANGES/1345.misc.rst
+++ b/CHANGES/1345.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of calling :py:meth:`~yarl.URL.build` and constructing unencoded :class:`~yarl.URL` -- by :user:`bdraco`.


### PR DESCRIPTION
`classmethod`s and `staticmethod`s are slower than normal methods, and these methods never need anything on the URL objects like `_normalize_path_segments`
