### PR TITLE
ci: add riscv64 manylinux wheels

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -481,6 +481,7 @@ jobs:
         - ppc64le
         - s390x
         - armv7l
+        - riscv64
         tag:
         - ''
         - musllinux

--- a/CHANGES/1626.feature.rst
+++ b/CHANGES/1626.feature.rst
@@ -1,0 +1,2 @@
+Start building and shipping riscv64 wheels
+-- by :user:`justeph`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -43,6 +43,8 @@ reStructuredText
 reencoding
 requote
 requoting
+riscv
+riscv64
 runtimes
 sdist
 subclass


### PR DESCRIPTION
Now that cibuildwheel and PyPI support riscv64, we can start building riscv64 wheels.

Fixes:https://github.com/aio-libs/yarl/issues/1626 