### PR TITLE
Only enable line tracing when building with Cython tracing

### DIFF
--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -293,7 +293,7 @@ def maybe_prebuild_c_extensions(
     with build_dir_ctx:
         config = _get_local_cython_config()
 
-        cythonize_args = _make_cythonize_cli_args_from_config(config)
+        cythonize_args = _make_cythonize_cli_args_from_config(config, cython_line_tracing_requested)
         with _patched_cython_env(config['env'], cython_line_tracing_requested):
             _cythonize_cli_cmd(cythonize_args)  # type: ignore[no-untyped-call]
         with patched_distutils_cmd_install():

--- a/packaging/pep517_backend/_transformers.py
+++ b/packaging/pep517_backend/_transformers.py
@@ -17,7 +17,9 @@ def _emit_opt_pairs(opt_pair: tuple[str, Union[dict[str, str], str]]) -> Iterato
     yield from ("=".join(map(str, (flag_opt,) + pair)) for pair in sub_pairs)
 
 
-def get_cli_kwargs_from_config(kwargs_map: dict[str, str]) -> list[str]:
+def get_cli_kwargs_from_config(
+    kwargs_map: dict[str, Union[str, dict[str, str]]],
+) -> list[str]:
     """Make a list of options with values from config."""
     return list(chain.from_iterable(map(_emit_opt_pairs, kwargs_map.items())))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ keep-going = false
 # https://cython.rtfd.io/en/latest/src/userguide/source_files_and_compilation.html#compiler-directives
 embedsignature = "True"
 emit_code_comments = "True"
-linetrace = "True"  # Implies `profile=True`
 
 [tool.local.cythonize.kwargs.compile-time-env]
 # This section can contain compile time env vars


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Only enable line tracing when building with Cython tracing

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
