### PR TITLE
Reject URLs with text before bracket in host

### DIFF
--- a/CHANGES/1654.bugfix.rst
+++ b/CHANGES/1654.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a parsing issue where URLs containing text before an opening bracket
+in the host component (e.g. ``http://127.0.0.1[aa::ff]``) were silently accepted
+instead of being rejected as strictly invalid per RFC 3986
+-- by :user:`rodrigobnogueira`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -344,19 +344,44 @@ def test_ipv6_missing_right_bracket() -> None:
         "http://[]/",
         "http://[1]/",
         "http://[127.0.0.1]/",
-        "http://]1dec:0:0:0::1[/",
     ),
     ids=(
         "empty-IPv6-like-URL",
         "no-colons-in-IPv6",
         "IPv4-inside-brackets",
-        "brackets-in-reversed-order",
     ),
 )
 def test_ipv6_invalid_url(url: str) -> None:
     with pytest.raises(
         ValueError, match="The IPv6 content between brackets is not valid"
     ):
+        URL(url)
+
+
+def test_ipv6_brackets_in_reversed_order() -> None:
+    with pytest.raises(ValueError, match="Invalid IPv6 URL"):
+        URL("http://]1dec:0:0:0::1[/")
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "http://127.0.0.1[aa::ff]",
+        "http://127.0.0.1[aa::ff]/",
+        "http://127.0.0.1[aa::ff]:8080/",
+        "http://user@127.0.0.1[aa::ff]/",
+        "http://example.com[::1]/",
+    ),
+    ids=(
+        "ipv4-before-bracket",
+        "ipv4-before-bracket-with-path",
+        "ipv4-before-bracket-with-port",
+        "userinfo-ipv4-before-bracket",
+        "hostname-before-bracket",
+    ),
+)
+def test_host_with_text_before_bracket_is_invalid(url: str) -> None:
+    with pytest.raises(ValueError, match="Invalid IPv6 URL"):
         URL(url)
 
 

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -64,6 +64,12 @@ def split_url(url: str) -> SplitURLType:
         ):
             raise ValueError("Invalid IPv6 URL")
         if has_left_bracket:
+            # Per RFC 3986, brackets are only valid at the START of the host
+            # for IP-literal addresses. Text before '[' (e.g. '127.0.0.1[::1]')
+            # is invalid and must be rejected to prevent SSRF bypasses.
+            hostinfo = netloc.rpartition("@")[2]
+            if hostinfo[0] != "[":
+                raise ValueError("Invalid IPv6 URL")
             bracketed_host = netloc.partition("[")[2].partition("]")[0]
             # Valid bracketed hosts are defined in
             # https://www.rfc-editor.org/rfc/rfc3986#page-49


### PR DESCRIPTION
## What do these changes do?

Fixes a parsing compliance issue where URLs containing text before an opening bracket in the host component (e.g. `http://127.0.0.1[aa::ff]`) were silently accepted, with the text before `[` being discarded.

### The bug

```python
>>> yarl.URL('http://127.0.0.1[aa::ff]')
URL('http://[aa::ff]')
>>> yarl.URL('http://127.0.0.1[aa::ff]').host
'aa::ff'
```

The `127.0.0.1` is silently dropped, and only the bracketed content `aa::ff` is used as the host.

### Root cause

In `_parse.py`, both `split_url()` (line 67) and `split_netloc()` (line 122) extract the bracketed content using `netloc.partition('[')` which discards everything before `[` into the throwaway `_` variable:

```python
# split_url line 67
bracketed_host = netloc.partition('[')[2].partition(']')[0]

# split_netloc line 123
_, _, bracketed = hostinfo.partition('[')
```

Per [RFC 3986 §3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2), IP-literal brackets must be at the **start** of the host component: `host = IP-literal / IPv4address / reg-name`. Any text before `[` makes the URL syntax invalid.

### The fix

Added a check in `split_url()` that verifies `[` is the first character of the host portion of the netloc (after stripping any `userinfo@`). If text precedes the opening bracket, a `ValueError('Invalid IPv6 URL')` is raised.

### Side effect on existing tests

The reversed-brackets test case (`http://]1dec:0:0:0::1[/`) is now caught earlier by the new check (since `]` ≠ `[`) with the message `Invalid IPv6 URL` rather than the previous `The IPv6 content between brackets is not valid`. The URL is still correctly rejected — the test has been updated to reflect the earlier error path.