### PR TITLE
docs: add ConfigDict with arbitrary_types_allowed to Pydantic example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -170,10 +170,11 @@ convert bools into strings using own preferred translation protocol.
 
 The :class:`~yarl.URL` could be used as a field type in pydantic_ models seamlessly::
 
-   from pydantic import BaseModel
+   from pydantic import BaseModel, ConfigDict
    from yarl import URL
 
    class Model(BaseModel):
+       model_config = ConfigDict(arbitrary_types_allowed=True)
        url: URL
 
 


### PR DESCRIPTION
Fixes #1624: Pydantic v2 requires arbitrary_types_allowed=True for URL field type.