### PR TITLE
Cleanup constant naming in `_url.py`

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -42,18 +42,18 @@ SCHEME_REQUIRES_HOST = frozenset(("http", "https", "ws", "wss", "ftp"))
 
 # Leading and trailing C0 control and space to be stripped per WHATWG spec.
 # == "".join([chr(i) for i in range(0, 0x20 + 1)])
-_WHATWG_C0_CONTROL_OR_SPACE = (
+WHATWG_C0_CONTROL_OR_SPACE = (
     "\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10"
     "\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f "
 )
 
 # Unsafe bytes to be removed per WHATWG spec
-_UNSAFE_URL_BYTES_TO_REMOVE = ["\t", "\r", "\n"]
+UNSAFE_URL_BYTES_TO_REMOVE = ["\t", "\r", "\n"]
 
 # reg-name: unreserved / pct-encoded / sub-delims
 # this pattern matches anything that is *not* in those classes. and is only used
 # on lower-cased ASCII values.
-_not_reg_name = re.compile(
+NOT_REG_NAME = re.compile(
     r"""
         # any character not in the unreserved or sub-delims sets, plus %
         # (validated with the additional check for pct-encoded sequences below)
@@ -160,8 +160,8 @@ def _split_url(url: str) -> SplitResult:
     # Adapted from urllib.parse.urlsplit
     # Only lstrip url as some applications rely on preserving trailing space.
     # (https://url.spec.whatwg.org/#concept-basic-url-parser would strip both)
-    url = url.lstrip(_WHATWG_C0_CONTROL_OR_SPACE)
-    for b in _UNSAFE_URL_BYTES_TO_REMOVE:
+    url = url.lstrip(WHATWG_C0_CONTROL_OR_SPACE)
+    for b in UNSAFE_URL_BYTES_TO_REMOVE:
         if b in url:
             url = url.replace(b, "")
 
@@ -1764,7 +1764,7 @@ def _ip_compressed_version(raw_ip: str) -> tuple[str, int]:
 @lru_cache(_MAXCACHE)
 def _host_validate(host: str) -> None:
     """Validate an ascii host name."""
-    invalid = _not_reg_name.search(host)
+    invalid = NOT_REG_NAME.search(host)
     if invalid is None:
         return
     value, pos, extra = invalid.group(), invalid.start(), ""


### PR DESCRIPTION
All of these are already in a protected namespace `_url` so they do not need to be prefixed with `_`
