### PR TITLE
Switch cibuildwheel to the uv build frontend

### DIFF
--- a/.github/workflows/reusable-cibuildwheel.yml
+++ b/.github/workflows/reusable-cibuildwheel.yml
@@ -112,6 +112,11 @@ jobs:
       with:
         package-dir: >-  # not necessarily a dir, we pass an acceptable sdist
           dist/${{ inputs.source-tarball-name }}
+        # `build-frontend = "build[uv]"` (pyproject.toml) requires uv to be
+        # available on the runner for Windows and macOS. Installing
+        # cibuildwheel with the `uv` extra bundles uv with it; Linux
+        # already has uv inside the manylinux/musllinux container.
+        extras: uv
 
     - name: Upload built artifacts for testing and publishing
       uses: actions/upload-artifact@v7

--- a/CHANGES/1699.contrib.rst
+++ b/CHANGES/1699.contrib.rst
@@ -1,0 +1,6 @@
+Switched the ``cibuildwheel`` build frontend to ``build[uv]`` so
+that ``uv`` provisions every build and test virtual environment
+in the wheel matrix. Test-dependency installation in particular
+drops from a multi-second ``pip install`` per ABI to a roughly
+sub-second ``uv`` resolve
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -29,6 +29,7 @@ dev
 dists
 downstreams
 facto
+frontend
 glibc
 google
 hardcoded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,17 +143,14 @@ select = [
   "PLC0415",
 ]
 
+# `build[uv]` makes cibuildwheel use `uv` for every venv it provisions,
+# both on the build side (passed to `python -m build` as `--installer=uv`)
+# and when materializing the test environment. uv resolves and installs
+# the wheel plus `requirements/test-cibuildwheel.txt` in roughly a second;
+# the previous pip-based path took noticeably longer per ABI and ran once
+# per matrix cell.
 [tool.cibuildwheel]
-build-frontend = "build"
-before-test = [
-  # NOTE: Attempt to have pip pre-compile PyYAML wheel with our build
-  # NOTE: constraints unset. The hope is that pip will cache that wheel
-  # NOTE: and the test env provisioning stage will pick up PyYAML from
-  # NOTE: said cache rather than attempting to build it with a conflicting.
-  # NOTE: Version of Cython.
-  # Ref: https://github.com/pypa/cibuildwheel/issues/1666
-  "PIP_CONSTRAINT= pip install PyYAML",
-]
+build-frontend = "build[uv]"
 test-requires = "-r requirements/test-cibuildwheel.txt"
 test-command = 'pytest -v -m "not hypothesis" --no-cov {project}/tests'
 # don't build PyPy wheels, install from source instead
@@ -169,6 +166,3 @@ PY_COLORS = "1"
 
 [tool.cibuildwheel.config-settings]
 pure-python = "false"
-
-[tool.cibuildwheel.windows]
-before-test = []  # Windows cmd has different syntax and pip chooses wheels


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Set ``build-frontend = "build[uv]"`` in ``[tool.cibuildwheel]``
so that ``uv`` provisions every virtual environment cibuildwheel
creates, both on the build side (passed to ``python -m build``
as ``--installer=uv``) and when materializing the per-ABI test
environment. The previous ``build-frontend = "build"`` left
every test env doing a multi-second pip resolve of
``requirements/test-cibuildwheel.txt`` per ABI; ``uv`` resolves
and installs the same set in roughly a second, which compounds
across the wheel matrix.

Passes ``extras: uv`` to the ``pypa/cibuildwheel`` action so the
``uv`` binary is bundled with cibuildwheel on the macOS and
Windows runners; on Linux the manylinux/musllinux containers
already ship ``uv``. Drops the now-unneeded PyYAML pre-cache
``before-test`` hook and the empty ``[tool.cibuildwheel.windows]``
override that paired with it. Also adds ``frontend`` to
``docs/spelling_wordlist.txt`` so the news fragment passes the
docs spell check.

## Are there changes in behavior for the user?

No, contributor tooling only.

## Is it a substantial burden for the maintainers to support this?

No, it removes config rather than adding it; the wheel matrix on
this PR is the verification path.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (CI-only change; the wheel-matrix run on this PR is the verification path)
- [x] Documentation reflects the changes: N/A (no user-visible API change)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``: N/A (no such file in this repo)
- [x] Add a new news fragment into the ``CHANGES/`` folder (``CHANGES/1699.contrib.rst``; rename if the PR lands at a different number)

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Local validation:

\`\`\`
$ make doc-spelling
7 pre-existing misspellings only (``quoter``, ``subdirectory``, ``Deprecations``, ``recode``, ``unobvious`` in ``CHANGES.rst`` and ``CHANGES/README.rst``); ``CHANGES/1699.contrib.rst`` is clean after adding ``frontend`` to the wordlist.
\`\`\`

Not verified locally: the actual cibuildwheel + uv interaction
inside the build container; that requires running cibuildwheel
which is impractical without pushing. The live CI run on this
branch is the verification.

Existing ``PIP_CONSTRAINT = "requirements/cython.txt"`` under
``[tool.cibuildwheel.environment]`` is left in place; ``uv``
ignores it (``uv`` reads ``UV_CONSTRAINT`` /
``UV_BUILD_CONSTRAINT``). If the wheel build ends up needing
the Cython pin to apply during ``uv``-driven build dependency
resolution, a follow-up can add a parallel
``UV_BUILD_CONSTRAINT`` entry.

This change mirrors the propcache change in
aio-libs/propcache#234.
</details>