### PR TITLE
Switch the test job to astral-sh/setup-uv

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -392,66 +392,36 @@ jobs:
 
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.pyver }}
-        allow-prereleases: true
-    - name: >-
-        Calculate dependency files' combined hash value
-        for use in the cache key
-      id: calc-cache-key-files
-      uses: ./.github/actions/cache-keys
-    - name: Set up pip cache
-      uses: re-actors/cache-python-deps@release/v1
-      with:
-        cache-key-for-dependency-files: >-
-          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
+        activate-environment: true
+        # Pre-release interpreters (alpha/beta/rc, `-dev`, or `~`-pinned
+        # latest) skip the wheel cache so each run resolves freshly
+        # against whatever the current snapshot ships.
+        enable-cache: >-
+          ${{
+            (
+              startsWith(matrix.pyver, '~')
+              || endsWith(matrix.pyver, '-dev')
+              || contains(matrix.pyver, 'a')
+              || contains(matrix.pyver, 'b')
+              || contains(matrix.pyver, 'rc')
+            )
+            && 'false'
+            || 'true'
+          }}
     - name: Install dependencies
-      uses: py-actions/py-dependency-install@v4
-      with:
-        path: >-
-          requirements/test.txt
-    - name: Determine pre-compiled compatible wheel
-      env:
-        # NOTE: When `pip` is forced to colorize output piped into `jq`,
-        # NOTE: the latter can't parse it. So we're overriding the color
-        # NOTE: preference here via https://no-color.org.
-        # NOTE: Setting `FORCE_COLOR` to any value (including 0, an empty
-        # NOTE: string, or a "YAML null" `~`) doesn't have any effect and
-        # NOTE: `pip` (through its verndored copy of `rich`) treats the
-        # NOTE: presence of the variable as "force-color" regardless.
-        #
-        # NOTE: This doesn't actually work either, so we'll resort to unsetting
-        # NOTE: in the Bash script.
-        # NOTE: Ref: https://github.com/Textualize/rich/issues/2622
-        NO_COLOR: 1
-      id: wheel-file
-      run: >
-        echo -n path= | tee -a "${GITHUB_OUTPUT}"
-
-
-        unset FORCE_COLOR
-
-
-        python
-        -X utf8
-        -u -I
-        -m pip install
+      run: uv pip install -r requirements/test.txt
+    - name: Install ${{ env.PROJECT_NAME }} from a pre-built wheel
+      run: >-
+        uv pip install
         --find-links=./dist
         --no-index
-        '${{ env.PROJECT_NAME }}'
-        --force-reinstall
-        --no-color
         --no-deps
+        --force-reinstall
         --only-binary=:all:
-        --dry-run
-        --report=-
-        --quiet
-        | jq --raw-output .install[].download_info.url
-        | tee -a "${GITHUB_OUTPUT}"
-      shell: bash
-    - name: Self-install
-      run: python -Im pip install '${{ steps.wheel-file.outputs.path }}'
+        '${{ env.PROJECT_NAME }}'
     - name: Produce the C-files for the Coverage.py Cython plugin
       if: >-  # Only works if the dists were built with line tracing
         !matrix.no-extensions
@@ -464,7 +434,7 @@ jobs:
       run: |
         set -eEuo pipefail
 
-        python -Im pip install expandvars
+        uv pip install expandvars
         python -m pep517_backend.cli translate-cython
       shell: bash
     - name: Disable the Cython.Coverage Produce plugin

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -392,6 +392,9 @@ jobs:
 
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
+      # important: do not use system python
+      env:
+        UV_PYTHON_PREFERENCE: only-managed
       uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.pyver }}

--- a/.github/workflows/reusable-codspeed.yml
+++ b/.github/workflows/reusable-codspeed.yml
@@ -97,72 +97,29 @@ jobs:
 
     - name: Setup Python 3.13
       id: python-install
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: 3.13
-    - name: >-
-        Calculate dependency files' combined hash value
-        for use in the cache key
-      id: calc-cache-key-files
-      uses: ./.github/actions/cache-keys
-    - name: Set up pip cache
-      uses: re-actors/cache-python-deps@release/v1
-      with:
-        cache-key-for-dependency-files: >-
-          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
-
-    - name: Determine pre-compiled compatible wheel
+        activate-environment: true
+        enable-cache: true
+    - name: Install benchmark dependencies
+      run: uv pip install -r requirements/codspeed.txt
+    - name: Install ${{ inputs.pypi-project-name }} from a pre-built wheel
       if: inputs.pypi-project-name != ''
       env:
