### PR TITLE
Increment version to 1.18.3.dev0

### DIFF
--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,7 +1,7 @@
 from ._query import Query, QueryVariable, SimpleQuery
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.18.2"
+__version__ = "1.18.3.dev0"
 
 __all__ = (
     "URL",


### PR DESCRIPTION
PyPI uploads (not sure if its PyPI or GitHub) are experiencing issues at the moment as uploads are taking ~5x as much time as normal.  Both 1.18.1 (hit the workflow timeout) and 1.18.2 (token expired before it finished) failed to upload.

~~I'll try doing the release again tomorrow~~. Based on the upload times on `aiohappyeyeballs` on Sat Nov 30th, I expect a release would still fail.

Tracking https://github.com/pypa/gh-action-pypi-publish/issues/307