### PR TITLE
Improve performances of `URL.joinpath`

### DIFF
--- a/CHANGES/1418.misc.rst
+++ b/CHANGES/1418.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the :py:meth:`~yarl.URL.joinpath` method -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -987,10 +987,7 @@ class URL:
             segments = path.split("/")
             segments.reverse()
             # remove trailing empty segment for all but the last path
-            if not last and segments[0] == "":
-                parsed += segments[1:]
-            else:
-                parsed += segments
+            parsed += segments[1:] if not last and segments[0] == "" else segments
         parsed.reverse()
 
         if (path := self._path) and (old_path_segments := path.split("/")):

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -987,12 +987,13 @@ class URL:
             segments = path.split("/")
             segments.reverse()
             # remove trailing empty segment for all but the last path
-            segment_slice_start = int(not last and segments[0] == "")
-            parsed += segments[segment_slice_start:]
+            if not last and segments[0] == "":
+                parsed += segments[1:]
+            else:
+                parsed += segments
         parsed.reverse()
 
-        path = self._path
-        if path and (old_path_segments := path.split("/")):
+        if (path := self._path) and (old_path_segments := path.split("/")):
             # If the old path ends with a slash, the last segment is an empty string
             # and should be removed before adding the new path segments.
             old_path_cutoff = -1 if old_path_segments[-1] == "" else None
@@ -1006,9 +1007,7 @@ class URL:
                 # where there was none before
                 parsed = ["", *parsed]
 
-        new_path = "/".join(parsed)
-
-        return self._from_parts(self._scheme, netloc, new_path, "", "")
+        return self._from_parts(self._scheme, netloc, "/".join(parsed), "", "")
 
     def with_scheme(self, scheme: str) -> "URL":
         """Return a new URL with scheme replaced."""

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -990,11 +990,11 @@ class URL:
             parsed += segments[1:] if not last and segments[0] == "" else segments
         parsed.reverse()
 
-        if (path := self._path) and (old_path_segments := path.split("/")):
+        if (path := self._path) and (old_segments := path.split("/")):
             # If the old path ends with a slash, the last segment is an empty string
             # and should be removed before adding the new path segments.
-            old_path_cutoff = -1 if old_path_segments[-1] == "" else None
-            parsed = [*old_path_segments[:old_path_cutoff], *parsed]
+            old = old_segments[:-1] if old_segments[-1] == "" else old_segments
+            parsed = [*old, *parsed]
 
         if netloc := self._netloc:
             # If the netloc is present, we need to ensure that the path is normalized

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -999,7 +999,7 @@ class URL:
         # If the netloc is present, inject a leading slash when adding a
         # path to an absolute URL where there was none before. If we need
         # to normalize the path, we need to reverse the segments before
-        # adding the leading slash.
+        # adding the leading slash instead of after.
         if (netloc := self._netloc) and needs_normalize:
             parsed.reverse()
             parsed = normalize_path_segments(parsed)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -997,20 +997,19 @@ class URL:
             parsed += old
 
         # If the netloc is present, inject a leading slash when adding a
-        # path to an absolute URL where there was none before. If we need
-        # to normalize the path, we need to reverse the segments before
-        # adding the leading slash instead of after.
-        if (netloc := self._netloc) and needs_normalize:
-            parsed.reverse()
-            parsed = normalize_path_segments(parsed)
-            if parsed and parsed[0] != "":
-                parsed = ["", *parsed]
-        else:
-            if netloc and parsed and parsed[-1] != "":
-                parsed.append("")
-            parsed.reverse()
+        # path to an absolute URL where there was none before.
+        if (netloc := self._netloc) and parsed and parsed[-1] != "":
+            parsed.append("")
 
-        return self._from_parts(self._scheme, netloc, "/".join(parsed), "", "")
+        parsed.reverse()
+        if not netloc or not needs_normalize:
+            return self._from_parts(self._scheme, netloc, "/".join(parsed), "", "")
+
+        path = "/".join(normalize_path_segments(parsed))
+        # If normalizing the path segments removed the leading slash, add it back.
+        if path and path[0] != "/":
+            path = f"/{path}"
+        return self._from_parts(self._scheme, netloc, path, "", "")
 
     def with_scheme(self, scheme: str) -> "URL":
         """Return a new URL with scheme replaced."""


### PR DESCRIPTION
- Avoid the slice for the common cases
- Avoid creating new lists
- Avoid reversing as long as possible so we do not have to insert at the front or create a new list since insert at 0 has O(n) time complexity, and append has O(1) time complexity