### PR TITLE
Migrate code formatting from black + isort to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,15 +25,26 @@ repos:
   hooks:
   - id: ruff-check
     name: ruff check | yarl & tests
-    # Uses the [tool.ruff] config in pyproject.toml. Currently enforces
-    # PLC0415 (top-level imports) repo-wide; legitimate lazy imports
-    # must be opted in with `# noqa: PLC0415` + a comment.
+    # Uses the [tool.ruff] config in pyproject.toml. Enforces PLC0415
+    # (top-level imports) and `I` (import sorting, replacing isort).
+    # Legitimate lazy imports must be opted in with `# noqa: PLC0415`
+    # plus a comment. Runs before ruff-format because --fix is used.
+    args:
+    # Ref: https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    - --exit-non-zero-on-fix
+    - --fix
+    - --show-fixes
+    exclude: ^packaging/pep517_backend/.+$
+  - id: ruff-format
+    name: ruff format | yarl & tests
+    # Replaces the standalone black hook. Defaults to a black-compatible
+    # 88-column style; no [tool.ruff.format] overrides in pyproject.toml.
     exclude: ^packaging/pep517_backend/.+$
 
 - repo: https://github.com/astral-sh/ruff-pre-commit.git
   rev: v0.15.9
   hooks:
-  - id: ruff-format  # Cython imports are handled by `isort`
+  - id: ruff-format
     alias: ruff-format-first-pass
     name: ruff-format | PEP 517 backend (first pass)
     files: ^packaging/pep517_backend/.+$
@@ -48,22 +59,10 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit.git
   rev: v0.15.9
   hooks:
-  - id: ruff-format  # Cython imports are handled by `isort`
+  - id: ruff-format
     alias: ruff-format-second-pass
     name: ruff-format | PEP 517 backend (second pass)
     files: ^packaging/pep517_backend/.+$
-
-- repo: https://github.com/PyCQA/isort
-  rev: '8.0.1'
-  hooks:
-  - id: isort
-    exclude: ^packaging/pep517_backend/.+$
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: '26.3.1'
-  hooks:
-  - id: black
-    exclude: ^packaging/pep517_backend/.+$
-    language_version: python3  # Should be a command that runs python
 
 - repo: https://github.com/python-jsonschema/check-jsonschema.git
   rev: 0.37.1

--- a/CHANGES/1698.contrib.rst
+++ b/CHANGES/1698.contrib.rst
@@ -1,0 +1,8 @@
+Migrated the main tree from standalone ``black`` and ``isort``
+pre-commit hooks to ``ruff format`` and the ruff ``I`` lint rule,
+sharing the existing ``[tool.ruff]`` config in ``pyproject.toml``.
+``ruff-check`` now runs with ``--fix`` so import-order fixes apply
+on commit, and the orphan ``[isort]`` block in ``setup.cfg`` was
+removed. The ``packaging/pep517_backend/`` subtree keeps its own
+``.ruff.toml`` and is unaffected
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -53,6 +53,7 @@ sdist
 subclass
 subclasses
 subcomponent
+subtree
 svetlov
 uncompiled
 unencoded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,9 +128,13 @@ extend-exclude = ["packaging/pep517_backend"]
 
 [tool.ruff.lint]
 # Keep this list small and intentional; the rest of the project still
