### PR TITLE
Use fetch-depth in codspeed checkout step

### DIFF
--- a/.github/workflows/reusable-codspeed.yml
+++ b/.github/workflows/reusable-codspeed.yml
@@ -79,7 +79,7 @@ jobs:
       # Ref: https://github.com/CodSpeedHQ/runner/issues/144
       uses: actions/checkout@v6
       with:
-        depth: 1  # Codspeed only checks the HEAD
+        fetch-depth: 1  # Codspeed only checks the HEAD
     - name: Retrieve the project source from an sdist inside the GHA artifact
       uses: re-actors/checkout-python-sdist@release/v2
       with:

--- a/CHANGES/1676.contrib.rst
+++ b/CHANGES/1676.contrib.rst
@@ -1,0 +1,4 @@
+Renamed the ``actions/checkout`` ``depth`` input to ``fetch-depth`` in the
+reusable codspeed workflow so the actionlint pre-commit hook passes and the
+intended shallow clone actually takes effect
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -11,6 +11,7 @@ PYX
 Towncrier
 Twitter
 UTF
+actionlint
 aiohttp
 armv
 ascii
@@ -20,6 +21,7 @@ booleans
 bools
 changelog
 changelogs
+codspeed
 config
 de
 decodable


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The reusable codspeed workflow passes ``depth: 1`` to ``actions/checkout@v6``, but the input is named ``fetch-depth``; renamed it so actionlint stops failing and the shallow clone actually takes effect.

## Are there changes in behavior for the user?

No user-facing change; on CI the codspeed job now performs the shallow clone it always intended to.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [ ] Add a new news fragment into the ``CHANGES/`` folder