### PR TITLE
Release 1.18.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,33 @@ Changelog
 
 .. towncrier release notes start
 
+1.18.3
+======
+
+*(2024-12-01)*
+
+
+Bug fixes
+---------
+
+- Fixed uppercase ASCII hosts being rejected by :meth:`URL.build() <yarl.URL.build>` and :py:meth:`~yarl.URL.with_host` -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`954`, :issue:`1442`.
+
+
+Miscellaneous internal changes
+------------------------------
+
+- Improved performances of multiple path method on cache miss -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1443`.
+
+
+----
+
+
 1.18.2
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ Bug fixes
 Miscellaneous internal changes
 ------------------------------
 
-- Improved performances of multiple path method on cache miss -- by :user:`bdraco`.
+- Improved performances of multiple path properties on cache miss -- by :user:`bdraco`.
 
   *Related issues and pull requests on GitHub:*
   :issue:`1443`.

--- a/CHANGES/1442.bugfix.rst
+++ b/CHANGES/1442.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed uppercase ASCII hosts being rejected by :meth:`URL.build() <yarl.URL.build>` and :py:meth:`~yarl.URL.with_host` -- by :user:`bdraco`.

--- a/CHANGES/1443.misc.rst
+++ b/CHANGES/1443.misc.rst
@@ -1,1 +1,0 @@
-Improved performances of multiple path method on cache miss -- by :user:`bdraco`.

--- a/CHANGES/954.bugfix.rst
+++ b/CHANGES/954.bugfix.rst
@@ -1,1 +1,0 @@
-1442.bugfix.rst

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,7 +1,7 @@
 from ._query import Query, QueryVariable, SimpleQuery
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.18.3.dev0"
+__version__ = "1.18.3"
 
 __all__ = (
     "URL",


### PR DESCRIPTION
<img width="684" alt="Screenshot 2024-12-01 at 1 36 11 PM" src="https://github.com/user-attachments/assets/7085a708-b4ac-446d-944b-5de64012a6cf">

benchmark change since 1.18.0 (last successful release): https://codspeed.io/aio-libs/yarl/runs/compare/673f3e7a6b39e9df22ee032d..674cb993dd045193b356dad7