### PR TITLE
Enforce top-level imports via ruff PLC0415

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,6 @@ repos:
   rev: 'v6.0.0'
   hooks:
   - id: check-merge-conflict
-- repo: https://github.com/asottile/yesqa
-  rev: v1.5.0
-  hooks:
-  - id: yesqa
-    exclude: ^packaging/pep517_backend/.+$
-    additional_dependencies:
-    - wemake-python-styleguide
 - repo: https://github.com/astral-sh/ruff-pre-commit.git
   rev: v0.15.9
   hooks:
@@ -26,6 +19,16 @@ repos:
     - --fix  # NOTE: When `--fix` is used, linting should be before ruff-format
     - --show-fixes
     files: ^packaging/pep517_backend/.+$
+
+- repo: https://github.com/astral-sh/ruff-pre-commit.git
+  rev: v0.15.9
+  hooks:
+  - id: ruff-check
+    name: ruff check | yarl & tests
+    # Uses the [tool.ruff] config in pyproject.toml. Currently enforces
+    # PLC0415 (top-level imports) repo-wide; legitimate lazy imports
+    # must be opted in with `# noqa: PLC0415` + a comment.
+    exclude: ^packaging/pep517_backend/.+$
 
 - repo: https://github.com/astral-sh/ruff-pre-commit.git
   rev: v0.15.9

--- a/CHANGES/1697.contrib.rst
+++ b/CHANGES/1697.contrib.rst
@@ -1,0 +1,8 @@
+Enforced top-level imports across ``yarl`` and ``tests`` via the ruff
+``PLC0415`` rule, wired through a new ``ruff-check`` pre-commit hook.
+Function-scoped imports must now opt in with ``# noqa: PLC0415`` plus
+a comment explaining the import-time reason. Dropped the ``yesqa``
+hook, which could not recognize ruff-only codes and stripped the new
+``noqa`` comments as stale; a wider migration off flake8 onto ruff
+will follow separately
+-- by :user:`bdraco`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,24 @@ freethreading_compatible = "True"
 #error_on_unknown_names = "True"
 #error_on_uninitialized = "True"
 
+[tool.ruff]
+# The packaging/pep517_backend/ tree has its own .ruff.toml and is linted
+# under that config via a separate pre-commit hook.
+extend-exclude = ["packaging/pep517_backend"]
+
+[tool.ruff.lint]
+# Keep this list small and intentional; the rest of the project still
+# relies on flake8 + isort + black. The rules below are ones we want to
+# enforce repo-wide as a baseline.
+select = [
+  # Imports must live at the top of the module. Late/inside-function
+  # imports must be opted into explicitly with `# noqa: PLC0415` and a
+  # comment explaining why (e.g. avoiding a heavy optional dependency
+  # in the import path). Enforced because AI-assisted contributions
+  # frequently introduce function-scoped imports that are unnecessary.
+  "PLC0415",
+]
+
 [tool.cibuildwheel]
 build-frontend = "build"
 before-test = [

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1516,7 +1516,10 @@ class URL:
             source_type: type[Self] | type[str],
             handler: "GetCoreSchemaHandler",
         ) -> "CoreSchema":
-            from pydantic_core import core_schema
+            # Lazy import: pulling in pydantic_core at module load time
+            # increases yarl's import cost 3-7x for users who don't use
+            # pydantic. Keep this import function-scoped.
+            from pydantic_core import core_schema  # noqa: PLC0415
 
             from_str_schema = core_schema.chain_schema(
                 [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add a `[tool.ruff]` config that selects `PLC0415` (import-outside-top-level) and wire a `ruff-check` pre-commit hook for the main tree (the existing `packaging/pep517_backend/` hook keeps its own `.ruff.toml`). The one legitimate function-scoped import in the tree, `from pydantic_core import core_schema` inside `URL.__get_pydantic_core_schema__`, is opted out with `# noqa: PLC0415` plus a comment on the import-time motivation. The `yesqa` hook is removed because it has no way to recognize `PLC0415` (which is not a flake8 code) and was stripping the new noqa as stale; the broader migration off flake8 onto ruff will follow in a separate PR.

## Are there changes in behavior for the user?

No, this is a contributor-facing lint rule and pre-commit configuration change.

## Is it a substantial burden for the maintainers to support this?

No. The rule has exactly one opt-out in the current tree, and that opt-out is documented inline. Future late imports must be justified with a `# noqa: PLC0415` and a comment.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (lint-config-only change; verified by running `ruff check` and the pre-commit suite against the tree)
- [x] Documentation reflects the changes: N/A (no user-visible API or behavior change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`: N/A (no `CONTRIBUTORS.txt` in this repo)
- [x] Add a new news fragment into the `CHANGES/` folder (`CHANGES/1697.contrib.rst`)

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Verified the rule fires on a fresh function-scoped import and passes against the current tree:

```
$ ruff check yarl/ tests/
All checks passed!
```

`make doc-spelling` was run before pushing the fragment. The 7 misspellings it surfaces are all pre-existing entries elsewhere in `CHANGES.rst` / `CHANGES/README.rst` and reproduce on the unmodified base branch; the new `CHANGES/1697.contrib.rst` fragment introduces none.

</details>