### PR TITLE
Extract staticmethods from URL object

### DIFF
--- a/tests/test_normalize_path.py
+++ b/tests/test_normalize_path.py
@@ -1,6 +1,6 @@
 import pytest
 
-from yarl import URL
+from yarl._url import _normalize_path
 
 PATHS = [
     # No dots
@@ -33,4 +33,4 @@ PATHS = [
 
 @pytest.mark.parametrize("original,expected", PATHS)
 def test__normalize_path(original, expected):
-    assert URL._normalize_path(original) == expected
+    assert _normalize_path(original) == expected


### PR DESCRIPTION
These do not need to be staticmethods. Ideally we can organize the code a bit more and move them into seperate modules later
