### PR TITLE
Bump pyupgrade to v3.21.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,7 +107,7 @@ repos:
   - id: detect-private-key
     exclude: ^examples/
 - repo: https://github.com/asottile/pyupgrade
-  rev: 'v3.20.0'
+  rev: 'v3.21.2'
   hooks:
   - id: pyupgrade
     args: ['--py310-plus']

--- a/CHANGES/1677.contrib.rst
+++ b/CHANGES/1677.contrib.rst
@@ -1,0 +1,3 @@
+Bumped the pinned ``pyupgrade`` pre-commit hook to ``v3.21.2`` so it stops
+crashing on Python 3.14, which made ``tokenize.cookie_re`` bytes-only
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Pin pyupgrade at ``v3.21.2``; the previous ``v3.20.0`` pin crashes under Python 3.14 with ``TypeError: cannot use a bytes pattern on a string-like object`` because ``tokenize.cookie_re`` is bytes-only there. Upstream v3.21.1 vendored the regex from cpython, so this just picks up that fix.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [ ] Add a new news fragment into the ``CHANGES/`` folder