### PR TITLE
Rework of the URL subtraction feature

### DIFF
--- a/CHANGES/1392.feature.rst
+++ b/CHANGES/1392.feature.rst
@@ -1,0 +1,22 @@
+Added support for using the :meth:`subtraction operator <yarl.URL.__sub__>`
+to get the relative path between URLs.
+
+Note that both URLs must have the same scheme, user, password, host and port:
+
+.. code-block:: pycon
+
+   >>> target = URL("http://example.com/path/index.html")
+   >>> base = URL("http://example.com/")
+   >>> target - base
+   URL('path/index.html')
+
+URLs can also be relative:
+
+.. code-block:: pycon
+
+   >>> target = URL("/")
+   >>> base = URL("/path/index.html")
+   >>> target - base
+   URL('..')
+
+-- by :user:`oleksbabieiev`

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -997,6 +997,20 @@ The path is encoded if needed.
          >>> base.join(URL('//python.org/page.html'))
          URL('http://python.org/page.html')
 
+.. method:: URL.__sub__(url)
+
+   Return a new URL with a relative *path* between two other URL objects.
+   *scheme*, *user*, *password*, *host*, *port*, *query* and *fragment* are removed.
+
+   .. doctest::
+
+      >>> target = URL('http://example.com/path/index.html')
+      >>> base = URL('http://example.com/')
+      >>> target - base
+      URL('path/index.html')
+
+   .. versionadded:: 1.17
+
 Human readable representation
 -----------------------------
 

--- a/tests/test_url_benchmarks.py
+++ b/tests/test_url_benchmarks.py
@@ -18,11 +18,14 @@ QUERY_URL_STR = "http://www.domain.tld?query=1&query=2&query=3&query=4&query=5"
 QUERY_URL = URL(QUERY_URL_STR)
 URL_WITH_PATH_STR = "http://www.domain.tld/req"
 URL_WITH_PATH = URL(URL_WITH_PATH_STR)
+URL_WITH_LONGER_PATH = URL("http://www.domain.tld/req/req/req")
 REL_URL = URL("/req")
 QUERY_SEQ = {str(i): tuple(str(j) for j in range(10)) for i in range(10)}
 SIMPLE_QUERY = {str(i): str(i) for i in range(10)}
 SIMPLE_INT_QUERY = {str(i): i for i in range(10)}
 QUERY_STRING = "x=y&z=1"
+URL_VERY_LONG_PATH = URL("http://www.domain.tld/" + "req/" * 100)
+URL_LONG_PATH = URL("http://www.domain.tld/" + "req/" * 30)
 
 
 class _SubClassedStr(str):
@@ -584,6 +587,20 @@ def test_empty_query(benchmark: BenchmarkFixture) -> None:
     def _run() -> None:
         for url in urls:
             url.query
+
+
+def test_url_subtract(benchmark: BenchmarkFixture) -> None:
+    @benchmark
+    def _run() -> None:
+        for _ in range(100):
+            URL_WITH_LONGER_PATH - URL_WITH_PATH
+
+
+def test_url_subtract_long_urls(benchmark: BenchmarkFixture) -> None:
+    @benchmark
+    def _run() -> None:
+        for _ in range(100):
+            URL_VERY_LONG_PATH - URL_LONG_PATH
 
 
 def test_url_host_port_subcomponent(benchmark: BenchmarkFixture) -> None:


### PR DESCRIPTION
## What do these changes do?

Rework of the feature added in #1340 and removed in #1391 

## Are there changes in behavior for the user?

Being able to calculate the relative path between two URLs using the subtraction syntax:

```py
from yarl import URL

target = URL("http://example.com/path/index.html")
base = URL("http://example.com/path/")

rel = target - base

print(rel)  # output: "index.html"
```

## Related issue number

Resolves #1183 

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes

## Known issues

- [ ] Time complexity is roughly O(base_path_segments * target_path_segments)
- [ ] Empty segments are not handled correctly #1388 
- [ ] Potentially handling special cases with leading/trailing slashes #1388 