### PR TITLE
Add missing coverage for `URL.build`

### DIFF
--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -280,6 +280,7 @@ def test_build_already_encoded_username_password():
         encoded=True,
     )
     assert str(u) == "http://u:p@x.org/x/y/z?x=z#any"
+    assert u.host_subcomponent == "x.org"
 
 
 def test_build_already_encoded_empty_host():
@@ -291,6 +292,7 @@ def test_build_already_encoded_empty_host():
         encoded=True,
     )
     assert str(u) == "/x/y/z?x=z#any"
+    assert u.host_subcomponent is None
 
 
 def test_build_percent_encoded():

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -268,6 +268,31 @@ def test_build_already_encoded():
     assert str(u) == "http://оун-упа.укр/шлях/криївка?ключ=знач#фраг"
 
 
+def test_build_already_encoded_username_password():
+    u = URL.build(
+        scheme="http",
+        host="x.org",
+        path="/x/y/z",
+        query_string="x=z",
+        fragment="any",
+        user="u",
+        password="p",
+        encoded=True,
+    )
+    assert str(u) == "http://u:p@x.org/x/y/z?x=z#any"
+
+
+def test_build_already_encoded_empty_host():
+    u = URL.build(
+        host="",
+        path="/x/y/z",
+        query_string="x=z",
+        fragment="any",
+        encoded=True,
+    )
+    assert str(u) == "/x/y/z?x=z#any"
+
+
 def test_build_percent_encoded():
     u = URL.build(
         scheme="http",


### PR DESCRIPTION
There were a few paths for `URL.build` where `encode=True` that were not fully covered.