### PR TITLE
📦 Cap Cython under Python 3.12+ below v3.1

### DIFF
--- a/CHANGES/1411.bugfix.rst
+++ b/CHANGES/1411.bugfix.rst
@@ -1,0 +1,1 @@
+1412.bugfix.rst

--- a/CHANGES/1411.packaging.rst
+++ b/CHANGES/1411.packaging.rst
@@ -1,0 +1,1 @@
+1412.packaging.rst

--- a/CHANGES/1412.bugfix.rst
+++ b/CHANGES/1412.bugfix.rst
@@ -1,0 +1,3 @@
+Stopped implicitly allowing the use of Cython pre-release versions when
+building the distribution package -- by :user:`ajsanchezsanz` and
+:user:`markgreene74`.

--- a/CHANGES/1412.packaging.rst
+++ b/CHANGES/1412.packaging.rst
@@ -1,0 +1,1 @@
+1412.bugfix.rst

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from shutil import copytree
 from sys import implementation as _system_implementation
 from sys import stderr as _standard_error_stream
-from sys import version_info as _python_version_tuple
 from tempfile import TemporaryDirectory
 from warnings import warn as _warn_that
 
@@ -81,9 +80,6 @@ PURE_PYTHON_CONFIG_SETTING = 'pure-python'
 
 PURE_PYTHON_ENV_VAR = 'YARL_NO_EXTENSIONS'
 """Environment variable name toggle used to opt out of making C-exts."""
-
-IS_PY3_12_PLUS = _python_version_tuple[:2] >= (3, 12)
-"""A flag meaning that the current runtime is Python 3.12 or higher."""
 
 IS_CPYTHON = _system_implementation.name == "cpython"
 """A flag meaning that the current interpreter implementation is CPython."""
@@ -378,8 +374,8 @@ def get_requires_for_build_wheel(
         )
 
     c_ext_build_deps = [] if is_pure_python_build else [
-        'Cython >= 3.0.0b3' if IS_PY3_12_PLUS  # Only Cython 3+ is compatible
-        else 'Cython',
+        'Cython ~= 3.0.0; python_version >= "3.12"',
+        'Cython; python_version < "3.12"',
     ]
 
     return _setuptools_get_requires_for_build_wheel(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Use latest Cython stable version, avoiding using pre-release versions.
Why? There is some issue with Cython 3.1.0a1 that is making the tests to fail.

## Are there changes in behavior for the user?

No

## Related issue number

Fixes https://github.com/aio-libs/yarl/issues/1411

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist - N/A
- [ ] Documentation reflects the changes -N/A
