### PR TITLE
Drop aiohttp 3.10 from CI

### DIFF
--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        branch: ['master', '3.10', '3.11', '3.12']
+        branch: ['master', '3.11', '3.12']
     steps:
     - name: Checkout aiohttp
       uses: actions/checkout@v4


### PR DESCRIPTION
aiohttp 3.10 is no longer being developed, and the CI is no longer being maintained, and no longer runs
