### PR TITLE
docs: fix Pydantic example to include arbitrary_types_allowed

### DIFF
--- a/CHANGES/1624.doc.rst
+++ b/CHANGES/1624.doc.rst
@@ -1,0 +1,1 @@
+Updated Pydantic example to include ``arbitrary_types_allowed=True`` in ``model_config`` -- by :user:`wuzhrun`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,10 +170,11 @@ convert bools into strings using own preferred translation protocol.
 
 The :class:`~yarl.URL` could be used as a field type in pydantic_ models seamlessly::
 
-   from pydantic import BaseModel
+   from pydantic import BaseModel, ConfigDict
    from yarl import URL
 
    class Model(BaseModel):
+       model_config = ConfigDict(arbitrary_types_allowed=True)
        url: URL
 
 


### PR DESCRIPTION
## What this PR does

Fixes #1624 — the Pydantic example in  does not work with Pydantic 2.x because  lacks . 

Added  to make the example immediately usable.

## Changes
- Updated  Pydantic example
- Added changelog fragment 

## Tested
