### PR TITLE
Switch the aiohttp workflow to astral-sh/setup-uv

### DIFF
--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -46,11 +46,15 @@ jobs:
       with:
         path: vendor/yarl
     - name: Setup Python
-      uses: actions/setup-python@v6
+      id: python-install
+      # important: do not use system python
+      env:
+        UV_PYTHON_PREFERENCE: only-managed
+      uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: "3.13"
-        cache: pip
-        cache-dependency-path: requirements/*.txt
+        activate-environment: true
+        enable-cache: true
     - name: Provision the dev env
       run: make .develop
     - name: Cythonize yarl
@@ -59,7 +63,7 @@ jobs:
     - name: Install yarl
       working-directory: vendor/yarl
       run: >-
-        python -m pip install -e .
+        uv pip install -e .
     - name: Run tests
       # aiohttp 3.14+ no longer enables xdist via its setup.cfg, so pass
       # --numprocesses=auto here to keep the run parallel on every branch.

--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -55,6 +55,10 @@ jobs:
         python-version: "3.13"
         activate-environment: true
         enable-cache: true
+    - name: Seed pip into the uv-managed venv
+      # aiohttp's `make .develop` shells out to `pip` / `python -m pip`,
+      # which uv's managed venvs omit by default.
+      run: uv pip install pip wheel setuptools
     - name: Provision the dev env
       run: make .develop
     - name: Cythonize yarl

--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -55,10 +55,8 @@ jobs:
         python-version: "3.13"
         activate-environment: true
         enable-cache: true
-    - name: Seed pip into the uv-managed venv
-      # aiohttp's `make .develop` shells out to `pip` / `python -m pip`,
-      # which uv's managed venvs omit by default.
-      run: uv pip install pip wheel setuptools
+    - name: Update pip, wheel, setuptools
+      run: uv pip install -U pip wheel setuptools
     - name: Provision the dev env
       run: make .develop
     - name: Cythonize yarl

--- a/CHANGES/1716.contrib.rst
+++ b/CHANGES/1716.contrib.rst
@@ -1,0 +1,5 @@
+Switched the ``Aiohttp`` workflow that runs the aiohttp test
+suite against the in-tree yarl checkout from
+``actions/setup-python`` to ``astral-sh/setup-uv`` with ``uv
+pip install``
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Switches the ``Aiohttp`` workflow
(``.github/workflows/aiohttp.yml``), which runs the aiohttp test
suite against the in-tree yarl checkout, from
``actions/setup-python`` to ``astral-sh/setup-uv`` and replaces
``python -m pip install -e .`` with ``uv pip install -e .``.
``UV_PYTHON_PREFERENCE: only-managed`` is scoped to the
``setup-uv`` step. The previous ``cache: pip`` /
``cache-dependency-path`` pair is subsumed by ``enable-cache:
true`` on ``setup-uv``.

Follow-up to #1715, applying the same pattern to the workflow
left out of that change.

## Are there changes in behavior for the user?

No. CI-only change; end-user-visible behavior of ``yarl`` is
unaffected.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

N/A; follow-up to #1715.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist -- N/A (CI configuration)
- [x] Documentation reflects the changes -- N/A (no user-visible change)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

Local verification:

- ``pre-commit run --files .github/workflows/aiohttp.yml`` passes
  (yamllint, actionlint, GHA workflow validators, codespell,
  timeout-minutes check).

</details>