### PR TITLE
Release 1.18.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,18 @@ Changelog
 
 .. towncrier release notes start
 
+1.18.2
+======
+
+*(2024-11-29)*
+
+
+No significant changes.
+
+
+----
+
+
 1.18.1
 ======
 

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,7 +1,7 @@
 from ._query import Query, QueryVariable, SimpleQuery
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.18.2.dev0"
+__version__ = "1.18.2"
 
 __all__ = (
     "URL",


### PR DESCRIPTION
1.18.1 timed out in the middle of the upload so I yanked it to ensure nobody ends up with a bad deployment because half the wheels were missing.

I was going to do a .post release but since PEP440 recommends not doing that for pre-release, and I've also had to explain what a post release is multiple times, I'm doing a .2 as its more strait-forward for humans
