### PR TITLE
Release 1.17.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,24 @@ Changelog
 
 .. towncrier release notes start
 
+1.17.0
+======
+
+*(2024-10-28)*
+
+
+Features
+--------
+
+- Added :attr:`~yarl.URL.host_port_subcomponent` which returns the :rfc:`3986#section-3.2.2` host and :rfc:`3986#section-3.2.3` port subcomponent -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1375`.
+
+
+----
+
+
 1.16.0
 ======
 

--- a/CHANGES/1375.feature.rst
+++ b/CHANGES/1375.feature.rst
@@ -1,1 +1,0 @@
-Added :attr:`~yarl.URL.host_port_subcomponent` which returns the :rfc:`3986#section-3.2.2` host and :rfc:`3986#section-3.2.3` port subcomponent -- by :user:`bdraco`.

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,7 +1,7 @@
 from ._query import Query, QueryVariable, SimpleQuery
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.17.0.dev0"
+__version__ = "1.17.0"
 
 __all__ = (
     "URL",


### PR DESCRIPTION
<img width="690" alt="Screenshot 2024-10-28 at 9 55 00 AM" src="https://github.com/user-attachments/assets/c3f48a1c-a3f1-4c99-834b-1b931164bc40">
