### PR TITLE
Add hidden folders to pytest's norecursedirs

### DIFF
--- a/CHANGES/1480.contrib.rst
+++ b/CHANGES/1480.contrib.rst
@@ -1,0 +1,2 @@
+Added all hidden folders to pytest's ``norecursedirs`` to prevent it
+from trying to collect tests there -- by :user:`lysnikolaou`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -35,6 +35,7 @@ manylinux
 multi
 nightlies
 pre
+pytest
 rc
 reStructuredText
 reencoding

--- a/pytest.ini
+++ b/pytest.ini
@@ -74,13 +74,8 @@ norecursedirs =
   venv
   virtualenv
   yarl.egg-info
-  .cache
-  .eggs
-  .git
-  .github
-  .tox
+  .*
   *.egg
-  .hypothesis
 
 testpaths = tests/
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -80,6 +80,7 @@ norecursedirs =
   .github
   .tox
   *.egg
+  .hypothesis
 
 testpaths = tests/
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Since we're setting (and not extending) `norecursedirs`, `.hypothesis` should also be there, otherwise we might be getting spurious warnings like the ones in [this test run](https://github.com/aio-libs/yarl/actions/runs/13787597245/job/38559648422?pr=1456#step:16:136).

## Are there changes in behavior for the user?

No.

