### PR TITLE
Document docs spell check pre-push gate in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,30 @@ cause is welcome (see
 for the right length). Long, multi-section essays with bolded
 sub-headings are not the style here.
 
-### 6. Commit hygiene
+### 6. Run the docs spell check before pushing
+
+CI builds the docs with `sphinxcontrib.spelling` and treats any
+unknown word as a hard failure. The spell checker reads every
+`CHANGES/*.rst` fragment as part of the build, so a technical
+word in your news fragment (`quoter`, `parametrization`,
+`repr`, and so on) that is not in
+[`docs/spelling_wordlist.txt`](docs/spelling_wordlist.txt)
+will fail `make doc-spelling` and burn a CI run before a human
+even sees the PR.
+
+Before pushing:
+
+```bash
+make doc-spelling
+```
+
+If it flags a word you actually meant to use, add it to
+`docs/spelling_wordlist.txt` (one word per line, roughly
+alphabetical within case) in the same commit as the fragment.
+If it flags a typo, fix the typo. Do not paper over real
+misspellings by adding them to the wordlist.
+
+### 7. Commit hygiene
 
 - One logical change per PR. If a refactor and a bugfix are
   bundled together, split them.
@@ -348,6 +371,10 @@ exercises the runnable examples in the docs.
   that was not possible in your environment.
 - Do not invent a `## What / ## Why / ## How / ## Testing` PR
   body; use the aio-libs template above.
+- Do not push without running `make doc-spelling` first if you
+  edited any `.rst` file (including `CHANGES/`). The docs build
+  fails on unknown words and burns a CI run; see _Run the docs
+  spell check before pushing_ above.
 - Do not skip the `CHANGES/` fragment "because the change is
   small". Even a one-line bugfix needs one.
 - Do not add `Co-Authored-By` trailers for LLM tools, in either

--- a/CHANGES/1693.contrib.rst
+++ b/CHANGES/1693.contrib.rst
@@ -1,0 +1,8 @@
+Documented the docs spell check (``make doc-spelling``) in
+:file:`AGENTS.md` as a pre-push gate, mirroring
+`aio-libs/multidict#1345
+<https://github.com/aio-libs/multidict/pull/1345>`__. The
+spell checker reads every ``CHANGES/*.rst`` fragment as part
+of the docs build, so an unknown technical word in a news
+fragment fails CI before a human sees the PR
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds a new PR rule to `AGENTS.md` that documents `make doc-spelling` as the pre-push gate, mirroring [aio-libs/multidict#1345](https://github.com/aio-libs/multidict/pull/1345). The new section explains that `sphinxcontrib.spelling` reads every `CHANGES/*.rst` fragment, so an unknown technical word in a news fragment fails CI before a human ever sees the PR; the fix is to either add the word to `docs/spelling_wordlist.txt` in the same commit or correct the typo.

Renumbers the surrounding PR rules (Commit hygiene becomes #7) and adds a matching bullet to Things not to do.

## Are there changes in behavior for the user?

No. Docs-only change to the agent-facing contributor notes.

## Is it a substantial burden for the maintainers to support this?

No. `make doc-spelling` is already a CI gate via `reusable-linters.yml`; this just writes the rule down where agents will read it.

## Related issue number

Mirrors [aio-libs/multidict#1345](https://github.com/aio-libs/multidict/pull/1345).

## Checklist

- [x] I think the code is well written
- [N/A] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [N/A] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder