### PR TITLE
Remove exclude for building armv7l wheels on manylinux

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -506,9 +506,6 @@ jobs:
         tag:
         - ''
         - musllinux
-        exclude:
-        - tag: ''
-          qemu: armv7l
     uses: ./.github/workflows/reusable-build-wheel.yml
     with:
       qemu: ${{ matrix.qemu }}

--- a/CHANGES/1495.feature.rst
+++ b/CHANGES/1495.feature.rst
@@ -1,0 +1,1 @@
+Started building armv7l wheels for manylinux -- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -11,6 +11,7 @@ Towncrier
 Twitter
 UTF
 aiohttp
+armv
 ascii
 backend
 boolean


### PR DESCRIPTION
In theory the manylinux armv7l images have been [fixed](https://github.com/pypa/cibuildwheel/releases/tag/v2.23.0) with cibuildwheel so this should now work 