### PR TITLE
Add release branches to aiohttp tests

### DIFF
--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -27,11 +27,15 @@ jobs:
     name: Aiohttp tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        branch: ['master', '3.10', '3.11', '3.12']
     steps:
     - name: Checkout aiohttp
       uses: actions/checkout@v4
       with:
         repository: aio-libs/aiohttp
+        ref: ${{ matrix.branch }}
         submodules: true
     - name: Checkout yarl
       uses: actions/checkout@v4


### PR DESCRIPTION
## What do these changes do?

Add release branches to aiohttp tests matrix. Test yarl against aiohttp maintained releases branch.

Discussed in #1415 

## Are there changes in behavior for the user?

## Related issue number

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
