### PR TITLE
Fix loop variable being redefined in `cache_configure`

### DIFF
--- a/CHANGES/1363.breaking.rst
+++ b/CHANGES/1363.breaking.rst
@@ -1,0 +1,1 @@
+1348.breaking.rst

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -36,6 +36,39 @@ def test_cache_configure_None() -> None:
     )
 
 
+def test_cache_configure_None_including_deprecated() -> None:
+    msg = (
+        r"cache_configure\(\) no longer accepts the ip_address_size "
+        r"or host_validate_size arguments, they are used to set the "
+        r"encode_host_size instead and will be removed in the future"
+    )
+    with pytest.warns(DeprecationWarning, match=msg):
+        yarl.cache_configure(
+            idna_decode_size=None,
+            idna_encode_size=None,
+            encode_host_size=None,
+            ip_address_size=None,
+            host_validate_size=None,
+        )
+    assert yarl.cache_info()["idna_decode"].maxsize is None
+    assert yarl.cache_info()["idna_encode"].maxsize is None
+    assert yarl.cache_info()["encode_host"].maxsize is None
+
+
+def test_cache_configure_None_only_deprecated() -> None:
+    msg = (
+        r"cache_configure\(\) no longer accepts the ip_address_size "
+        r"or host_validate_size arguments, they are used to set the "
+        r"encode_host_size instead and will be removed in the future"
+    )
+    with pytest.warns(DeprecationWarning, match=msg):
+        yarl.cache_configure(
+            ip_address_size=None,
+            host_validate_size=None,
+        )
+    assert yarl.cache_info()["encode_host"].maxsize is None
+
+
 def test_cache_configure_explicit() -> None:
     yarl.cache_configure(
         idna_decode_size=128,

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1467,30 +1467,30 @@ def cache_configure(
     global _idna_decode, _idna_encode, _encode_host
     # ip_address_size, host_validate_size are no longer
     # used, but are kept for backwards compatibility.
-    if encode_host_size is _SENTINEL:
-        encode_host_size = _DEFAULT_ENCODE_SIZE
+    if ip_address_size is not _SENTINEL or host_validate_size is not _SENTINEL:
+        warnings.warn(
+            "cache_configure() no longer accepts the "
+            "ip_address_size or host_validate_size arguments, "
+            "they are used to set the encode_host_size instead "
+            "and will be removed in the future",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    if encode_host_size is not None:
         for size in (ip_address_size, host_validate_size):
-            if size is not _SENTINEL:
-                warnings.warn(
-                    "cache_configure() no longer accepts the "
-                    "ip_address_size or host_validate_size arguments, "
-                    "they are used to set the encode_host_size instead "
-                    "and will be removed in the future",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
             if size is None:
                 encode_host_size = None
-                continue
-            if encode_host_size is None:
-                continue
-            if size is _SENTINEL:
-                encode_host_size = max(_DEFAULT_ENCODE_SIZE, encode_host_size)
-                continue
-            if TYPE_CHECKING:
-                assert not isinstance(size, object)
-            if size > encode_host_size:
-                encode_host_size = size
+            elif encode_host_size is _SENTINEL:
+                if size is not _SENTINEL:
+                    encode_host_size = size
+            elif size is not _SENTINEL:
+                if TYPE_CHECKING:
+                    assert isinstance(size, int)
+                    assert isinstance(encode_host_size, int)
+                encode_host_size = max(size, encode_host_size)
+        if encode_host_size is _SENTINEL:
+            encode_host_size = _DEFAULT_ENCODE_SIZE
 
     if TYPE_CHECKING:
         assert not isinstance(encode_host_size, object)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1481,9 +1481,12 @@ def cache_configure(
                 )
             if size is None:
                 encode_host_size = None
-                break
-            elif size is _SENTINEL:
-                size = _DEFAULT_ENCODE_SIZE
+                continue
+            if encode_host_size is None:
+                continue
+            if size is _SENTINEL:
+                encode_host_size = max(_DEFAULT_ENCODE_SIZE, encode_host_size)
+                continue
             if TYPE_CHECKING:
                 assert not isinstance(size, object)
             if size > encode_host_size:


### PR DESCRIPTION
The loop variable `size` should not get redefined. Python `for` doesn't define its own scope. Add more coverage to make sure everything works as expected with the backwards compat.