### PR TITLE
Fix ruff ISC004 in PEP 517 backend cython config

### DIFF
--- a/CHANGES/1674.contrib.rst
+++ b/CHANGES/1674.contrib.rst
@@ -1,0 +1,3 @@
+Resolved a ruff ``ISC004`` violation in the PEP 517 build backend so the
+pre-commit ``ruff-check`` hook passes again
+-- by :user:`bdraco`.

--- a/packaging/pep517_backend/_cython_configuration.py
+++ b/packaging/pep517_backend/_cython_configuration.py
@@ -232,8 +232,7 @@ def patched_env(
             if temporary_build_directory is None
             # Temporary build directory mode:
             else (
-                '-ffile-prefix-map='
-                f'{temporary_build_directory!s}={original_source_directory!s}',
+                f'-ffile-prefix-map={temporary_build_directory!s}={original_source_directory!s}',
             )
         ),
         # Finally, append the user-set env var, ensuring its top priority:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The pre-commit ruff-check hook flags an `ISC004` warning on the implicit string concatenation inside the tuple in `_cython_configuration.py`; collapsed the two adjacent literals into a single f-string so the value is one expression, no parens gymnastics needed.

## Are there changes in behavior for the user?

No; the resulting `-ffile-prefix-map=...` flag is byte-identical.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder