### PR TITLE
ci: switch lint and codspeed jobs to uv-native install

### DIFF
--- a/.github/workflows/reusable-codspeed.yml
+++ b/.github/workflows/reusable-codspeed.yml
@@ -97,71 +97,29 @@ jobs:
 
     - name: Setup Python 3.13
       id: python-install
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: 3.13
-    - name: >-
-        Calculate dependency files' combined hash value
-        for use in the cache key
-      id: calc-cache-key-files
-      uses: ./.github/actions/cache-keys
-    - name: Set up pip cache
-      uses: re-actors/cache-python-deps@release/v1
-      with:
-        cache-key-for-dependency-files: >-
-          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
+        activate-environment: true
+        enable-cache: true
 
-    - name: Determine pre-compiled compatible wheel
-      if: inputs.pypi-project-name != ''
-      env:
-        # NOTE: When `pip` is forced to colorize output piped into `jq`,
-        # NOTE: the latter can't parse it. So we're overriding the color
-        # NOTE: preference here via https://no-color.org.
-        # NOTE: Setting `FORCE_COLOR` to any value (including 0, an empty
-        # NOTE: string, or a "YAML null" `~`) doesn't have any effect and
-        # NOTE: `pip` (through its verndored copy of `rich`) treats the
-        # NOTE: presence of the variable as "force-color" regardless.
-        #
-        # NOTE: This doesn't actually work either, so we'll resort to unsetting
-        # NOTE: in the Bash script.
-        # NOTE: Ref: https://github.com/Textualize/rich/issues/2622
-        NO_COLOR: 1
-        PROJECT_NAME: ${{ inputs.pypi-project-name }}
-      id: wheel-file
-      run: >
-        echo -n path= | tee -a "${GITHUB_OUTPUT}"
-
-
-        unset FORCE_COLOR
-
-
-        python
-        -X utf8
-        -u -I
-        -m pip install
-        --find-links=./dist
-        --no-index
-        "${PROJECT_NAME}"
-        --force-reinstall
-        --no-color
-        --no-deps
-        --only-binary=:all:
-        --dry-run
-        --report=-
-        --quiet
-        | jq --raw-output .install[].download_info.url
-        | tee -a "${GITHUB_OUTPUT}"
-      shell: bash
     - name: Install benchmark deps and the project from a pre-built wheel
       if: inputs.pypi-project-name != ''
-      run: >-
-        python -Im pip install
-        -r requirements/codspeed.txt
-        '${{ steps.wheel-file.outputs.path }}'
+      env:
+        PROJECT_NAME: ${{ inputs.pypi-project-name }}
+      run: |
+        uv pip install -r requirements/codspeed.txt
+        uv pip install \
+          --find-links=./dist \
+          --no-index \
+          --no-deps \
+          --force-reinstall \
+          --only-binary=:all: \
+          "${PROJECT_NAME}"
     - name: Install benchmark deps and the project from source
       if: inputs.pypi-project-name == ''
       run: >-
-        python -Im pip install
+        uv pip install
         -r requirements/codspeed.txt
         .
         --config-setting=pure-python=false

--- a/.github/workflows/reusable-linters.yml
+++ b/.github/workflows/reusable-linters.yml
@@ -29,19 +29,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Setup Python ${{ env.PYTHON_LATEST }}
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ env.PYTHON_LATEST }}
-    - name: >-
-        Calculate dependency files' combined hash value
-        for use in the cache key
-      id: calc-cache-key-files
-      uses: ./.github/actions/cache-keys
-    - name: Set up pip cache
-      uses: re-actors/cache-python-deps@release/v1
-      with:
-        cache-key-for-dependency-files: >-
-          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
+        activate-environment: true
+        enable-cache: true
     - name: Cache pre-commit.com virtualenvs
       uses: actions/cache@v5
       with:
@@ -53,12 +45,9 @@ jobs:
             hashFiles('.pre-commit-config.yaml')
           }}
     - name: Install dependencies
-      uses: py-actions/py-dependency-install@v4
-      with:
-        path: requirements/lint.txt
+      run: uv pip install -r requirements/lint.txt
     - name: Self-install
-      run: |
-        pip install .
+      run: uv pip install .
     - name: Run linters
       run: |
         make lint
@@ -75,13 +64,13 @@ jobs:
     - name: Install spell checker
       run: |
         sudo apt install libenchant-2-dev
-        pip install -r requirements/doc-spelling.txt
+        uv pip install -r requirements/doc-spelling.txt
     - name: Run docs spelling
       run: |
         make doc-spelling
     - name: Prepare twine checker
       run: |
-        pip install -U build twine
+        uv pip install -U build twine
         python -m build --config-setting=pure-python=true
     - name: Run twine checker
       run: |

--- a/CHANGES/1705.contrib.rst
+++ b/CHANGES/1705.contrib.rst
@@ -1,0 +1,6 @@
+Switched the linter and CodSpeed CI jobs from ``actions/setup-python``
+to ``astral-sh/setup-uv``, matching the change already in the test
+matrix and removing the ``re-actors/cache-python-deps`` /
+``py-actions/py-dependency-install`` middleware in favour of
+``uv pip install`` directly
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Follow-up to #1704. Apply the same ``actions/setup-python`` →
``astral-sh/setup-uv`` swap to the two remaining workflows that
use the ``re-actors/cache-python-deps`` wrapper:

* ``.github/workflows/reusable-linters.yml`` (the linter job)
* ``.github/workflows/reusable-codspeed.yml`` (the CodSpeed
  benchmark job)

Both jobs now use ``setup-uv`` with ``activate-environment: true``
and ``enable-cache: true``, drop the cache-key + pip-cache pair,
and install everything via ``uv pip install`` directly.

## Are there changes in behavior for the user?

No. CI-only change; end-user-visible behavior of ``yarl`` is
unaffected.

## Is it a substantial burden for the maintainer to support this?

No. The swap mirrors the one already merged for the test matrix
in #1704; no new dependencies, no new public surface.

``.github/workflows/aiohttp.yml`` is **intentionally left on
``actions/setup-python``**: it only runs on ``ubuntu-latest`` with
``3.13`` (sub-1s setup from the tool-cache) and shells out to
upstream aiohttp's ``make .develop`` target, which calls ``pip``
directly. Migrating it would require seeding ``pip`` back into a
uv-managed venv solely to keep that Makefile happy, with no perf
upside.

## Related issue number

Follow-up to #1703 / #1704.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist — N/A (CI configuration)
- [x] Documentation reflects the changes — N/A (no user-visible change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder (``1705.contrib.rst``)

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Verified locally that ``uv pip install -r requirements/lint.txt``
and ``uv pip install -r requirements/codspeed.txt`` resolve cleanly
in an unseeded uv venv, and that ``uv pip install`` accepts the
``--config-setting`` form used by the from-source codspeed install.

Pre-commit (yamllint, actionlint) passes on both modified workflows.

</details>