### PR TITLE
Use faster built-in walk_up implementation for calculate_relative_path on Python 3.12+

### DIFF
--- a/CHANGES/1381.feature.rst
+++ b/CHANGES/1381.feature.rst
@@ -1,0 +1,1 @@
+1340.feature.rst

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -61,6 +61,7 @@ def calculate_relative_path(target: str, base: str) -> str:
     if sys.version_info >= (3, 12):
         return str(target_path.relative_to(base_path, walk_up=True))
 
+    # For Python 3.11 and below, we need to implement the walk_up logic ourselves
     for step, path in enumerate((base_path, *base_path.parents)):
         if target_path.is_relative_to(path):
             break

--- a/yarl/_path.py
+++ b/yarl/_path.py
@@ -1,5 +1,6 @@
 """Utilities for working with paths."""
 
+import sys
 from collections.abc import Sequence
 from contextlib import suppress
 from pathlib import PurePosixPath
@@ -56,6 +57,9 @@ def calculate_relative_path(target: str, base: str) -> str:
 
     if not base[-1] == "/":
         base_path = base_path.parent
+
+    if sys.version_info >= (3, 12):
+        return str(target_path.relative_to(base_path, walk_up=True))
 
     for step, path in enumerate((base_path, *base_path.parents)):
         if target_path.is_relative_to(path):


### PR DESCRIPTION
For Python 3.12+ we can use the built-in walk_up implementation in pathlib.