### PR TITLE
Increase allowed upload time for the release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -506,7 +506,7 @@ jobs:
     - build-wheels-for-tested-arches
     - pre-setup  # transitive, for accessing settings
     runs-on: ubuntu-latest
-    timeout-minutes: 14
+    timeout-minutes: 30
 
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases


### PR DESCRIPTION
The timeout was hit at 14 minutes and the 1.18.1 release only partially uploaded
