### PR TITLE
Drop lone surrogates that split a percent escape in the Cython quoter

### DIFF
--- a/CHANGES/1752.bugfix.rst
+++ b/CHANGES/1752.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed the Cython quoting backend percent-encoding the ``%`` of a
+``%XX`` escape when a lone surrogate fell within it, instead of
+dropping the surrogate and keeping the escape; it now matches the
+pure-Python backend and produces identical output
+-- by :user:`rodrigobnogueira`.

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -136,6 +136,25 @@ def test_quote_drops_surrogate_with_encoded_char(quoter: type[_Quoter]) -> None:
     assert q("é\ud800é") == "%C3%A9%C3%A9"
 
 
+def test_quote_drops_surrogate_splitting_percent_escape(
+    quoter: type[_Quoter],
+) -> None:
+    # A lone surrogate cannot be UTF-8 encoded and is dropped. When one lands
+    # inside or next to a "%XX" escape while requoting, it must not stop the
+    # escape from being recognised: the pure-Python quoter strips surrogates
+    # before scanning, so the C quoter has to look through them too. Each case
+    # changes only because the surrogate is removed and the escape recombines.
+    q = quoter()
+    assert q("%\ud83420") == "%20"  # surrogate between "%" and the digits
+    assert q("%2\ud834A") == "*"  # surrogate between the two hex digits, %2A
+    assert q("%4\ud8341") == "A"  # recombines to a safe char, %41
+    assert q("%\ud8340A") == "%0A"  # recombines to a char that needs encoding
+    assert q("%\ud834e9") == "%E9"  # lowercase hex still normalised to upper
+    assert q("%\ud800\udfff20") == "%20"  # two surrogates skipped in a row
+    # Too few real characters after "%" to form an escape: "%" stays literal.
+    assert q("%a\ud800") == "%25a"
+
+
 def test_unquote_to_bytes(unquoter: type[_Unquoter]) -> None:
     assert unquoter()("abc%20def") == "abc def"
     assert unquoter()("") == ""

--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -46,6 +46,20 @@ cdef inline int _is_lower_hex(Py_UCS4 v) noexcept:
     return 'a' <= v <= 'f'
 
 
+cdef inline bint _is_surrogate(Py_UCS4 ch) noexcept:
+    return 0xD800 <= ch <= 0xDFFF
+
+
+cdef inline Py_ssize_t _skip_surrogates(
+    int kind, const void *data, Py_ssize_t idx, Py_ssize_t length
+) noexcept:
+    # Advance past lone surrogates; they cannot be UTF-8 encoded and are
+    # dropped, so they must not break up a percent escape during requoting.
+    while idx < length and _is_surrogate(PyUnicode_READ(kind, data, idx)):
+        idx += 1
+    return idx
+
+
 cdef inline long _restore_ch(Py_UCS4 d1, Py_UCS4 d2):
     cdef int digit1 = _from_hex(d1)
     if digit1 < 0:
@@ -260,21 +274,35 @@ cdef class _Quoter:
         Writer *writer
     ):
         cdef Py_UCS4 ch
+        cdef Py_UCS4 d1
+        cdef Py_UCS4 d2
         cdef long chl
         cdef int changed
+        cdef bint surrogate_skipped
         cdef Py_ssize_t idx = 0
+        cdef Py_ssize_t pos1
+        cdef Py_ssize_t pos2
 
         while idx < length:
             ch = PyUnicode_READ(kind, data, idx)
             idx += 1
