### PR TITLE
Skip CI on draft pull requests

### DIFF
--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -17,6 +17,11 @@ on:
     - master
     paths-ignore:
     - .github/workflows/reusable-codspeed.yml
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
 
 
 env:
@@ -29,6 +34,9 @@ jobs:
 
   test-aiohttp:
     name: Aiohttp tests
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -16,6 +16,11 @@ on:
     - master
     - >-
       [0-9].[0-9]+
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
   schedule:
   - cron: 0 6 * * *  # Daily 6AM UTC build
 
@@ -45,6 +50,9 @@ jobs:
 
   pre-setup:
     name: ⚙️ Pre-set global build settings
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 1
     defaults:
@@ -125,6 +133,9 @@ jobs:
         retention-days: 15
 
   lint:
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.draft == false
     uses: ./.github/workflows/reusable-linters.yml
 
   build-wheels-for-tested-arches:
@@ -448,6 +459,10 @@ jobs:
     name: Coverage processing
     if: >-
       !cancelled()
+      && (
+        github.event_name != 'pull_request'
+        || github.event.pull_request.draft == false
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 1
     needs:
@@ -465,7 +480,12 @@ jobs:
 
   test-summary:
     name: Test matrix status
-    if: always()
+    if: >-
+      always()
+      && (
+        github.event_name != 'pull_request'
+        || github.event.pull_request.draft == false
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 1
     needs: [lint, test]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,12 +9,20 @@ on:
   pull_request:
     branches:
     - master
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
   schedule:
   - cron: "46 14 * * 0"
 
 jobs:
   analyze:
     name: Analyze
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 4
     permissions:

--- a/CHANGES/1694.contrib.rst
+++ b/CHANGES/1694.contrib.rst
@@ -1,0 +1,1 @@
+Skipped CI workflows on draft pull requests; jobs run once a PR is marked ready for review.


### PR DESCRIPTION
## What do these changes do?

Skip the pull_request workflows on draft PRs, and re-run them when a PR is marked ready for review. Affects ci-cd.yml, aiohttp.yml, and codeql.yml; root jobs and the always-running summary jobs get a guard on `github.event.pull_request.draft`.

## Are there changes in behavior for the user?

No end-user behavior change. For contributors and reviewers, drafts now show skipped checks instead of a spinning matrix.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes