### PR TITLE
Add additional test case for unicode decomposition normalization

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -10,8 +10,9 @@ _WHATWG_C0_CONTROL_OR_SPACE = (
     "\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10"
     "\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f "
 )
-_VERTICAL_COLON = "\ufe13"
-_FULL_WITH_NUMBER_SIGN = "\uFF03"
+_VERTICAL_COLON = "\ufe13"  # normalizes to ":"
+_FULL_WITH_NUMBER_SIGN = "\uFF03"  # normalizes to "#"
+_ACCOUNT_OF = "\u2100"  # normalizes to "a/c"
 
 
 def test_inheritance():
@@ -2187,7 +2188,7 @@ def test_control_chars_are_removed(byte: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "disallowed_unicode", [_VERTICAL_COLON, _FULL_WITH_NUMBER_SIGN]
+    "disallowed_unicode", [_VERTICAL_COLON, _FULL_WITH_NUMBER_SIGN, _ACCOUNT_OF]
 )
 def test_url_with_invalid_unicode(disallowed_unicode: str) -> None:
     with pytest.raises(


### PR DESCRIPTION
"\u2100" which normalizes to "a/c" should be tested since it could mean a `/` injection