### PR TITLE
Move `split_url` cache around encoding the URL

### DIFF
--- a/CHANGES/1369.misc.rst
+++ b/CHANGES/1369.misc.rst
@@ -1,1 +1,1 @@
-Reworked the internal encoding cache to improve performance on cache hit -- by:user:`bdraco`.
+Reworked the internal encoding cache to improve performance on cache hit -- by :user:`bdraco`.

--- a/CHANGES/1369.misc.rst
+++ b/CHANGES/1369.misc.rst
@@ -1,0 +1,1 @@
+Reworked the internal encoding cache to improve performance on cache hit -- by:user:`bdraco`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -71,9 +71,9 @@ def test_origin():
     assert URL("http://example.com:8888") == url.origin()
 
 
-def test_origin_is_self():
+def test_origin_is_equal_to_self():
     url = URL("http://example.com:8888")
-    assert url.origin() is url
+    assert url.origin() == url
 
 
 def test_origin_with_no_auth():
@@ -1737,7 +1737,7 @@ def test_str_for_empty_url():
 
 def test_parent_for_empty_url():
     url = URL()
-    assert url is url.parent
+    assert url == url.parent
 
 
 def test_parent_for_relative_url_with_child():

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -78,7 +78,7 @@ def split_url(url: str) -> tuple[str, str, str, str, str]:
         url, _, query = url.partition("?")
     if netloc and not netloc.isascii():
         _check_netloc(netloc)
-    return (scheme, netloc, url, query, fragment)
+    return scheme, netloc, url, query, fragment
 
 
 def _check_netloc(netloc: str) -> None:

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -4,7 +4,7 @@ import re
 import unicodedata
 from functools import lru_cache
 from typing import Union
-from urllib.parse import SplitResult, scheme_chars, uses_netloc
+from urllib.parse import scheme_chars, uses_netloc
 
 from ._quoters import QUOTER
 
@@ -20,8 +20,7 @@ UNSAFE_URL_BYTES_TO_REMOVE = ["\t", "\r", "\n"]
 USES_AUTHORITY = frozenset(uses_netloc)
 
 
-@lru_cache
-def split_url(url: str) -> SplitResult:
+def split_url(url: str) -> tuple[str, str, str, str, str]:
     """Split URL into parts."""
     # Adapted from urllib.parse.urlsplit
     # Only lstrip url as some applications rely on preserving trailing space.
@@ -79,7 +78,7 @@ def split_url(url: str) -> SplitResult:
         url, _, query = url.partition("?")
     if netloc and not netloc.isascii():
         _check_netloc(netloc)
-    return tuple.__new__(SplitResult, (scheme, netloc, url, query, fragment))
+    return (scheme, netloc, url, query, fragment)
 
 
 def _check_netloc(netloc: str) -> None:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -121,11 +121,8 @@ def rewrite_module(obj: _T) -> _T:
     return obj
 
 
-# encoded is used for the LRU cache key only; Do not remove it
-# as it would mean encoded and non-encoded URLs would share the same cache
-# and result in incorrect encoding for non-encoded URLs
 @lru_cache
-def encode_url(url_str: str, encoded: bool) -> tuple[SplitResult, _InternalURLCache]:
+def encode_url(url_str: str) -> tuple[SplitResult, _InternalURLCache]:
     """Encode URL."""
     cache: _InternalURLCache = {}
     host: Union[str, None]
@@ -267,7 +264,7 @@ class URL:
         if strict is not None:  # pragma: no cover
             warnings.warn("strict parameter is ignored")
         if type(val) is str:
-            split_result, cache = encode_url(val, encoded)
+            split_result, cache = encode_url(val)
         elif type(val) is cls:
             return val
         elif type(val) is SplitResult:
@@ -276,7 +273,7 @@ class URL:
             split_result = val
             cache = {}
         elif isinstance(val, str):