-# relies on flake8 + isort + black. The rules below are ones we want to
-# enforce repo-wide as a baseline.
+# relies on flake8 for general style. The rules below are ones we want
+# to enforce repo-wide as a baseline.
 select = [
+  # Import sorting. Replaces the dedicated isort pre-commit hook so the
+  # formatter (ruff format) and the import sorter (ruff check --select I)
+  # come from the same tool and rev.
+  "I",
   # Imports must live at the top of the module. Late/inside-function
   # imports must be opted into explicitly with `# noqa: PLC0415` and a
   # comment explaining why (e.g. avoiding a heavy optional dependency

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,6 +92,3 @@ per-file-ignores =
 
   # F401   imported but unused
   packaging/pep517_backend/hooks.py: F401
-
-[isort]
-profile=black

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -106,9 +106,7 @@ def test_unquote_to_bytes(unquoter: type[_Unquoter]) -> None:
 
 def test_never_quote(quoter: type[_Quoter]) -> None:
     # Make sure quote() does not quote letters, digits, and "_,.-~"
-    do_not_quote = (
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "abcdefghijklmnopqrstuvwxyz" "0123456789" "_.-~"
-    )
+    do_not_quote = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-~"
     assert quoter()(do_not_quote) == do_not_quote
     assert quoter(qs=True)(do_not_quote) == do_not_quote
 

--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -257,7 +257,6 @@ def test_with_class_that_implements__int__() -> None:
     """Allow classes that implement __int__ to be used in query strings."""
 
     class myint:
-
         def __int__(self) -> int:
             return 84
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1868,8 +1868,8 @@ def test_to_idna() -> None:
 
 
 def test_from_ascii_login() -> None:
-    url = URL("http://" "%D0%B2%D0%B0%D1%81%D1%8F" "@host:1234/")
-    assert ("http://" "%D0%B2%D0%B0%D1%81%D1%8F" "@host:1234/") == str(url)
+    url = URL("http://%D0%B2%D0%B0%D1%81%D1%8F@host:1234/")
+    assert ("http://%D0%B2%D0%B0%D1%81%D1%8F@host:1234/") == str(url)
 
 
 def test_from_non_ascii_login() -> None:
@@ -1903,16 +1903,16 @@ def test_from_non_ascii_login_and_password() -> None:
 
 
 def test_from_ascii_path() -> None:
-    url = URL("http://example.com/" "%D0%BF%D1%83%D1%82%D1%8C/%D1%82%D1%83%D0%B4%D0%B0")
+    url = URL("http://example.com/%D0%BF%D1%83%D1%82%D1%8C/%D1%82%D1%83%D0%B4%D0%B0")
     assert (
-        "http://example.com/" "%D0%BF%D1%83%D1%82%D1%8C/%D1%82%D1%83%D0%B4%D0%B0"
+        "http://example.com/%D0%BF%D1%83%D1%82%D1%8C/%D1%82%D1%83%D0%B4%D0%B0"
     ) == str(url)
 
 
 def test_from_ascii_path_lower_case() -> None:
-    url = URL("http://example.com/" "%d0%bf%d1%83%d1%82%d1%8c/%d1%82%d1%83%d0%b4%d0%b0")
+    url = URL("http://example.com/%d0%bf%d1%83%d1%82%d1%8c/%d1%82%d1%83%d0%b4%d0%b0")
     assert (
-        "http://example.com/" "%D0%BF%D1%83%D1%82%D1%8C/%D1%82%D1%83%D0%B4%D0%B0"
+        "http://example.com/%D0%BF%D1%83%D1%82%D1%8C/%D1%82%D1%83%D0%B4%D0%B0"
     ) == str(url)
 
 
@@ -1933,23 +1933,17 @@ def test_bytes() -> None:
 
 def test_from_ascii_query_parts() -> None:
     url = URL(
-        "http://example.com/"
-        "?%D0%BF%D0%B0%D1%80%D0%B0%D0%BC"
-        "=%D0%B7%D0%BD%D0%B0%D1%87"
+        "http://example.com/?%D0%BF%D0%B0%D1%80%D0%B0%D0%BC=%D0%B7%D0%BD%D0%B0%D1%87"
     )
     assert (
-        "http://example.com/"
-        "?%D0%BF%D0%B0%D1%80%D0%B0%D0%BC"
-        "=%D0%B7%D0%BD%D0%B0%D1%87"
+        "http://example.com/?%D0%BF%D0%B0%D1%80%D0%B0%D0%BC=%D0%B7%D0%BD%D0%B0%D1%87"
     ) == str(url)
 
 
 def test_from_non_ascii_query_parts() -> None:
     url = URL("http://example.com/?парам=знач")
     assert (
-        "http://example.com/"
-        "?%D0%BF%D0%B0%D1%80%D0%B0%D0%BC"
-        "=%D0%B7%D0%BD%D0%B0%D1%87"
+        "http://example.com/?%D0%BF%D0%B0%D1%80%D0%B0%D0%BC=%D0%B7%D0%BD%D0%B0%D1%87"
     ) == str(url)
 
 
@@ -1959,16 +1953,16 @@ def test_from_non_ascii_query_parts2() -> None:
 
 
 def test_from_ascii_fragment() -> None:
-    url = URL("http://example.com/" "#%D1%84%D1%80%D0%B0%D0%B3%D0%BC%D0%B5%D0%BD%D1%82")
+    url = URL("http://example.com/#%D1%84%D1%80%D0%B0%D0%B3%D0%BC%D0%B5%D0%BD%D1%82")
     assert (
-        "http://example.com/" "#%D1%84%D1%80%D0%B0%D0%B3%D0%BC%D0%B5%D0%BD%D1%82"
+        "http://example.com/#%D1%84%D1%80%D0%B0%D0%B3%D0%BC%D0%B5%D0%BD%D1%82"
     ) == str(url)
 
 
 def test_from_bytes_with_non_ascii_fragment() -> None:
     url = URL("http://example.com/#фрагмент")
     assert (
-        "http://example.com/" "#%D1%84%D1%80%D0%B0%D0%B3%D0%BC%D0%B5%D0%BD%D1%82"
+        "http://example.com/#%D1%84%D1%80%D0%B0%D0%B3%D0%BC%D0%B5%D0%BD%D1%82"
     ) == str(url)
 
 
@@ -1979,12 +1973,10 @@ def test_to_str() -> None:
 
 def test_to_str_long() -> None:
     url = URL(
-        "https://host-12345678901234567890123456789012345678901234567890" "-name:8888/"
+        "https://host-12345678901234567890123456789012345678901234567890-name:8888/"
     )
     expected = (
-        "https://host-"
-        "12345678901234567890123456789012345678901234567890"
-        "-name:8888/"
+        "https://host-12345678901234567890123456789012345678901234567890-name:8888/"
     )
     assert expected == str(url)
 

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -593,9 +593,7 @@ class TestStripEmptyParts:
 )
 def test_schemes_that_require_host(scheme: str) -> None:
     """Verify that schemes that require a host raise with empty host."""
