### PR TITLE
Make the deploy job re-runnable after a partial release failure

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -680,17 +680,23 @@ jobs:
     - name: Check whether the GitHub Release already exists
       # Allows re-running the deploy job after a partial failure (e.g. PyPI
       # upload error) without the Make Release step failing with HTTP 422
-      # because the tag/release was created on a prior attempt.
+      # because the tag/release was created on a prior attempt. Treat
+      # only the literal `release not found` reply as "does not exist";
+      # other failures (auth, rate-limit, network) re-raise so the job
+      # fails loudly instead of falling through to Make Release.
       id: gh-release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.ref_name }}
       run: |
         if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-            >/dev/null 2>&1; then
+            >/dev/null 2>err; then
           echo 'exists=true' >> "${GITHUB_OUTPUT}"
-        else
+        elif grep -qx 'release not found' err; then
           echo 'exists=false' >> "${GITHUB_OUTPUT}"
+        else
+          cat err >&2
+          exit 1
         fi
     - name: Make Release
       if: steps.gh-release.outputs.exists != 'true'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -677,7 +677,23 @@ jobs:
     - name: Login
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+    - name: Check whether the GitHub Release already exists
+      # Allows re-running the deploy job after a partial failure (e.g. PyPI
+      # upload error) without the Make Release step failing with HTTP 422
+      # because the tag/release was created on a prior attempt.
+      id: gh-release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+            >/dev/null 2>&1; then
+          echo 'exists=true' >> "${GITHUB_OUTPUT}"
+        else
+          echo 'exists=false' >> "${GITHUB_OUTPUT}"
+        fi
     - name: Make Release
+      if: steps.gh-release.outputs.exists != 'true'
       uses: aio-libs/create-release@v1.6.6
       with:
         changes_file: CHANGES.rst
@@ -693,6 +709,10 @@ jobs:
     - name: >-
         Publish 🐍📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        # Allow re-running the deploy job after a partial PyPI upload
+        # without failing on dists that were already published.
+        skip-existing: true
 
     - name: Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v3.3.0

--- a/CHANGES/1721.contrib.rst
+++ b/CHANGES/1721.contrib.rst
@@ -1,0 +1,5 @@
+Allowed re-running the deploy job after a partial release failure: the
+``Make Release`` step now skips when the GitHub Release already exists,
+and the PyPI publish step uses ``skip-existing`` so dists that were
+already uploaded on a prior attempt do not break the retry
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Make the ``deploy`` job in ``ci-cd.yml`` re-runnable after a partial
release failure.

- The ``Make Release`` step is now gated on a preceding ``gh release
  view`` check, so it is skipped when the GitHub Release for the tag
  already exists (instead of failing with ``HTTP 422 already_exists``).
- The PyPI publish step is invoked with ``skip-existing: true`` so a
  retry does not fail on dists that were already uploaded.

Concretely, this means that if PyPI returns a 5xx (or any other
transient failure after the GitHub Release was created), the maintainer
can re-run the failed ``deploy`` job instead of cutting a brand-new
release. The ``v1.24.0`` cut hit exactly this: run [26108327868][r1]
created the Release, run [26110409646][r2] then failed at ``Make
Release`` because the tag already existed.

[r1]: https://github.com/aio-libs/yarl/actions/runs/26108327868
[r2]: https://github.com/aio-libs/yarl/actions/runs/26110409646/job/76798068142

## Are there changes in behavior for the user?

No. This only affects how the release pipeline recovers from partial
failures; the produced artifacts and release are unchanged.

## Is it a substantial burden for the maintainers to support this?

No; it removes a manual recovery step.

## Related issue number

Refs the v1.24.0 publish failure linked above; no tracking issue.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist — N/A (CI workflow change, exercised by the next release run)
- [ ] Documentation reflects the changes — N/A
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt`` — already listed
- [x] Add a new news fragment into the ``CHANGES/`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.

Local checks:
- ``make doc-spelling`` — passes for the new fragment (the 7 misspelled-word warnings are pre-existing on ``master`` in ``CHANGES.rst`` and ``CHANGES/README.rst``; the fragment added here does not contribute any new ones).
- ``yamllint`` (via pre-commit) — passes for the workflow change.
</details>