### PR TITLE
Restore pytest-xdist auto on aiohttp 3.14 CI runner

### DIFF
--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -61,7 +61,9 @@ jobs:
       run: >-
         python -m pip install -e .
     - name: Run tests
-      run: python -m pytest
+      # aiohttp 3.14+ no longer enables xdist via its setup.cfg, so pass
+      # --numprocesses=auto here to keep the run parallel on every branch.
+      run: python -m pytest --numprocesses=auto
       shell: bash
 
 ...


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Restore pytest-xdist auto on aiohttp 3.14 runner

## Are there changes in behavior for the user?

no

## Related issue number

was removed in https://github.com/aio-libs/aiohttp/pull/12364


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
