### PR TITLE
Additional small cleanups to as a followup to removing `self._val`

### DIFF
--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -300,19 +300,20 @@ class URL:
         if strict is not None:  # pragma: no cover
             warnings.warn("strict parameter is ignored")
         if type(val) is str:
-            pass
-        elif type(val) is cls:
+            return pre_encoded_url(val) if encoded else encode_url(val)
+        if type(val) is cls:
             return val
-        elif type(val) is SplitResult:
+        if type(val) is SplitResult:
             if not encoded:
                 raise ValueError("Cannot apply decoding to SplitResult")
             self = object.__new__(URL)
             self._scheme, self._netloc, self._path, self._query, self._fragment = val
             self._cache = {}
             return self
-        elif isinstance(val, str):
+        if isinstance(val, str):
             val = str(val)
-        elif val is UNDEFINED:
+            return pre_encoded_url(val) if encoded else encode_url(val)
+        if val is UNDEFINED:
             # Special case for UNDEFINED since it might be unpickling and we do
             # not want to cache as the `__set_state__` call would mutate the URL
             # object in the `pre_encoded_url` or `encoded_url` caches.
@@ -324,9 +325,7 @@ class URL:
             self._fragment = ""
             self._cache = {}
             return self
-        else:
-            raise TypeError("Constructor parameter should be str")
-        return pre_encoded_url(val) if encoded else encode_url(val)
+        raise TypeError("Constructor parameter should be str")
 
     @classmethod
     def build(

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -318,6 +318,7 @@ class URL:
             # object in the `pre_encoded_url` or `encoded_url` caches.
             self = object.__new__(URL)
             self._scheme = self._netloc = self._path = self._query = self._fragment = ""
+            self._cache = {}
             return self
         raise TypeError("Constructor parameter should be str")
 

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -311,8 +311,7 @@ class URL:
             self._cache = {}
             return self
         if isinstance(val, str):
-            val = str(val)
-            return pre_encoded_url(val) if encoded else encode_url(val)
+            return pre_encoded_url(str(val)) if encoded else encode_url(str(val))
         if val is UNDEFINED:
             # Special case for UNDEFINED since it might be unpickling and we do
             # not want to cache as the `__set_state__` call would mutate the URL

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -191,12 +191,12 @@ def encode_url(url_str: str) -> "URL":
     cache["raw_query_string"] = query
     cache["raw_fragment"] = fragment
     self = object.__new__(URL)
-    self._cache = cache
     self._scheme = scheme
     self._netloc = netloc
     self._path = path
     self._query = query
     self._fragment = fragment
+    self._cache = cache
     return self
 
 
@@ -1403,8 +1403,7 @@ class URL:
         if TYPE_CHECKING:
             assert fragment is not None
         netloc = make_netloc(user, password, host, self.explicit_port)
-        scheme = self._scheme
-        return unsplit_result(scheme, netloc, path, query_string, fragment)
+        return unsplit_result(self._scheme, netloc, path, query_string, fragment)
 
 
 _DEFAULT_IDNA_SIZE = 256

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -317,12 +317,7 @@ class URL:
             # not want to cache as the `__set_state__` call would mutate the URL
             # object in the `pre_encoded_url` or `encoded_url` caches.
             self = object.__new__(URL)
-            self._scheme = ""
-            self._netloc = ""
-            self._path = ""
-            self._query = ""
-            self._fragment = ""
-            self._cache = {}
+            self._scheme = self._netloc = self._path = self._query = self._fragment = ""
             return self
         raise TypeError("Constructor parameter should be str")
 


### PR DESCRIPTION
followup to #1397

- avoid `elif` blocks
- made the `__new__` code a bit more concise
- avoid some unneeded intermediate variables
- make URL object creation always happen in the same order