### PR TITLE
Bump Python version for benchmarks to 3.13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -382,11 +382,11 @@ jobs:
         pattern: ${{ needs.pre-setup.outputs.dists-artifact-name }}*
         merge-multiple: true
 
-    - name: Setup Python 3.12
+    - name: Setup Python 3.13
       id: python-install
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.13
         cache: pip
         cache-dependency-path: requirements/*.txt
     - name: Install dependencies


### PR DESCRIPTION
Python 3.13.1 has been released. As its rare to see performance changes in Python versions after .0, and even more rare to see them after .1 its time to start benchmarking against 3.13.1
