### PR TITLE
Add missing test coverage for `URL.update_query`

### DIFF
--- a/tests/test_url_query.py
+++ b/tests/test_url_query.py
@@ -209,3 +209,34 @@ def test_skip_dropping_query_params(
     url = URL(f"http://example.com?{original_query_string}")
     new_url = url.without_query_params(*keys_to_drop)
     assert new_url is url
+
+
+def test_update_query_rejects_bytes():
+    url = URL("http://example.com")
+    with pytest.raises(TypeError):
+        url.update_query(b"foo=bar")
+
+
+def test_update_query_rejects_bytearray():
+    url = URL("http://example.com")
+    with pytest.raises(TypeError):
+        url.update_query(bytearray(b"foo=bar"))
+
+
+def test_update_query_rejects_memoryview():
+    url = URL("http://example.com")
+    with pytest.raises(TypeError):
+        url.update_query(memoryview(b"foo=bar"))
+
+
+def test_update_query_rejects_invalid_type():
+    url = URL("http://example.com")
+    with pytest.raises(TypeError):
+        url.update_query(42)
+
+
+def test_update_query_with_sequence_of_pairs():
+    url = URL("http://example.com")
+    new_url = url.update_query([("a", "1"), ("b", "2")])
+    assert new_url.query == MultiDict([("a", "1"), ("b", "2")])
+    assert new_url.query_string == "a=1&b=2"


### PR DESCRIPTION
There were a few uncovered line from splitting up the `update_query` that turned out to not have direct coverage