-            if ch == '%' and self._requote and idx <= length - 2:
-                chl = _restore_ch(
-                    PyUnicode_READ(kind, data, idx),
-                    PyUnicode_READ(kind, data, idx + 1)
-                )
+            if ch == '%' and self._requote and idx < length:
+                # Lone surrogates are dropped (see _skip_surrogates), so look
+                # through them for the two hex digits of the "%XX" escape; this
+                # keeps the C quoter consistent with the pure-Python backend,
+                # which strips surrogates before scanning.
+                pos1 = _skip_surrogates(kind, data, idx, length)
+                pos2 = _skip_surrogates(kind, data, pos1 + 1, length)
+                if pos2 < length:
+                    d1 = PyUnicode_READ(kind, data, pos1)
+                    d2 = PyUnicode_READ(kind, data, pos2)
+                    chl = _restore_ch(d1, d2)
+                else:
+                    chl = -1
                 if chl != -1:
                     ch = <Py_UCS4>chl
-                    idx += 2
+                    surrogate_skipped = pos1 != idx or pos2 != pos1 + 1
+                    idx = pos2 + 1
                     if ch < 128:
                         if bit_at(self._protected_table, ch):
                             if _write_pct(writer, ch, True) < 0:
@@ -286,8 +314,8 @@ cdef class _Quoter:
                                 raise
                             continue
 
-                    changed = (_is_lower_hex(PyUnicode_READ(kind, data, idx - 2)) or
-                               _is_lower_hex(PyUnicode_READ(kind, data, idx - 1)))
+                    changed = (surrogate_skipped or
+                               _is_lower_hex(d1) or _is_lower_hex(d2))
                     if _write_pct(writer, ch, changed) < 0:
                         raise
                     continue

--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -159,7 +159,7 @@ cdef inline int _write_utf8(Writer* writer, Py_UCS4 symbol):
         if _write_pct(writer, <uint8_t>(0xc0 | (utf >> 6)), True) < 0:
             return -1
         return _write_pct(writer,  <uint8_t>(0x80 | (utf & 0x3f)), True)
-    elif 0xD800 <= utf <= 0xDFFF:
+    elif _is_surrogate(symbol):
         # lone surrogate; invalid in UTF-8 so it is dropped, matching the
         # pure-Python quoter's errors="ignore" encode. Mark the writer as
         # changed so _do_quote returns the surrogate-free buffer rather than


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The Cython quoter scans a string code point by code point, so a lone
surrogate that lands inside a ``%XX`` escape broke it: the ``%`` was
treated as a literal and re-encoded to ``%25`` while the hex digits
were left in place (for example ``%2``, a lone surrogate, then ``0``
quoted to ``%2520``). The pure-Python quoter drops lone surrogates with
``errors="ignore"`` before it scans, so it read the same input as
``%20``. The C quoter now skips lone surrogates while reading the two
hex digits, so both backends recombine the escape identically.

This is the second of two lone-surrogate parity gaps between the
backends; #1751 handles the case where a lone surrogate is the only
character that changes.

## Are there changes in behavior for the user?

Yes, on the compiled extension only: requoting a string where a lone
surrogate falls within a ``%XX`` escape now drops the surrogate and
keeps the escape (matching the pure-Python build) instead of
percent-encoding the ``%``.

## Is it a substantial burden for the maintainers to support this?

No. It adds a small helper that skips lone surrogates in the requote
lookahead of ``yarl/_quoting_c.pyx``; the pure-Python quoter already
behaves this way, so there is no public API change.

## Related issue number

No public issue; related to #1751.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A; internal behaviour, no public API change)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A; file not present in repo)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Test details (optional, for reviewers)</summary>

Tests (both backends): `python -m pytest tests/test_quoting.py tests/test_url_parsing.py`, and the same with `YARL_NO_EXTENSIONS=1`; all pass. The new `test_quoting.py` case runs under both the `py_quoter` and `c_quoter` fixtures and fails on the unpatched C extension (`%2520` vs `%20`), confirming it catches the bug. A differential fuzz of the C and pure-Python quoters over surrogate-laden inputs across the built-in quoter configurations shows no remaining divergence in this class. Pre-commit (ruff, codespell, cython-lint) and a Cython line-tracing coverage build of the changed lines pass locally.
</details>
