### PR TITLE
Release 1.16.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,54 @@ Changelog
 
 .. towncrier release notes start
 
+1.16.0
+======
+
+*(2024-10-21)*
+
+
+Bug fixes
+---------
+
+- Fixed blocking I/O to load Python code when creating a new :class:`~yarl.URL` with non-ascii characters in the network location part -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1342`.
+
+
+Removals and backward incompatible breaking changes
+---------------------------------------------------
+
+- Migrated to using a single cache for encoding hosts -- by :user:`bdraco`.
+
+  Passing ``ip_address_size`` and ``host_validate_size`` to :py:meth:`~yarl.cache_configure` is deprecated in favor of the new ``encode_host_size`` parameter and will be removed in a future release. For backwards compatibility, the old parameters affect the ``encode_host`` cache size.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1348`, :issue:`1357`, :issue:`1363`.
+
+
+Miscellaneous internal changes
+------------------------------
+
+- Improved performance of constructing :class:`~yarl.URL` -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1336`.
+
+- Improved performance of calling :py:meth:`~yarl.URL.build` and constructing unencoded :class:`~yarl.URL` -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1345`.
+
+- Reworked the internal encoding cache to improve performance on cache hit -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1369`.
+
+
+----
+
+
 1.15.5
 ======
 

--- a/CHANGES/1336.misc.rst
+++ b/CHANGES/1336.misc.rst
@@ -1,1 +1,0 @@
-Improved performance of constructing :class:`~yarl.URL` -- by :user:`bdraco`.

--- a/CHANGES/1342.bugfix.rst
+++ b/CHANGES/1342.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed blocking I/O to load Python code when creating a new :class:`~yarl.URL` with non-ascii characters in the network location part -- by :user:`bdraco`.

--- a/CHANGES/1345.misc.rst
+++ b/CHANGES/1345.misc.rst
@@ -1,1 +1,0 @@
-Improved performance of calling :py:meth:`~yarl.URL.build` and constructing unencoded :class:`~yarl.URL` -- by :user:`bdraco`.

--- a/CHANGES/1348.breaking.rst
+++ b/CHANGES/1348.breaking.rst
@@ -1,3 +1,0 @@
-Migrated to using a single cache for encoding hosts -- by :user:`bdraco`.
-
-Passing ``ip_address_size`` and ``host_validate_size`` to :py:meth:`~yarl.cache_configure` is deprecated in favor of the new ``encode_host_size`` parameter and will be removed in a future release. For backwards compatibility, the old parameters affect the ``encode_host`` cache size.

--- a/CHANGES/1357.breaking.rst
+++ b/CHANGES/1357.breaking.rst
@@ -1,1 +1,0 @@
-1348.breaking.rst

--- a/CHANGES/1363.breaking.rst
+++ b/CHANGES/1363.breaking.rst
@@ -1,1 +1,0 @@
-1348.breaking.rst

--- a/CHANGES/1369.misc.rst
+++ b/CHANGES/1369.misc.rst
@@ -1,1 +1,0 @@
-Reworked the internal encoding cache to improve performance on cache hit -- by :user:`bdraco`.

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,7 +1,7 @@
 from ._query import Query, QueryVariable, SimpleQuery
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.16.0.dev0"
+__version__ = "1.16.0"
 
 __all__ = (
     "URL",


### PR DESCRIPTION
<img width="523" alt="Screenshot 2024-10-21 at 10 48 24 AM" src="https://github.com/user-attachments/assets/b67658fa-a5ea-45d2-a48e-05de8c4a033e">
