### PR TITLE
Add a cache for building encoded URLs

### DIFF
--- a/CHANGES/1432.misc.rst
+++ b/CHANGES/1432.misc.rst
@@ -1,0 +1,1 @@
+Improved cache performance when :class:`~yarl.URL` objects are constructed from :py:meth:`~yarl.URL.build` with ``encoded=True`` -- by :user:`bdraco`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -222,7 +222,7 @@ def build_pre_encoded_url(
     host: str,
     port: Union[int, None],
     path: str,
-    query_string: str,
+    qs: str,
     fragment: str,
     quote_query: bool,
 ) -> "URL":
@@ -241,7 +241,7 @@ def build_pre_encoded_url(
     else:
         self._netloc = ""
     self._path = path
-    self._query = query_string
+    self._query = qs
     self._fragment = fragment
     self._cache = {}
     return self
@@ -256,7 +256,7 @@ def build_unencoded_url(
     host: str,
     port: Union[int, None],
     path: str,
-    query_string: str,
+    qs: str,
     fragment: str,
     quote_query: bool,
 ) -> "URL":
@@ -291,9 +291,7 @@ def build_unencoded_url(
             raise ValueError(msg)
 
     self._path = path
-    self._query = (
-        QUERY_QUOTER(query_string) if quote_query and query_string else query_string
-    )
+    self._query = QUERY_QUOTER(qs) if quote_query and qs else qs
     self._fragment = FRAGMENT_QUOTER(fragment) if fragment else fragment
     self._cache = {}
     return self

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -412,7 +412,6 @@ class URL:
                 path,
                 query_string,
                 fragment,
-                not query,
             )
 
         self = object.__new__(URL)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -213,6 +213,88 @@ def pre_encoded_url(url_str: str) -> "URL":
     return self
 
 
+@lru_cache
+def build_pre_encoded_url(
+    scheme: str,
+    authority: str,
+    user: Union[str, None],
+    password: Union[str, None],
+    host: str,
+    port: Union[int, None],
+    path: str,
+    query_string: str,
+    fragment: str,
+) -> "URL":
+    """Build a pre-encoded URL from parts."""
+    self = object.__new__(URL)
+    self._scheme = scheme
+    if authority:
+        self._netloc = authority
+    elif host:
+        if port is not None:
+            port = None if port == DEFAULT_PORTS.get(scheme) else port
+        if user is None and password is None:
+            self._netloc = host if port is None else f"{host}:{port}"
+        else:
+            self._netloc = make_netloc(user, password, host, port)
+    else:
+        self._netloc = ""
+    self._path = path
+    self._query = query_string
+    self._fragment = fragment
+    self._cache = {}
+    return self
+
+
+@lru_cache
+def build_unencoded_url(
+    scheme: str,
+    authority: str,
+    user: Union[str, None],
+    password: Union[str, None],
+    host: str,
+    port: Union[int, None],
+    path: str,
+    query_string: str,
+    fragment: str,
+) -> "URL":
+    """Build an unencoded URL from parts."""
+    self = object.__new__(URL)
+    self._scheme = scheme
+    _host: Union[str, None] = None
+    if authority:
+        user, password, _host, port = split_netloc(authority)
+        _host = _encode_host(_host, validate_host=False) if _host else ""
+    elif host:
+        _host = _encode_host(host, validate_host=True)
+    else:
+        self._netloc = ""
+
+    if _host is not None:
+        if port is not None:
+            port = None if port == DEFAULT_PORTS.get(scheme) else port
+        if user is None and password is None:
+            self._netloc = _host if port is None else f"{_host}:{port}"
+        else:
+            self._netloc = make_netloc(user, password, _host, port, True)
+
+    path = PATH_QUOTER(path) if path else path
+    if path and self._netloc:
+        if "." in path:
+            path = normalize_path(path)
+        if path[0] != "/":
+            msg = (
+                "Path in a URL with authority should " "start with a slash ('/') if set"
+            )
+            raise ValueError(msg)
+
+    self._path = path
+    self._query = QUERY_QUOTER(query_string) if query_string else query_string
+    self._fragment = FRAGMENT_QUOTER(fragment) if fragment else fragment
+    self._cache = {}
+    return self
+
+
 @rewrite_module
 class URL:
     # Don't derive from str
@@ -365,61 +447,21 @@ class URL:
                 '"query_string", and "fragment" args, use empty string instead.'
             )
 
