### PR TITLE
Allow optional 'v' prefix in release head_line regex

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -680,7 +680,7 @@ jobs:
         version_file: ${{ env.PROJECT_NAME }}/__init__.py
         github_token: ${{ secrets.GITHUB_TOKEN }}
         head_line: >-
-          v{version}\n=+\n\n\*\({date}\)\*\n
+          v?{version}\n=+\n\n\*\({date}\)\*\n
         fix_issue_regex: >-
           :issue:`(\d+)`
         fix_issue_repl: >-


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Loosens the ``head_line`` regex used by ``aio-libs/create-release`` to
accept the leading ``v`` that ``towncrier`` 25.x writes on the new
section header (per ``title_format = "v{version}"`` in
``towncrier.toml``), while still matching the older unprefixed
section headers already present in ``CHANGES.rst``.

Without this, the regex matches the new ``v1.x.y`` block at the top
of the file but fails to find the next-section boundary against the
historical unprefixed headers below it, so ``get-releasenote`` spills
the entire changelog into the GitHub release notes instead of just
the latest section.

## Are there changes in behavior for the user?

No, this only affects the release workflow's release-note extraction.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist — N/A, workflow regex
- [ ] Documentation reflects the changes — N/A
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [ ] Add a new news fragment into the ``CHANGES/`` folder — skipped at maintainer's request

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Reproduced locally with ``towncrier==25.8.0`` against the project's
``towncrier.toml`` and ``CHANGES/.TEMPLATE.rst``. Confirmed:

* Old regex (``v{version}\n=+\n...``): matches new ``v1.24.0`` head
  but ``search`` past the match returns ``None`` because the next
  header is ``1.23.0`` (unprefixed), so release notes capture
  everything to EOF.
* New regex (``v?{version}\n=+\n...``): matches both shapes; the
  next-section search finds the legacy ``1.23.0`` header and the
  extracted notes contain only the new section.

</details>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.