-            split_result, cache = encode_url(str(val), encoded)
+            split_result, cache = encode_url(str(val))
         else:
             raise TypeError("Constructor parameter should be str")
         self = object.__new__(cls)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -267,21 +267,18 @@ class URL:
         if strict is not None:  # pragma: no cover
             warnings.warn("strict parameter is ignored")
         if type(val) is str:
-            pass
+            split_result, cache = encode_url(val, encoded)
         elif type(val) is cls:
             return val
         elif type(val) is SplitResult:
             if not encoded:
                 raise ValueError("Cannot apply decoding to SplitResult")
-            url = object.__new__(cls)
-            url._val = val
-            url._cache = {}
-            return url
+            split_result = val
+            cache = {}
         elif isinstance(val, str):
-            val = str(val)
+            split_result, cache = encode_url(str(val), encoded)
         else:
             raise TypeError("Constructor parameter should be str")
-        split_result, cache = encode_url(val, encoded)
         url = object.__new__(cls)
         url._val = split_result
         url._cache = cache

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -123,7 +123,7 @@ def rewrite_module(obj: _T) -> _T:
 
 @lru_cache
 def encode_url(url_str: str) -> tuple[SplitResult, _InternalURLCache]:
-    """Encode URL."""
+    """Parse unencoded URL."""
     cache: _InternalURLCache = {}
     host: Union[str, None]
     scheme, netloc, path, query, fragment = split_url(url_str)
@@ -181,7 +181,7 @@ def encode_url(url_str: str) -> tuple[SplitResult, _InternalURLCache]:
 
 @lru_cache
 def pre_encoded_url(url_str: str) -> tuple[SplitResult, _InternalURLCache]:
-    """Pre-encoded URL."""
+    """Parse pre-encoded URL."""
     return tuple.__new__(SplitResult, split_url(url_str)), {}
 
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -268,22 +268,19 @@ class URL:
         if strict is not None:  # pragma: no cover
             warnings.warn("strict parameter is ignored")
         if type(val) is str:
-            pass
-        elif type(val) is cls:
+            return _encode_url(val)
+        if type(val) is cls:
             return val
-        elif type(val) is SplitResult:
+        if type(val) is SplitResult:
             if not encoded:
                 raise ValueError("Cannot apply decoding to SplitResult")
             self = object.__new__(cls)
             self._val = val
             self._cache = {}
             return self
