### PR TITLE
Improve performance of converting a URL to a string

### DIFF
--- a/CHANGES/1422.misc.rst
+++ b/CHANGES/1422.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of converting :class:`~yarl.URL` to a string -- by :user:`bdraco`.

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -146,10 +146,8 @@ def unsplit_result(
     if netloc or (scheme and scheme in USES_AUTHORITY) or url[:2] == "//":
         if url and url[:1] != "/":
             url = f"{scheme}://{netloc}/{url}" if scheme else f"{scheme}:{url}"
-        elif scheme:
-            url = f"{scheme}://{netloc}{url}"
         else:
-            url = f"//{netloc}{url}"
+            url = f"{scheme}://{netloc}{url}" if scheme else f"//{netloc}{url}"
     elif scheme:
         url = f"{scheme}:{url}"
     if query:

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -145,10 +145,12 @@ def unsplit_result(
     """Unsplit a URL without any normalization."""
     if netloc or (scheme and scheme in USES_AUTHORITY) or url[:2] == "//":
         if url and url[:1] != "/":
-            url = f"//{netloc or ''}/{url}"
+            url = f"{scheme}://{netloc}/{url}" if scheme else f"{scheme}:{url}"
+        elif scheme:
+            url = f"{scheme}://{netloc}{url}"
         else:
-            url = f"//{netloc or ''}{url}"
-    if scheme:
+            url = f"//{netloc}{url}"
+    elif scheme:
         url = f"{scheme}:{url}"
     if query:
         url = f"{url}?{query}"


### PR DESCRIPTION
The `or ""` check was not needed.  Avoid one branch and string copy for the common case where `scheme` is set.