-        # NOTE: When `pip` is forced to colorize output piped into `jq`,
-        # NOTE: the latter can't parse it. So we're overriding the color
-        # NOTE: preference here via https://no-color.org.
-        # NOTE: Setting `FORCE_COLOR` to any value (including 0, an empty
-        # NOTE: string, or a "YAML null" `~`) doesn't have any effect and
-        # NOTE: `pip` (through its verndored copy of `rich`) treats the
-        # NOTE: presence of the variable as "force-color" regardless.
-        #
-        # NOTE: This doesn't actually work either, so we'll resort to unsetting
-        # NOTE: in the Bash script.
-        # NOTE: Ref: https://github.com/Textualize/rich/issues/2622
-        NO_COLOR: 1
         PROJECT_NAME: ${{ inputs.pypi-project-name }}
-      id: wheel-file
-      run: >
-        echo -n path= | tee -a "${GITHUB_OUTPUT}"
-
-
-        unset FORCE_COLOR
-
-
-        python
-        -X utf8
-        -u -I
-        -m pip install
+      run: >-
+        uv pip install
         --find-links=./dist
         --no-index
-        "${PROJECT_NAME}"
-        --force-reinstall
-        --no-color
         --no-deps
+        --force-reinstall
         --only-binary=:all:
-        --dry-run
-        --report=-
-        --quiet
-        | jq --raw-output .install[].download_info.url
-        | tee -a "${GITHUB_OUTPUT}"
-      shell: bash
-    - name: Install benchmark deps and the project from a pre-built wheel
-      if: inputs.pypi-project-name != ''
-      run: >-
-        python -Im pip install
-        -r requirements/codspeed.txt
-        '${{ steps.wheel-file.outputs.path }}'
-    - name: Install benchmark deps and the project from source
+        "${PROJECT_NAME}"
+    - name: Install the project from source
       if: inputs.pypi-project-name == ''
       run: >-
-        python -Im pip install
-        -r requirements/codspeed.txt
+        uv pip install
         .
         --config-setting=pure-python=false
         --config-setting=with-cython-tracing=false

--- a/.github/workflows/reusable-codspeed.yml
+++ b/.github/workflows/reusable-codspeed.yml
@@ -97,32 +97,72 @@ jobs:
 
     - name: Setup Python 3.13
       id: python-install
-      # important: do not use system python
-      env:
-        UV_PYTHON_PREFERENCE: only-managed
-      uses: astral-sh/setup-uv@v8.1.0
+      uses: actions/setup-python@v6
       with:
         python-version: 3.13
-        activate-environment: true
-        enable-cache: true
-    - name: Install benchmark dependencies
-      run: uv pip install -r requirements/codspeed.txt
-    - name: Install ${{ inputs.pypi-project-name }} from a pre-built wheel
+    - name: >-
+        Calculate dependency files' combined hash value
+        for use in the cache key
+      id: calc-cache-key-files
+      uses: ./.github/actions/cache-keys
+    - name: Set up pip cache
+      uses: re-actors/cache-python-deps@release/v1
+      with:
+        cache-key-for-dependency-files: >-
+          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
+
+    - name: Determine pre-compiled compatible wheel
       if: inputs.pypi-project-name != ''
       env:
+        # NOTE: When `pip` is forced to colorize output piped into `jq`,
+        # NOTE: the latter can't parse it. So we're overriding the color
+        # NOTE: preference here via https://no-color.org.
+        # NOTE: Setting `FORCE_COLOR` to any value (including 0, an empty
+        # NOTE: string, or a "YAML null" `~`) doesn't have any effect and
+        # NOTE: `pip` (through its verndored copy of `rich`) treats the
+        # NOTE: presence of the variable as "force-color" regardless.
+        #
+        # NOTE: This doesn't actually work either, so we'll resort to unsetting
+        # NOTE: in the Bash script.
+        # NOTE: Ref: https://github.com/Textualize/rich/issues/2622
+        NO_COLOR: 1
         PROJECT_NAME: ${{ inputs.pypi-project-name }}
-      run: >-
-        uv pip install
+      id: wheel-file
+      run: >
+        echo -n path= | tee -a "${GITHUB_OUTPUT}"
+
+
+        unset FORCE_COLOR
+
+
+        python
+        -X utf8
+        -u -I
+        -m pip install
         --find-links=./dist
         --no-index
-        --no-deps
-        --force-reinstall
-        --only-binary=:all:
         "${PROJECT_NAME}"
-    - name: Install the project from source
+        --force-reinstall
+        --no-color
+        --no-deps
+        --only-binary=:all:
+        --dry-run
+        --report=-
+        --quiet
+        | jq --raw-output .install[].download_info.url
+        | tee -a "${GITHUB_OUTPUT}"
+      shell: bash
+    - name: Install benchmark deps and the project from a pre-built wheel
+      if: inputs.pypi-project-name != ''
+      run: >-
+        python -Im pip install
+        -r requirements/codspeed.txt
+        '${{ steps.wheel-file.outputs.path }}'
+    - name: Install benchmark deps and the project from source
       if: inputs.pypi-project-name == ''
       run: >-
