### PR TITLE
ci: honor cython pin under build[uv] with UV_CONSTRAINT

### DIFF
--- a/CHANGES/1729.contrib.rst
+++ b/CHANGES/1729.contrib.rst
@@ -1,0 +1,7 @@
+Added ``UV_CONSTRAINT`` and ``UV_BUILD_CONSTRAINT`` alongside
+``PIP_CONSTRAINT`` and ``PIP_BUILD_CONSTRAINT`` in the
+``cibuildwheel`` environment so the :file:`requirements/cython.txt`
+pin is honored under the ``build[uv]`` frontend; ``uv pip``
+ignores the ``PIP_`` variables and reads only the ``UV_`` ones,
+while the ``PIP_`` variants are kept for the pip fallback path
+-- by :user:`bdraco`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,9 +160,12 @@ skip = "pp*"
 COLOR = "yes"
 FORCE_COLOR = "1"
 MYPY_FORCE_COLOR = "1"
+PIP_BUILD_CONSTRAINT = "requirements/cython.txt"
 PIP_CONSTRAINT = "requirements/cython.txt"
 PRE_COMMIT_COLOR = "always"
 PY_COLORS = "1"
+UV_BUILD_CONSTRAINT = "requirements/cython.txt"
+UV_CONSTRAINT = "requirements/cython.txt"
 
 [tool.cibuildwheel.config-settings]
 pure-python = "false"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add ``UV_CONSTRAINT`` and ``UV_BUILD_CONSTRAINT`` to the
``[tool.cibuildwheel.environment]`` block, mirroring the existing
``PIP_CONSTRAINT`` / ``PIP_BUILD_CONSTRAINT`` entries. Both point at
``requirements/cython.txt``.

Since #1699 switched the default cibuildwheel build frontend to
``build[uv]``, the ``PIP_CONSTRAINT`` env var is silently ignored
during the wheel build; ``uv pip`` reads only ``UV_CONSTRAINT`` /
``UV_BUILD_CONSTRAINT``. Empirically, with ``python -m build
--installer=uv`` and ``PIP_CONSTRAINT`` set to pin ``cython==3.0.11``,
uv still resolves ``cython==3.2.4``; setting ``UV_CONSTRAINT`` to the
same file pins it correctly. The ``PIP_`` variants are kept because
the odd-arch matrix in ``ci-cd.yml`` overrides ``CIBW_BUILD_FRONTEND=build``
(pip frontend) on containers that do not ship ``uv``.

## Are there changes in behavior for the user?

No user-facing change; the Cython version pin used at wheel build time
is now actually enforced under the ``build[uv]`` frontend, matching the
intent of the existing ``PIP_CONSTRAINT`` line.

## Is it a substantial burden for the maintainers to support this?

No; two extra env vars in ``pyproject.toml``.

## Related issue number

Surfaced while investigating the CodSpeed regression on
aio-libs/yarl#1710.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A, CI/packaging env change)
- [ ] Documentation reflects the changes (N/A)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [x] Add a new news fragment into the ``CHANGES/`` folder