### PR TITLE
Add CLAUDE.md that imports AGENTS.md via @-syntax

### DIFF
--- a/CHANGES/1696.contrib.rst
+++ b/CHANGES/1696.contrib.rst
@@ -1,0 +1,5 @@
+Added a ``CLAUDE.md`` at the repository root that imports
+:file:`AGENTS.md` via Claude Code's ``@``-syntax, so the
+project's LLM contributor rules load automatically when
+working in Claude Code
+-- by :user:`bdraco`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add a `CLAUDE.md` at the repository root containing a single
`@AGENTS.md` line. Claude Code resolves the `@`-prefix as an
import, so the project's LLM contributor rules in `AGENTS.md`
load automatically when an agent starts a session in this repo,
without duplicating any content.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No. The file is one line and points at the existing `AGENTS.md`,
so future edits stay in `AGENTS.md` only.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist — N/A, docs-only
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` — N/A, docs-only
- [x] Add a new news fragment into the `CHANGES/` folder