### PR TITLE
ci: pin CIBW_ARCHS_WINDOWS per runner to avoid wheel name collisions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -274,7 +274,12 @@ jobs:
       # CIBW_CONFIG_SETTINGS: `pure-python` — force C-extensions
       # CIBW_ARCHS_*: on PR/non-tag, only build the arches that the test matrix
       # actually consumes (linux x86_64 from cibw default, macos arm64,
-      # windows AMD64). Tag releases keep the full arch set.
+      # windows AMD64). Tag releases keep the full arch set; CIBW_ARCHS_WINDOWS
+      # is pinned per runner so each Windows host builds only its native arch.
+      # Building both arches on both Windows runners produced two artifacts
+      # with identically-named wheels but different bytes, which the Deploy
+      # job's `download-artifact ... merge-multiple: true` step then tore
+      # together, yielding a wheel PyPI rejected with `Mis-matched data size`.
       environment-variables: |-
         CIBW_ARCHS_MACOS=${{
           (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
@@ -283,9 +288,7 @@ jobs:
         }}
 
         CIBW_ARCHS_WINDOWS=${{
-          (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
-          && 'AMD64 ARM64'
-          || 'AMD64'
+          matrix.runner-vm-os == 'windows-11-arm' && 'ARM64' || 'AMD64'
         }}
 
         CIBW_CONFIG_SETTINGS<<EOF

--- a/CHANGES/1725.contrib.rst
+++ b/CHANGES/1725.contrib.rst
@@ -1,0 +1,9 @@
+Restored per-runner native arches in the Windows wheel matrix on tag
+releases. The previous ``CIBW_ARCHS_WINDOWS=AMD64 ARM64`` setting made
+both ``windows-latest`` and ``windows-11-arm`` cross-compile the other
+arch, producing two artifacts with identically-named wheels whose
+bytes differed; the deploy job's ``download-artifact ... merge-multiple``
+step tore those writes together, yielding a wheel that PyPI rejected
+with ``400 Invalid distribution file. ZIP archive not accepted:
+Mis-matched data size`` during the 1.24.0 and 1.24.1 releases
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Scope ``CIBW_ARCHS_WINDOWS`` to each runner's native architecture on
tag pushes, so ``windows-latest`` emits only ``win_amd64`` wheels and
``windows-11-arm`` emits only ``win_arm64`` wheels. #1692 had set both
runners to ``AMD64 ARM64``, which made each cross-compile the other
arch and produce two artifacts containing identically-named wheels
with different bytes. The Deploy job's ``download-artifact ...
merge-multiple: true`` step then tore those writes together, yielding
a wheel PyPI rejected with ``400 Invalid distribution file. ZIP
archive not accepted: Mis-matched data size``. This is what broke
the 1.24.0 and 1.24.1 release uploads.

## Are there changes in behavior for the user?

No. Same set of wheels still published on tag releases; only the
build assignment between the two Windows runners changes.

## Is it a substantial burden for the maintainers to support this?

No, the workflow becomes slightly simpler.

## Related issue number

Fixes the upload-side regression seen on the v1.24.0 and v1.24.1
release runs (no separate tracking issue).

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist — N/A, CI-only change
- [ ] Documentation reflects the changes — N/A
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [x] Add a new news fragment into the ``CHANGES/`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Investigation evidence from run ``26117323819``:

- Both windows-latest and windows-11-arm artifacts contained
  ``yarl-1.24.1-cp310-cp310-win_amd64.whl`` with different sha256
  (``402ea013…`` vs ``dc399e51…``) and slightly different sizes
  (92295 vs 92294 bytes).
- The Deploy job's attestation log recorded a third sha256
  (``5636f36f…``) for the wheel actually uploaded, matching
  neither pristine artifact, consistent with a torn write across
  the two same-named files during merge.
- PyPI rejected that wheel with ``400 ... Mis-matched data size``;
  the re-run hit a newer twine that flagged the same corruption
  earlier as ``zipfile.BadZipFile: Bad magic number for file
  header``.
- Pre-#1692 behavior, with ``CIBW_ARCHS_WINDOWS`` unset, used
  cibuildwheel's ``auto`` default and gave each runner its native
  arch only, so no filename overlap existed.

Local verification: edit is a CI workflow change only; ``make
doc-spelling`` runs to completion against the new fragment with no
new misspellings (the seven pre-existing warnings on master are
unrelated and only surface under the local enchant dictionary
backend; CI's enchant accepts them, as the v1.24.1 spellcheck-docs
job did). The behavior in CI cannot be exercised without pushing a
tag, so the change relies on inspection rather than a local repro.

Drafted with Claude Opus 4.7; reviewed by @bdraco.
</details>