### PR TITLE
Correctly handle zero explicit_port

### DIFF
--- a/CHANGES/1413.bugfix.rst
+++ b/CHANGES/1413.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug causing ``URL.port`` to return the default port when the given port was zero
+-- by :user:`gmacon`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -380,6 +380,12 @@ def test_port_for_unknown_scheme():
     assert url.explicit_port is None
 
 
+def test_explicit_zero_port():
+    url = URL("http://example.com:0")
+    assert url.explicit_port == 0
+    assert url.port == 0
+
+
 def test_explicit_port_for_explicit_port():
     url = URL("http://example.com:8888")
     assert 8888 == url.explicit_port

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -784,7 +784,10 @@ class URL:
         scheme without default port substitution.
 
         """
-        return self.explicit_port or self._default_port
+        port = self.explicit_port
+        if port is None:
+            port = self._default_port
+        return port
 
     @cached_property
     def explicit_port(self) -> Union[int, None]:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This changes `URL.port` to return the explicit port instead of the default port when the explicit port is zero (i.e. not-`None` but falsy).

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

The `URL.port` attribute is supposed to give the port part of the URL with a scheme-based fallback, but it incorrectly used the fallback value when the given value was zero. This fixes the bug, returning the given value even when it is zero.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
Fixes #1408

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