-        uv pip install
+        python -Im pip install
+        -r requirements/codspeed.txt
         .
         --config-setting=pure-python=false
         --config-setting=with-cython-tracing=false

--- a/.github/workflows/reusable-codspeed.yml
+++ b/.github/workflows/reusable-codspeed.yml
@@ -57,7 +57,6 @@ env:
   PY_COLORS: 1  # Recognized by the `py` package, dependency of `pytest`
   PYTHONIOENCODING: utf-8
   PYTHONUTF8: 1
-  UV_PYTHON_PREFERENCE: only-managed  # avoid ancient system Python
 
 jobs:
 
@@ -98,6 +97,9 @@ jobs:
 
     - name: Setup Python 3.13
       id: python-install
+      # important: do not use system python
+      env:
+        UV_PYTHON_PREFERENCE: only-managed
       uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: 3.13

--- a/.github/workflows/reusable-codspeed.yml
+++ b/.github/workflows/reusable-codspeed.yml
@@ -57,6 +57,7 @@ env:
   PY_COLORS: 1  # Recognized by the `py` package, dependency of `pytest`
   PYTHONIOENCODING: utf-8
   PYTHONUTF8: 1
+  UV_PYTHON_PREFERENCE: only-managed  # avoid ancient system Python
 
 jobs:
 

--- a/CHANGES/1715.contrib.rst
+++ b/CHANGES/1715.contrib.rst
@@ -1,0 +1,6 @@
+Switched the CI ``test`` and CodSpeed benchmark jobs from
+``actions/setup-python`` to ``astral-sh/setup-uv`` with ``uv pip
+install``, mirroring the same change in ``propcache``. Pre-release
+interpreters skip the wheel cache so each run resolves freshly
+against the current snapshot
+-- by :user:`bdraco`.

--- a/CHANGES/1715.contrib.rst
+++ b/CHANGES/1715.contrib.rst
@@ -1,6 +1,5 @@
 Switched the CI ``test`` and CodSpeed benchmark jobs from
 ``actions/setup-python`` to ``astral-sh/setup-uv`` with ``uv pip
-install``, mirroring the same change in ``propcache``. Pre-release
-interpreters skip the wheel cache so each run resolves freshly
-against the current snapshot
+install``. Pre-release interpreters skip the wheel cache so each
+run resolves freshly against the current snapshot
 -- by :user:`bdraco`.

--- a/CHANGES/1715.contrib.rst
+++ b/CHANGES/1715.contrib.rst
@@ -1,5 +1,5 @@
-Switched the CI ``test`` and CodSpeed benchmark jobs from
-``actions/setup-python`` to ``astral-sh/setup-uv`` with ``uv pip
-install``. Pre-release interpreters skip the wheel cache so each
-run resolves freshly against the current snapshot
+Switched the CI ``test`` job from ``actions/setup-python`` to
+``astral-sh/setup-uv`` with ``uv pip install``. Pre-release
+interpreters skip the wheel cache so each run resolves freshly
+against the current snapshot
 -- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Switches the CI ``test`` job in ``.github/workflows/ci-cd.yml``
from ``actions/setup-python`` plus ``pip`` to
``astral-sh/setup-uv`` plus ``uv pip install``.
``UV_PYTHON_PREFERENCE: only-managed`` is scoped to the
``setup-uv`` step (matching aio-libs/aiohttp#12629). Pre-release
interpreters (alpha, beta, rc, ``-dev``, or ``~``-pinned latest)
skip the wheel cache so each run resolves freshly against the
current snapshot.

The CodSpeed benchmark workflow (``reusable-codspeed.yml``) is
left on ``actions/setup-python``; an earlier revision of this PR
swapped it too, and the CodSpeed runner reported missing
profiling data on the resulting uv-managed interpreter, so that
change was reverted.

## Are there changes in behavior for the user?

No. CI-only change; end-user-visible behavior of ``yarl`` is
unaffected.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

N/A; follow-up to #1711.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist -- N/A (CI configuration)
- [x] Documentation reflects the changes -- N/A (no user-visible change)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Local verification:

- ``pre-commit run --files .github/workflows/ci-cd.yml
  CHANGES/1715.contrib.rst`` passes (yamllint, actionlint,
  GHA workflow validators, codespell, timeout-minutes check).
- ``make doc-spelling`` produces only the seven pre-existing
  misspellings already on ``master``; the new
  ``CHANGES/1715.contrib.rst`` fragment is clean.

Scope intentionally narrow:

- Only the ``test`` job in ``ci-cd.yml`` moves to ``uv``. The
  ``cibuildwheel`` job and the tox-driven jobs added in #1711
  are untouched.
- ``reusable-codspeed.yml`` was rolled back after a previous
  revision lost CodSpeed profiling data on the uv-managed
  interpreter.

</details>