### PR TITLE
Complete removal of `SplitResult` as an internal

### DIFF
--- a/CHANGES/1396.misc.rst
+++ b/CHANGES/1396.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of building and accessing :class:`~yarl.URL` properties -- by :user:`bdraco`.

--- a/CHANGES/1396.misc.rst
+++ b/CHANGES/1396.misc.rst
@@ -1,1 +1,1 @@
-Improved performance of building and accessing :class:`~yarl.URL` properties -- by :user:`bdraco`.
+Improved performance many :class:`~yarl.URL` methods -- by :user:`bdraco`.

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -18,15 +18,7 @@ def test_pickle():
 def test_default_style_state():
     u = URL("test")
     hash(u)
-    u.__setstate__(
-        (
-            None,
-            {
-                "_val": ("test", "test", "test", "test", "test"),
-                "_strict": False,
-                "_cache": {"hash": 1},
-            },
-        )
-    )
+    val = ("test", "test", "test", "test", "test")
+    u.__setstate__((None, {"_val": val, "_strict": False, "_cache": {"hash": 1}}))
     assert not u._cache
-    assert u._val == ("test", "test", "test", "test", "test")
+    assert u._val == val

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -18,6 +18,15 @@ def test_pickle():
 def test_default_style_state():
     u = URL("test")
     hash(u)
-    u.__setstate__((None, {"_val": "test", "_strict": False, "_cache": {"hash": 1}}))
+    u.__setstate__(
+        (
+            None,
+            {
+                "_val": ("test", "test", "test", "test", "test"),
+                "_strict": False,
+                "_cache": {"hash": 1},
+            },
+        )
+    )
     assert not u._cache
-    assert u._val == "test"
+    assert u._val == ("test", "test", "test", "test", "test")

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -132,13 +132,13 @@ def test_scheme():
 def test_raw_user():
     url = URL("http://user@example.com")
     assert "user" == url.raw_user
-    assert url.raw_user == url._val.username
+    assert url.raw_user == SplitResult(*url._val).username
 
 
 def test_raw_user_non_ascii():
     url = URL("http://бажан@example.com")
     assert "%D0%B1%D0%B0%D0%B6%D0%B0%D0%BD" == url.raw_user
-    assert url.raw_user == url._val.username
+    assert url.raw_user == SplitResult(*url._val).username
 
 
 def test_no_user():
@@ -154,13 +154,13 @@ def test_user_non_ascii():
 def test_raw_password():
     url = URL("http://user:password@example.com")
     assert "password" == url.raw_password
-    assert url.raw_password == url._val.password
+    assert url.raw_password == SplitResult(*url._val).password
 
 
 def test_raw_password_non_ascii():
     url = URL("http://user:пароль@example.com")
     assert "%D0%BF%D0%B0%D1%80%D0%BE%D0%BB%D1%8C" == url.raw_password
-    assert url.raw_password == url._val.password
+    assert url.raw_password == SplitResult(*url._val).password
 
 
 def test_password_non_ascii():
@@ -179,7 +179,7 @@ def test_empty_password_without_user():
     assert url.user is None
     assert url.password == ""
     assert url.raw_password == ""
-    assert url.raw_password == url._val.password
+    assert url.raw_password == SplitResult(*url._val).password
 
 
 def test_user_empty_password():
@@ -191,7 +191,7 @@ def test_user_empty_password():
 def test_raw_host():
     url = URL("http://example.com")
     assert "example.com" == url.raw_host
