### PR TITLE
Pass PIP="uv pip" to make .develop in aiohttp workflow

### DIFF
--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Update pip, wheel, setuptools
       run: uv pip install -U pip wheel setuptools
     - name: Provision the dev env
-      run: make .develop
+      run: make .develop PIP="uv pip"
     - name: Cythonize yarl
       working-directory: vendor/yarl
       run: make cythonize

--- a/CHANGES/1717.contrib.rst
+++ b/CHANGES/1717.contrib.rst
@@ -1,0 +1,4 @@
+Switched the ``Aiohttp`` workflow's ``make .develop`` step to
+install aiohttp's dev env through ``uv pip`` by passing
+``PIP="uv pip"``
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Pass ``PIP="uv pip"`` to ``make .develop`` in the ``Aiohttp`` workflow so aiohttp's dev env installs through uv instead of falling back to plain pip inside the Makefile.

## Are there changes in behavior for the user?

No; CI-only change to the downstream aiohttp test runner.

## Is it a substantial burden for the maintainers to support this?

No; one argument added to a ``make`` invocation.

## Related issue number

Depends on aio-libs/aiohttp#12641 (master), aio-libs/aiohttp#12644 (3.13 backport), aio-libs/aiohttp#12642 (3.14 backport), which add the ``PIP`` variable to aiohttp's Makefile.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
  * N/A, CI workflow change.
- [ ] Documentation reflects the changes
  * N/A, internal CI knob.
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
  * Already listed.
- [x] Add a new news fragment into the ``CHANGES/`` folder
  * ``CHANGES/1717.contrib.rst``.

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.