### PR TITLE
Update CI to test aiohttp 3.12 and aiohttp 3.13

### DIFF
--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        branch: ['master', '3.11', '3.12']
+        branch: ['master', '3.12', '3.13']
     steps:
     - name: Checkout aiohttp
       uses: actions/checkout@v4


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Update CI to test aiohttp 3.12 and aiohttp 3.13
We are not shipping 3.11 builds anymore