-    assert url.raw_host == url._val.hostname
+    assert url.raw_host == SplitResult(*url._val).hostname
 
 
 @pytest.mark.parametrize(
@@ -244,7 +244,7 @@ def test_invalid_idna_a_label_encoding():
 def test_raw_host_non_ascii():
     url = URL("http://оун-упа.укр")
     assert "xn----8sb1bdhvc.xn--j1amh" == url.raw_host
-    assert url.raw_host == url._val.hostname
+    assert url.raw_host == SplitResult(*url._val).hostname
 
 
 def test_host_non_ascii():
@@ -265,19 +265,19 @@ def test_host_with_underscore():
 def test_raw_host_when_port_is_specified():
     url = URL("http://example.com:8888")
     assert "example.com" == url.raw_host
-    assert url.raw_host == url._val.hostname
+    assert url.raw_host == SplitResult(*url._val).hostname
 
 
 def test_raw_host_from_str_with_ipv4():
     url = URL("http://127.0.0.1:80")
     assert url.raw_host == "127.0.0.1"
-    assert url.raw_host == url._val.hostname
+    assert url.raw_host == SplitResult(*url._val).hostname
 
 
 def test_raw_host_from_str_with_ipv6():
     url = URL("http://[::1]:80")
     assert url.raw_host == "::1"
-    assert url.raw_host == url._val.hostname
+    assert url.raw_host == SplitResult(*url._val).hostname
 
 
 def test_authority_full() -> None:
@@ -311,13 +311,13 @@ def test_lowercase():
     url = URL("http://gitHUB.com")
     assert url.raw_host == "github.com"
     assert url.host == url.raw_host
-    assert url.raw_host == url._val.hostname
+    assert url.raw_host == SplitResult(*url._val).hostname
 
 
 def test_lowercase_nonascii():
     url = URL("http://Слава.Укр")
     assert url.raw_host == "xn--80aaf8a3a.xn--j1amh"
-    assert url.raw_host == url._val.hostname
+    assert url.raw_host == SplitResult(*url._val).hostname
     assert url.host == "слава.укр"
 
 
@@ -325,7 +325,7 @@ def test_compressed_ipv6():
     url = URL("http://[1DEC:0:0:0::1]")
     assert url.raw_host == "1dec::1"
     assert url.host == url.raw_host
-    assert url.raw_host == url._val.hostname
+    assert url.raw_host == SplitResult(*url._val).hostname
 
 
 def test_ipv6_missing_left_bracket():
@@ -353,19 +353,19 @@ def test_ipv4_zone():
     url = URL("http://1.2.3.4%тест%42:123")
     assert url.raw_host == "1.2.3.4%тест%42"
     assert url.host == url.raw_host
-    assert url.raw_host == url._val.hostname
+    assert url.raw_host == SplitResult(*url._val).hostname
 
 
 def test_port_for_explicit_port():
     url = URL("http://example.com:8888")
     assert 8888 == url.port
-    assert url.explicit_port == url._val.port
+    assert url.explicit_port == SplitResult(*url._val).port
 
 
 def test_port_for_implicit_port():
     url = URL("http://example.com")
     assert 80 == url.port
-    assert url.explicit_port == url._val.port
+    assert url.explicit_port == SplitResult(*url._val).port
 
 
 def test_port_for_relative_url():
@@ -383,25 +383,25 @@ def test_port_for_unknown_scheme():
 def test_explicit_port_for_explicit_port():
     url = URL("http://example.com:8888")
     assert 8888 == url.explicit_port
-    assert url.explicit_port == url._val.port
+    assert url.explicit_port == SplitResult(*url._val).port
 
 
 def test_explicit_port_for_implicit_port():
     url = URL("http://example.com")
     assert url.explicit_port is None
-    assert url.explicit_port == url._val.port
+    assert url.explicit_port == SplitResult(*url._val).port
 
 
 def test_explicit_port_for_relative_url():
     url = URL("/path/to")
     assert url.explicit_port is None
-    assert url.explicit_port == url._val.port
+    assert url.explicit_port == SplitResult(*url._val).port
 
 
 def test_explicit_port_for_unknown_scheme():
     url = URL("unknown://example.com")
     assert url.explicit_port is None
-    assert url.explicit_port == url._val.port
+    assert url.explicit_port == SplitResult(*url._val).port
 
 
 def test_raw_path_string_empty():
@@ -1563,7 +1563,7 @@ def test_is_default_port_for_unknown_scheme():
 def test_handling_port_zero():
     url = URL("http://example.com:0")
     assert url.explicit_port == 0
-    assert url.explicit_port == url._val.port
+    assert url.explicit_port == SplitResult(*url._val).port
     assert str(url) == "http://example.com:0"
     assert not url.is_default_port()
 
@@ -1767,13 +1767,13 @@ def test_parent_for_empty_url():
 def test_parent_for_relative_url_with_child():
     url = URL("path/to")
     assert url.parent == URL("path")
-    assert url.parent._val.path == "path"
+    assert SplitResult(*url.parent._val).path == "path"
 
 
 def test_parent_for_relative_url():
     url = URL("path")
     assert url.parent == URL("")
-    assert url.parent._val.path == ""
+    assert SplitResult(*url.parent._val).path == ""
 
 
 def test_parent_for_no_netloc_url():
@@ -1784,7 +1784,7 @@ def test_parent_for_no_netloc_url():
 def test_parent_for_top_level_no_netloc_url():
     url = URL("/")
     assert url.parent == URL("/")
-    assert url.parent._val.path == "/"
+    assert SplitResult(*url.parent._val).path == "/"
 
 
 def test_parent_for_absolute_url():
@@ -1795,7 +1795,7 @@ def test_parent_for_absolute_url():
 def test_parent_for_top_level_absolute_url():
     url = URL("http://go.to/")
     assert url.parent == URL("http://go.to/")
-    assert url.parent._val.path == "/"
+    assert SplitResult(*url.parent._val).path == "/"
 
 
 def test_empty_value_for_query():

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -1,3 +1,5 @@
+from urllib.parse import SplitResult
+
 import pytest
 
 from yarl import URL
@@ -616,6 +618,7 @@ def test_url_round_trips(
 ) -> None:
     """Verify that URLs round-trip correctly."""
     parsed = URL(url)
+    assert SplitResult(*parsed._val).hostname == hostname_without_brackets
     assert parsed.raw_host == hostname_without_brackets
     assert parsed.host_subcomponent == hostname
     assert str(parsed) == url

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -616,7 +616,6 @@ def test_url_round_trips(
 ) -> None:
     """Verify that URLs round-trip correctly."""
     parsed = URL(url)
-    assert parsed._val.hostname == hostname_without_brackets
     assert parsed.raw_host == hostname_without_brackets
     assert parsed.host_subcomponent == hostname
     assert str(parsed) == url

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -3,7 +3,7 @@
 import re
 import unicodedata
 from functools import lru_cache
-from typing import Union
+from typing import Final, Union
 from urllib.parse import scheme_chars, uses_netloc
 
 from ._quoters import QUOTER
@@ -19,8 +19,15 @@ WHATWG_C0_CONTROL_OR_SPACE = (
 UNSAFE_URL_BYTES_TO_REMOVE = ["\t", "\r", "\n"]
 USES_AUTHORITY = frozenset(uses_netloc)
 
+SplitURL = tuple[str, str, str, str, str]
+SCHEME: Final[int] = 0
+NETLOC: Final[int] = 1
+PATH: Final[int] = 2
+QUERY: Final[int] = 3
+FRAGMENT: Final[int] = 4
 
-def split_url(url: str) -> tuple[str, str, str, str, str]:
+
+def split_url(url: str) -> SplitURL:
     """Split URL into parts."""
     # Adapted from urllib.parse.urlsplit
     # Only lstrip url as some applications rely on preserving trailing space.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -4,14 +4,25 @@ import warnings
 from collections.abc import Mapping, Sequence
 from functools import _CacheInfo, lru_cache
 from ipaddress import ip_address
-from typing import TYPE_CHECKING, Any, Final, TypedDict, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, Union, overload
 from urllib.parse import SplitResult, parse_qsl, uses_relative
 
 import idna
 from multidict import MultiDict, MultiDictProxy
 from propcache.api import under_cached_property as cached_property
 
-from ._parse import USES_AUTHORITY, make_netloc, split_netloc, split_url, unsplit_result
+from ._parse import (
+    FRAGMENT,
+    NETLOC,
+    QUERY,
+    SCHEME,
+    USES_AUTHORITY,
+    SplitURL,
+    make_netloc,
+    split_netloc,
+    split_url,
+    unsplit_result,
+)
 from ._path import normalize_path, normalize_path_segments
 from ._query import (
     Query,
@@ -62,12 +73,7 @@ NOT_REG_NAME = re.compile(
 )
 
 _T = TypeVar("_T")
-SplitURL = tuple[str, str, str, str, str]
-SCHEME: Final[int] = 0
-NETLOC: Final[int] = 1
-PATH: Final[int] = 2
-QUERY: Final[int] = 3
-FRAGMENT: Final[int] = 4
+
 
 if sys.version_info >= (3, 11):
     from typing import Self

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -430,11 +430,13 @@ class URL:
         if type(other) is not URL:
             return NotImplemented
 
-        scheme1, netloc1, path1, query1, fragment1 = self._val
+        val1 = self._val
+        scheme1, netloc1, path1, query1, fragment1 = val1
         if not path1 and netloc1:
             val1 = (scheme1, netloc1, "/", query1, fragment1)
 
-        scheme2, netloc2, path2, query2, fragment2 = other._val
+        val2 = other._val
+        scheme2, netloc2, path2, query2, fragment2 = val2
         if not path2 and netloc2:
             val2 = (scheme2, netloc2, "/", query2, fragment2)
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -185,10 +185,6 @@ def encode_url(url_str: str) -> tuple[SplitURL, _InternalURLCache]:
     cache["scheme"] = scheme
     cache["raw_query_string"] = query
     cache["raw_fragment"] = fragment
-    # Constructing the tuple directly to avoid the overhead of
-    # the lambda and arg processing since NamedTuples are constructed
-    # with a run time built lambda
-    # https://github.com/python/cpython/blob/d83fcf8371f2f33c7797bc8f5423a8bca8c46e5c/Lib/collections/__init__.py#L441
     return (scheme, netloc, path, query, fragment), cache
 
 
@@ -395,10 +391,6 @@ class URL:
             query_string = get_str_query(query) or ""
 
         url = object.__new__(cls)
-        # Constructing the tuple directly to avoid the overhead of the lambda and
-        # arg processing since NamedTuples are constructed with a run time built
-        # lambda
-        # https://github.com/python/cpython/blob/d83fcf8371f2f33c7797bc8f5423a8bca8c46e5c/Lib/collections/__init__.py#L441
         url._val = (scheme, netloc, path, query_string, fragment)
         url._cache = {}
         return url

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -398,7 +398,7 @@ class URL:
     def _from_tup(cls, val: SplitURL) -> "URL":
         """Create a new URL from a tuple.
 
-        The tuple should be in the form of a SplitResult.
+        The tuple should be in the form of a SplitURL.
 
         (scheme, netloc, path, query, fragment)
         """


### PR DESCRIPTION
partially implements #172

It was suggested in #172 to only upgrade to `SplitResult` when needed.  This will give us more flexibility to change how the internal structure works in the future and we won't be forever bound to using `SplitResult`.

The only place we can't fully get rid of it is for pickle without a breaking change. #172 suggested leaving it for compat, so thats what I did.

In the future we may want to change the split functions to unpack the values into named variables in future. ie `self._scheme, self._netloc, self._path, self._query, self._fragment = val` or store everything in `self._cache` as the single source of truth; However that was too large of a redesign for this PR since it would also require changing all the tuple unpacking and pre cache in `__new__`.

One consideration about getting rid of the `_val` tuple is that `SplitResult` is exposed as an allowed incoming value in new we would have to have code to convert it. With `_val` being a normal tuple, `SplitResult` can be passed in and its still compatible.

It would be a lot nicer if we stored everything in `self._cache` though since it means the `encode_url` and `pre_encoded_url` calls would return a simple dict that was pre-populated, and it also means `propcache` would have more keys pre-populated.

