### PR TITLE
Fix pydantic example to include arbitrary_types_allowed config

### DIFF
--- a/CHANGES/1624.doc.rst
+++ b/CHANGES/1624.doc.rst
@@ -1,0 +1,3 @@
+Fixed the pydantic usage example to include the required
+``model_config = ConfigDict(arbitrary_types_allowed=True)``
+setting -- by :user:`veeceey`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -168,12 +168,15 @@ convert bools into strings using own preferred translation protocol.
 
 .. _yarl-pydantic-support:
 
-The :class:`~yarl.URL` could be used as a field type in pydantic_ models seamlessly::
+The :class:`~yarl.URL` could be used as a field type in pydantic_ models
+by setting ``arbitrary_types_allowed`` in the model config::
 
-   from pydantic import BaseModel
+   from pydantic import BaseModel, ConfigDict
    from yarl import URL
 
    class Model(BaseModel):
+       model_config = ConfigDict(arbitrary_types_allowed=True)
+
        url: URL
 
 


### PR DESCRIPTION
## Summary

- Fixes #1624
- The pydantic usage example in the docs was missing the required `model_config = ConfigDict(arbitrary_types_allowed=True)` setting, causing a `PydanticSchemaGenerationError` when users followed the example verbatim
- Updated the code example to import `ConfigDict` and set `arbitrary_types_allowed=True`, and adjusted the prose to mention this requirement

## What changed

**`docs/index.rst`**: Updated the pydantic example to include:
```python
from pydantic import BaseModel, ConfigDict
from yarl import URL

class Model(BaseModel):
    model_config = ConfigDict(arbitrary_types_allowed=True)

    url: URL
```

**`CHANGES/1624.doc.rst`**: Added a towncrier changelog fragment for this documentation fix.

## Test plan

- [x] Verify the docs render correctly (RST syntax is valid)
- [x] Verify the example works with `pydantic>=2.0` and current yarl