### PR TITLE
Ensure ASCII host case normalization happens before validation

### DIFF
--- a/CHANGES/1442.bugfix.rst
+++ b/CHANGES/1442.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed uppercase ASCII hosts being rejected -- by :user:`bdraco`.
+Fixed uppercase ASCII hosts being rejected by :meth:`URL.build() <yarl.URL.build>` and :py:meth:`~yarl.URL.with_host` -- by :user:`bdraco`.

--- a/CHANGES/1442.bugfix.rst
+++ b/CHANGES/1442.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed uppercase ascii host names being rejected -- by :user:`bdraco`.
+Fixed uppercase ASCII hosts being rejected -- by :user:`bdraco`.

--- a/CHANGES/1442.bugfix.rst
+++ b/CHANGES/1442.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed uppercase ascii host names being rejected -- by :user:`bdraco`.

--- a/CHANGES/954.bugfix.rst
+++ b/CHANGES/954.bugfix.rst
@@ -1,0 +1,1 @@
+1442.bugfix.rst

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -382,3 +382,11 @@ def test_build_with_none_query_string():
 def test_build_with_none_fragment():
     with pytest.raises(TypeError):
         URL.build(scheme="http", host="example.com", fragment=None)
+
+
+def test_build_uppercase_host():
+    u = URL.build(
+        host="UPPER.case",
+        encoded=False,
+    )
+    assert u.host == "upper.case"

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1499,6 +1499,7 @@ def _encode_host(host: str, validate_host: bool) -> str:
     if host.isascii():
         # Check for invalid characters explicitly; _idna_encode() does this
         # for non-ascii host names.
+        host = host.lower()
         if validate_host and (invalid := NOT_REG_NAME.search(host)):
             value, pos, extra = invalid.group(), invalid.start(), ""
             if value == "@" or (value == ":" and "@" in host[pos:]):
@@ -1510,7 +1511,7 @@ def _encode_host(host: str, validate_host: bool) -> str:
             raise ValueError(
                 f"Host {host!r} cannot contain {value!r} (at position {pos}){extra}"
             ) from None
-        return host.lower()
+        return host
 
     return _idna_encode(host)
 


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes a regression was introduced in https://github.com/aio-libs/yarl/pull/954 that prevented uppercase host names from working

https://github.com/aio-libs/yarl/issues/386 covered some of the paths, but we didn't have coverage for the build path

## Are there changes in behavior for the user?

Allows uppercase hosts again


## Related issue number
fixes #1441