-        if encoded:
-            if authority:
-                netloc = authority
-            elif host:
-                if port is not None:
-                    port = None if port == DEFAULT_PORTS.get(scheme) else port
-                if user is None and password is None:
-                    netloc = host if port is None else f"{host}:{port}"
-                else:
-                    netloc = make_netloc(user, password, host, port)
-            else:
-                netloc = ""
-        else:  # not encoded
-            _host: Union[str, None] = None
-            if authority:
-                user, password, _host, port = split_netloc(authority)
-                _host = _encode_host(_host, validate_host=False) if _host else ""
-            elif host:
-                _host = _encode_host(host, validate_host=True)
-            else:
-                netloc = ""
-
-            if _host is not None:
-                if port is not None:
-                    port = None if port == DEFAULT_PORTS.get(scheme) else port
-                if user is None and password is None:
-                    netloc = _host if port is None else f"{_host}:{port}"
-                else:
-                    netloc = make_netloc(user, password, _host, port, True)
-
-            path = PATH_QUOTER(path) if path else path
-            if path and netloc:
-                if "." in path:
-                    path = normalize_path(path)
-                if path[0] != "/":
-                    msg = (
-                        "Path in a URL with authority should "
-                        "start with a slash ('/') if set"
-                    )
-                    raise ValueError(msg)
-
-            query_string = QUERY_QUOTER(query_string) if query_string else query_string
-            fragment = FRAGMENT_QUOTER(fragment) if fragment else fragment
-
         if query:
             query_string = get_str_query(query) or ""
 
-        url = object.__new__(cls)
-        url._scheme = scheme
-        url._netloc = netloc
-        url._path = path
-        url._query = query_string
-        url._fragment = fragment
-        url._cache = {}
-        return url
+        builder = build_pre_encoded_url if encoded else build_unencoded_url
+        return builder(
+            scheme,
+            authority,
+            user,
+            password,
+            host,
+            port,
+            path,
+            query_string,
+            fragment,
+        )
 
     @classmethod
     def _from_parts(

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -224,6 +224,7 @@ def build_pre_encoded_url(
     path: str,
     query_string: str,
     fragment: str,
+    quote_query: bool,
 ) -> "URL":
     """Build a pre-encoded URL from parts."""
     self = object.__new__(URL)
@@ -257,6 +258,7 @@ def build_unencoded_url(
     path: str,
     query_string: str,
     fragment: str,
+    quote_query: bool,
 ) -> "URL":
     """Build an unencoded URL from parts."""
     self = object.__new__(URL)
@@ -289,7 +291,9 @@ def build_unencoded_url(
             raise ValueError(msg)
 
     self._path = path
-    self._query = QUERY_QUOTER(query_string) if query_string else query_string
+    self._query = (
+        QUERY_QUOTER(query_string) if quote_query and query_string else query_string
+    )
     self._fragment = FRAGMENT_QUOTER(fragment) if fragment else fragment
     self._cache = {}
     return self
@@ -461,6 +465,7 @@ class URL:
             path,
             query_string,
             fragment,
+            not query,
         )
 
     @classmethod


### PR DESCRIPTION
Since `aiohttp` `web_request` tends to see the same `URL`s over and over, its advantageous to cache building the `URL` objects. We currently have a cache for parsing URLs, but we did not have one for building URLs.  

We didn't have a cache on `URL.build`  because `URL.build` accepts a dict for the query which is not hashable. This is solved by constructing the query string before the cache is used. Note, that it may be better to avoid caching URLs with a query string in future but it didn't seem make enough difference in testing that it was worth the additional complexity.

Since `aiohttp` rarely `URL.build` with `encoded=False` we do not cache unencoded builds as the hit rate was < 50% in production testing.  The hit rate for https://github.com/aio-libs/aiohttp/blob/1fa237ffc9e7aa70cbabb68ab64d6fe03255cbc0/aiohttp/web_request.py#L429 is nearly perfect

Additionally, and similar to https://github.com/aio-libs/yarl/pull/1434 every time the new `URL` object was created it would have a new `self._cache`, but caching the build, `self._cache` will already be initialized.