-        elif isinstance(val, str):
-            val = str(val)
-        else:
-            raise TypeError("Constructor parameter should be str")
-
-        return _encode_url(val)
+        if isinstance(val, str):
+            return _encode_url(str(val))
+        raise TypeError("Constructor parameter should be str")
 
     @classmethod
     def build(

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -279,10 +279,10 @@ class URL:
             split_result, cache = encode_url(str(val), encoded)
         else:
             raise TypeError("Constructor parameter should be str")
-        url = object.__new__(cls)
-        url._val = split_result
-        url._cache = cache
-        return url
+        self = object.__new__(cls)
+        self._val = split_result
+        self._cache = cache
+        return self
 
     @classmethod
     def build(

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -182,8 +182,7 @@ def encode_url(url_str: str) -> tuple[SplitResult, _InternalURLCache]:
 @lru_cache
 def pre_encoded_url(url_str: str) -> tuple[SplitResult, _InternalURLCache]:
     """Pre-encoded URL."""
-    cache: _InternalURLCache = {}
-    return tuple.__new__(SplitResult, split_url(url_str)), cache
+    return tuple.__new__(SplitResult, split_url(url_str)), {}
 
 
 @rewrite_module

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -121,8 +121,10 @@ def rewrite_module(obj: _T) -> _T:
     return obj
 
 
+# encoded is used for the LRU cache key only
+# do not remove it
 @lru_cache
-def encode_url(url_str: str) -> tuple[SplitResult, _InternalURLCache]:
+def encode_url(url_str: str, encoded: bool) -> tuple[SplitResult, _InternalURLCache]:
     """Encode URL."""
     cache: _InternalURLCache = {}
     host: Union[str, None]
@@ -278,10 +280,10 @@ class URL:
             val = str(val)
         else:
             raise TypeError("Constructor parameter should be str")
-        split_result, cache = encode_url(val)
+        split_result, cache = encode_url(val, encoded)
         url = object.__new__(cls)
         url._val = split_result
-        url._cache = cache.copy()
+        url._cache = cache
         return url
 
     @classmethod

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -264,18 +264,25 @@ class URL:
         if strict is not None:  # pragma: no cover
             warnings.warn("strict parameter is ignored")
         if type(val) is str:
-            split_result, cache = encode_url(val)
+            pass
         elif type(val) is cls:
             return val
         elif type(val) is SplitResult:
             if not encoded:
                 raise ValueError("Cannot apply decoding to SplitResult")
-            split_result = val
-            cache = {}
+            self = object.__new__(cls)
+            self._val = val
+            self._cache = {}
+            return self
         elif isinstance(val, str):
-            split_result, cache = encode_url(str(val))
+            val = str(val)
         else:
             raise TypeError("Constructor parameter should be str")
+        if not encoded:
+            split_result, cache = encode_url(val)
+        else:
+            cache = {}
+            split_result = tuple.__new__(SplitResult, split_url(val))
         self = object.__new__(cls)
         self._val = split_result
         self._cache = cache

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -121,8 +121,9 @@ def rewrite_module(obj: _T) -> _T:
     return obj
 
 
-# encoded is used for the LRU cache key only
-# do not remove it
+# encoded is used for the LRU cache key only do not remove it
+# as it would mean encoded and non-encoded URLs would share the same cache
+# and result in incorrect encoding for non-encoded URLs
 @lru_cache
 def encode_url(url_str: str, encoded: bool) -> tuple[SplitResult, _InternalURLCache]:
     """Encode URL."""

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -121,7 +121,7 @@ def rewrite_module(obj: _T) -> _T:
     return obj
 
 
-# encoded is used for the LRU cache key only do not remove it
+# encoded is used for the LRU cache key only; Do not remove it
 # as it would mean encoded and non-encoded URLs would share the same cache
 # and result in incorrect encoding for non-encoded URLs
 @lru_cache

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -179,6 +179,13 @@ def encode_url(url_str: str) -> tuple[SplitResult, _InternalURLCache]:
     return tuple.__new__(SplitResult, (scheme, netloc, path, query, fragment)), cache
 
 
+@lru_cache
+def pre_encoded_url(url_str: str) -> tuple[SplitResult, _InternalURLCache]:
+    """Pre-encoded URL."""
+    cache: _InternalURLCache = {}
+    return tuple.__new__(SplitResult, split_url(url_str)), cache
+
+
 @rewrite_module
 class URL:
     # Don't derive from str
@@ -278,11 +285,10 @@ class URL:
             val = str(val)
         else:
             raise TypeError("Constructor parameter should be str")
-        if not encoded:
-            split_result, cache = encode_url(val)
+        if encoded:
+            split_result, cache = pre_encoded_url(val)
         else:
-            cache = {}
-            split_result = tuple.__new__(SplitResult, split_url(val))
+            split_result, cache = encode_url(val)
         self = object.__new__(cls)
         self._val = split_result
         self._cache = cache

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -263,7 +263,7 @@ class URL:
         *,
         encoded: bool = False,
         strict: Union[bool, None] = None,
-    ) -> "URL":
+    ) -> Self:
         if strict is not None:  # pragma: no cover
             warnings.warn("strict parameter is ignored")
         if type(val) is str:


### PR DESCRIPTION
Now that we have own url splitting implementation, we can move the cache one level higher so we can cache more of the url encoding.

We can avoid the case where we have to reconstruct the `SplitResult` after the quoter the values since the `SplitResult` is now only generated after all the work is done.