-    expect = (
-        "Invalid URL: host is required for " f"absolute urls with the {scheme} scheme"
-    )
+    expect = f"Invalid URL: host is required for absolute urls with the {scheme} scheme"
     with pytest.raises(ValueError, match=expect):
         URL(f"{scheme}://:1")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Follow-up to #1697. Drop the standalone `black` and `isort` pre-commit hooks for the main tree and use ruff for both formatting and import sorting. Adds the `I` rule to `[tool.ruff.lint]` and a `ruff-format` hook (alongside the existing `ruff-check`, which now runs with `--fix --exit-non-zero-on-fix --show-fixes` so import-sorting fixes apply on commit). Removes the orphan `[isort]` block from `setup.cfg`. The `packaging/pep517_backend/` subtree keeps its own `.ruff.toml` and its two-pass ruff-format hooks unchanged.

`ruff format` applied four small reformats in `tests/test_quoting.py`, `tests/test_update_query.py`, `tests/test_url.py`, and `tests/test_url_parsing.py`: adjacent string-literal concatenations were collapsed, and one stray blank line after a class header was removed. `ruff check --select I` produced no diffs against the existing import order, so the isort half of the swap is a no-op on imports.

## Are there changes in behavior for the user?

No, contributor tooling only.

## Is it a substantial burden for the maintainers to support this?

No. The pre-commit list is shorter (two hooks gone, one added) and the formatter and import sorter now share a single tool and rev.

## Related issue number

N/A; follow-up to #1697.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (tooling-only change; ran `pytest` against the reformatted test files and the full pre-commit suite to verify)
- [x] Documentation reflects the changes: N/A (no user-visible API change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`: N/A (no such file in this repo)
- [x] Add a new news fragment into the `CHANGES/` folder (`CHANGES/1698.contrib.rst`)

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Verified:

```
$ ruff check yarl/ tests/ docs/conf.py benchmark.py url_benchmark.py
All checks passed!
$ ruff format --check yarl/ tests/ docs/conf.py benchmark.py url_benchmark.py
26 files already formatted
$ venv/bin/python -m pytest tests/test_quoting.py tests/test_update_query.py tests/test_url.py tests/test_url_parsing.py --no-cov -q
1184 passed, 4 xfailed
$ pre-commit run --all-files
all hooks Passed (including mypy)
$ make doc-spelling
7 pre-existing misspellings only; the new fragment is clean after adding "subtree" to docs/spelling_wordlist.txt
```

</details>