### PR TITLE
Fix pickling URLs with Python 3.15.0a6+ (Fixes #1632)

### DIFF
--- a/CHANGES/1642.bugfix.rst
+++ b/CHANGES/1642.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed pickle compatibility with Python 3.15. -- by :user:`befeleme`.

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -566,8 +566,8 @@ class URL:
     def __bool__(self) -> bool:
         return bool(self._netloc or self._path or self._query or self._fragment)
 
-    def __getstate__(self) -> tuple[SplitResult]:
-        return (tuple.__new__(SplitResult, self._val),)
+    def __getstate__(self) -> tuple[SplitURLType]:
+        return (self._val,)
 
     def __setstate__(
         self, state: tuple[SplitURLType] | tuple[None, _InternalURLCache]


### PR DESCRIPTION
## What do these changes do?

In Python 3.15 urllib.parse.SplitResult gained a new `__getstate__` method which fails when called on instances created via `tuple.__new__`: https://github.com/python/cpython/commit/c5cfcdf1
Returning `self._val` directly instead of creating a new `SplitResult` instance avoids the problematic code path, and is backwards compatible.

Tested with Python 3.15 and 3.14 and the tests pass. This also makes the `__getstate__` and `__setstate__` closer to each other, as previously one of those created an instance of `SplitResult`, while the other was working with `SplitURLType`. I'm not sure if there's a reason to create a new instance while getting the state, but I saw there were attempts to not use `SplitResult` in the codebase previously: https://github.com/aio-libs/yarl/commit/41af4a354367b4136d696f32f5150aff470bde12 and https://github.com/aio-libs/yarl/commit/3f2c26f0f5744f2c7a36dffe5c5bf05c56077f05#diff-5bf2c937d02f1880615d9b7ccb8ce28d293be5205cc993a0df34588eba239270 (where a similar construction of `tuple.__new__(SplitResult, ...)` was removed from `__setstate__`).

## Are there changes in behavior for the user?

There shouldn't be any.

## Related issue number

Fixes: #1632

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
