### PR TITLE
reject non-digit port in split_netloc

### DIFF
--- a/CHANGES/1745.bugfix.rst
+++ b/CHANGES/1745.bugfix.rst
@@ -1,0 +1,6 @@
+Rejected URL authorities whose port is not made up solely of ASCII
+digits (e.g. ``http://h:80_80/``, ``http://h:+80/`` or a port written with
+non-ASCII decimal digits), which were previously accepted because ``int()``
+tolerates underscores, a leading sign, surrounding whitespace and non-ASCII
+decimal digits, letting a malformed authority resolve to an unexpected port per
+:rfc:`3986#section-3.2.3` -- by :user:`alhudz`.

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -229,6 +229,13 @@ class TestPort:
         with pytest.raises(ValueError):
             URL("//h:-80/path")
 
+    @pytest.mark.parametrize("port", ["80_80", "+80", " 80", "80 ", "８０"])
+    def test_non_digit_port(self, port: str) -> None:
+        # int() accepts underscores, a sign, whitespace and non-ASCII digits,
+        # none of which are valid per RFC 3986 port = *DIGIT.
+        with pytest.raises(ValueError):
+            URL(f"//h:{port}/path")
+
 
 class TestUserInfo:
     def test_canonical(self) -> None:

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -159,10 +159,13 @@ def split_netloc(
     if not port_str:
         return username or None, password, hostname or None, None
 
-    try:
-        port = int(port_str)
-    except ValueError:
+    # RFC 3986 section 3.2.3 defines the port as *DIGIT (ASCII 0-9 only).
+    # int() additionally accepts surrounding whitespace, a leading sign,
+    # underscore digit separators and non-ASCII decimal digits, any of which
+    # would let a malformed authority resolve to an unexpected port.
+    if not (port_str.isascii() and port_str.isdigit()):
         raise ValueError("Invalid URL: port can't be converted to integer")
+    port = int(port_str)
     if not (0 <= port <= 65535):
         raise ValueError("Port out of range 0-65535")
     return username or None, password, hostname or None, port


### PR DESCRIPTION
split_netloc parses the authority port with int(), which also accepts underscores, a leading sign, surrounding whitespace and non-ASCII decimal digits. So http://h:80_80/, http://h:+80/ and a fullwidth-digit port were accepted and silently resolved to an unexpected port, where urllib and a strict RFC 3986 parser reject them. The check belongs in split_netloc since that is the single place the port substring is turned into an int; it now rejects anything that is not solely ASCII digits.

Drafted with Claude Code; reviewed by alhudz.