### PR TITLE
Improve performance of query string parsing

### DIFF
--- a/CHANGES/1493.misc.rst
+++ b/CHANGES/1493.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of parsing query strings -- by :user:`bdraco`.

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -199,7 +199,5 @@ def query_to_pairs(query_string: str) -> list[tuple[str, str]]:
         return pairs
     for k_v in query_string.split("&"):
         k, _, v = k_v.partition("=")
-        # replaces '+' with ' ' before unquoting to match
-        # urllib.parse.parse_qsl unquote_plus behavior.
         pairs.append((UNQUOTER_PLUS(k), UNQUOTER_PLUS(v)))
     return pairs

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -194,12 +194,10 @@ def query_to_pairs(query_string: str) -> list[tuple[str, str]]:
 
     Works like urllib.parse.parse_qsl with keep empty values.
     """
-    pairs: list[tuple[str, str]] = []
     if not query_string:
-        return pairs
-    for k_v in query_string.split("&"):
-        k, _, v = k_v.partition("=")
-        # replaces '+' with ' ' before unquoting to match
-        # urllib.parse.parse_qsl unquote_plus behavior.
-        pairs.append((UNQUOTER_PLUS(k), UNQUOTER_PLUS(v)))
-    return pairs
+        return []
+    return [
+        (UNQUOTER_PLUS(parts[0]), UNQUOTER_PLUS(parts[2]))
+        for k_v in query_string.split("&")
+        if (parts := k_v.partition("="))  # type: ignore[redundant-expr]
+    ]

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -194,10 +194,12 @@ def query_to_pairs(query_string: str) -> list[tuple[str, str]]:
 
     Works like urllib.parse.parse_qsl with keep empty values.
     """
+    pairs: list[tuple[str, str]] = []
     if not query_string:
-        return []
-    return [
-        (UNQUOTER_PLUS(parts[0]), UNQUOTER_PLUS(parts[2]))
-        for k_v in query_string.split("&")
-        if (parts := k_v.partition("="))  # type: ignore[redundant-expr]
-    ]
+        return pairs
+    for k_v in query_string.split("&"):
+        k, _, v = k_v.partition("=")
+        # replaces '+' with ' ' before unquoting to match
+        # urllib.parse.parse_qsl unquote_plus behavior.
+        pairs.append((UNQUOTER_PLUS(k), UNQUOTER_PLUS(v)))
+    return pairs

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from typing import Union
 from urllib.parse import scheme_chars, uses_netloc
 
-from ._quoters import QUOTER, UNQUOTER
+from ._quoters import QUOTER, UNQUOTER_PLUS
 
 # Leading and trailing C0 control and space to be stripped per WHATWG spec.
 # == "".join([chr(i) for i in range(0, 0x20 + 1)])
@@ -201,5 +201,5 @@ def query_to_pairs(query_string: str) -> list[tuple[str, str]]:
         k, _, v = k_v.partition("=")
         # replaces '+' with ' ' before unquoting to match
         # urllib.parse.parse_qsl unquote_plus behavior.
-        pairs.append((UNQUOTER(k.replace("+", " ")), UNQUOTER(v.replace("+", " "))))
+        pairs.append((UNQUOTER_PLUS(k), UNQUOTER_PLUS(v)))
     return pairs

--- a/yarl/_quoters.py
+++ b/yarl/_quoters.py
@@ -19,7 +19,7 @@ UNQUOTER = _Unquoter()
 PATH_UNQUOTER = _Unquoter(unsafe="+")
 PATH_SAFE_UNQUOTER = _Unquoter(ignore="/%", unsafe="+")
 QS_UNQUOTER = _Unquoter(qs=True)
-UNQUOTER_PLUS = _Unquoter(plus=True)
+UNQUOTER_PLUS = _Unquoter(plus=True)  # to match urllib.parse.unquote_plus
 
 
 def human_quote(s: Union[str, None], unsafe: str) -> Union[str, None]:

--- a/yarl/_quoters.py
+++ b/yarl/_quoters.py
@@ -19,6 +19,7 @@ UNQUOTER = _Unquoter()
 PATH_UNQUOTER = _Unquoter(unsafe="+")
 PATH_SAFE_UNQUOTER = _Unquoter(ignore="/%", unsafe="+")
 QS_UNQUOTER = _Unquoter(qs=True)
