### PR TITLE
Increase minimum propcache version to 0.2.1

### DIFF
--- a/CHANGES/1479.contrib.rst
+++ b/CHANGES/1479.contrib.rst
@@ -1,0 +1,4 @@
+Increased minimum `propcache`_ version to 0.2.1 to fix failing tests -- by :user:`bdraco`.
+
+.. _`propcache`:
+   https://github.com/aio-libs/propcache

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ include_package_data = True
 install_requires =
   idna >= 2.0
   multidict >= 4.0
-  propcache >= 0.2.0
+  propcache >= 0.2.1
 
 [options.package_data]
 # Ref:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Ensure propcache 0.2.1 or later is used so the tests will pass

## Are there changes in behavior for the user?

propcache 0.2.1 is now required

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

fixes #1457
