### PR TITLE
Drop lone surrogates in the Cython quoter to match the pure-Python backend

### DIFF
--- a/CHANGES/1751.bugfix.rst
+++ b/CHANGES/1751.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed the Cython quoting backend preserving lone surrogate code
+points that the pure-Python backend already dropped; both now drop
+them and produce identical output
+-- by :user:`rodrigobnogueira`.

--- a/CHANGES/1751.bugfix.rst
+++ b/CHANGES/1751.bugfix.rst
@@ -1,4 +1,5 @@
-Fixed the Cython quoting backend preserving lone surrogate code
-points that the pure-Python backend already dropped; both now drop
-them and produce identical output
+Fixed the Cython quoting backend retaining a lone surrogate code
+point when it was the only character forcing a rewrite; the
+pure-Python backend already dropped lone surrogates, so both now
+drop them and produce identical output
 -- by :user:`rodrigobnogueira`.

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -125,9 +125,11 @@ def test_quote_drops_lone_surrogate(quoter: type[_Quoter]) -> None:
 
 
 def test_quote_drops_surrogate_with_encoded_char(quoter: type[_Quoter]) -> None:
-    # Regression guard: mixing a lone surrogate with a character that does
-    # require percent-encoding ("é" -> %C3%A9) must drop the surrogate while
-    # still encoding the real character, on both backends.
+    # Parity guard for the mixed case: a lone surrogate alongside a character
+    # that does require percent-encoding ("é" -> %C3%A9) must drop the
+    # surrogate while still encoding the real character, on both backends.
+    # This does not isolate the C bug ("é" forces a rewrite on its own, so it
+    # passes even unpatched); test_quote_drops_lone_surrogate is the guard.
     q = quoter()
     assert q("é\ud800") == "%C3%A9"
     assert q("\ud800é") == "%C3%A9"

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -109,6 +109,31 @@ def test_quote_lone_surrogate_only_trigger(quoter: type[_Quoter]) -> None:
     assert s == "/admin"
 
 
+def test_quote_drops_lone_surrogate(quoter: type[_Quoter]) -> None:
+    # A lone Unicode surrogate (0xD800..0xDFFF) cannot be UTF-8 encoded, so
+    # both quoters must drop it. When the surrogate is the only non-safe
+    # character, the C quoter used to leave it in the output; the Python
+    # quoter has always dropped it via errors="ignore". Keep every other
+    # character safe ASCII so the surrogate is the sole driver of any change;
+    # an unsafe character such as "/" would mask the bug by forcing a rewrite.
+    q = quoter()
+    assert q("\ud800") == ""
+    assert q("\udfff") == ""
+    assert q("a\ud800b") == "ab"
+    # The result must be pure ASCII, never a retained surrogate.
+    assert q("a\ud800b").encode("ascii") == b"ab"
+
+
+def test_quote_drops_surrogate_with_encoded_char(quoter: type[_Quoter]) -> None:
+    # Regression guard: mixing a lone surrogate with a character that does
+    # require percent-encoding ("é" -> %C3%A9) must drop the surrogate while
+    # still encoding the real character, on both backends.
+    q = quoter()
+    assert q("é\ud800") == "%C3%A9"
+    assert q("\ud800é") == "%C3%A9"
+    assert q("é\ud800é") == "%C3%A9%C3%A9"
+
+
 def test_unquote_to_bytes(unquoter: type[_Unquoter]) -> None:
     assert unquoter()("abc%20def") == "abc def"
     assert unquoter()("") == ""

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -771,3 +771,11 @@ class TestPercentEncodedSchemeBypass:
         assert u.scheme == ""
         assert ":" in str(u)
         assert "%3A" not in str(u)
+
+
+def test_raw_path_drops_lone_surrogate() -> None:
+    """A lone surrogate in the path is dropped; raw_path stays ASCII."""
+    url = URL("http://example.com/\ud800path")
+    assert url.raw_path == "/path"
+    # raw_path is always percent-encoded ASCII; a retained surrogate is a bug.
+    assert url.raw_path.encode("ascii") == b"/path"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The Cython quoting backend kept a lone Unicode surrogate code point
(``U+D800``..``U+DFFF``) in its output when the surrogate was the only
character that needed handling, because the surrogate branch of
``_write_utf8`` returned without marking the writer as changed. The
pure-Python quoter has always dropped surrogates via
``str.encode("utf8", errors="ignore")``, so the two backends produced
different output for the same input. The C quoter now drops lone
surrogates as well, so both backends agree.

## Are there changes in behavior for the user?

Yes, on the compiled extension only: quoted components (for example
``URL`` paths) built from strings containing lone surrogates no longer
retain them; the result is plain ASCII, matching the pure-Python build.
This also restores the invariant that ``raw_path`` is always
ASCII-encodable.

## Is it a substantial burden for the maintainers to support this?

No. It is a one-line change in ``yarl/_quoting_c.pyx`` that brings the C
quoter in line with the existing pure-Python behaviour; there is no
public API change.

## Related issue number

No public issue; this corrects an inconsistency between the two quoting
backends.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A; internal behaviour, no public API change)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A; file not present in repo)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Test details (optional, for reviewers)</summary>

Tests (both backends): `python -m pytest tests/test_quoting.py tests/test_url_parsing.py`, and the same with `YARL_NO_EXTENSIONS=1`; all pass. The two new `test_quoting.py` cases run under both the `py_quoter` and `c_quoter` fixtures and fail on the unpatched C extension, confirming they catch the regression. Pre-commit (ruff, codespell, cython-lint, mypy) passes on the changed files; the docs spell check reports only pre-existing words unrelated to this change.
</details>