+UNQUOTER_PLUS = _Unquoter(plus=True)
 
 
 def human_quote(s: Union[str, None], unsafe: str) -> Union[str, None]:

--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -310,13 +310,15 @@ cdef class _Unquoter:
     cdef str _ignore
     cdef str _unsafe
     cdef bint _qs
+    cdef bint _plus  # to match urllib.parse.unquote_plus
     cdef _Quoter _quoter
     cdef _Quoter _qs_quoter
 
-    def __init__(self, *, ignore="", unsafe="", qs=False):
+    def __init__(self, *, ignore="", unsafe="", qs=False, plus=False):
         self._ignore = ignore
         self._unsafe = unsafe
         self._qs = qs
+        self._plus = plus
         self._quoter = _Quoter()
         self._qs_quoter = _Quoter(qs=True)
 
@@ -397,7 +399,7 @@ cdef class _Unquoter:
                 buflen = 0
 
             if ch == '+':
-                if not self._qs or ch in self._unsafe:
+                if (not self._qs and not self._plus) or ch in self._unsafe:
                     ret.append('+')
                 else:
                     changed = 1

--- a/yarl/_quoting_py.py
+++ b/yarl/_quoting_py.py
@@ -119,10 +119,18 @@ class _Quoter:
 
 
 class _Unquoter:
-    def __init__(self, *, ignore: str = "", unsafe: str = "", qs: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        ignore: str = "",
+        unsafe: str = "",
+        qs: bool = False,
+        plus: bool = False,
+    ) -> None:
         self._ignore = ignore
         self._unsafe = unsafe
         self._qs = qs
+        self._plus = plus  # to match urllib.parse.unquote_plus
         self._quoter = _Quoter()
         self._qs_quoter = _Quoter(qs=True)
 
@@ -181,7 +189,7 @@ class _Unquoter:
                 decoder.reset()
 
             if ch == "+":
-                if not self._qs or ch in self._unsafe:
+                if (not self._qs and not self._plus) or ch in self._unsafe:
                     ret.append("+")
                 else:
                     ret.append(" ")

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -6,7 +6,7 @@ from enum import Enum
 from functools import _CacheInfo, lru_cache
 from ipaddress import ip_address
 from typing import TYPE_CHECKING, Any, NoReturn, TypedDict, TypeVar, Union, overload
-from urllib.parse import SplitResult, parse_qsl, uses_relative
+from urllib.parse import SplitResult, uses_relative
 
 import idna
 from multidict import MultiDict, MultiDictProxy
@@ -16,6 +16,7 @@ from ._parse import (
     USES_AUTHORITY,
     SplitURLType,
     make_netloc,
+    query_to_pairs,
     split_netloc,
     split_url,
     unsplit_result,
@@ -863,7 +864,7 @@ class URL:
     @cached_property
     def _parsed_query(self) -> list[tuple[str, str]]:
         """Parse query part of URL."""
-        return parse_qsl(self._query, keep_blank_values=True)
+        return query_to_pairs(self._query)
 
     @cached_property
     def query(self) -> "MultiDictProxy[str]":
@@ -1251,7 +1252,7 @@ class URL:
             query = get_str_query_from_sequence_iterable(qm.items())
         elif isinstance(in_query, str):
             qstr: MultiDict[str] = MultiDict(self._parsed_query)
-            qstr.update(parse_qsl(in_query, keep_blank_values=True))
+            qstr.update(query_to_pairs(in_query))
             query = get_str_query_from_iterable(qstr.items())
         elif isinstance(in_query, (bytes, bytearray, memoryview)):  # type: ignore[unreachable]
             msg = "Invalid query type: bytes, bytearray and memoryview are forbidden"


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

When looking at the performance regression in #1492, I noticed that much of the time was spent in `parse_qsl`, however we do not need all the complexity of `parse_sql` since we use a very limited subset of the functionality.

We can write a faster version using the unquoter built-in to yarl with very little code.

## Are there changes in behavior for the user?

no

## Related issue number
n/a

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
