### PR TITLE
extend_query: strip a leading '&' from new_query

### DIFF
--- a/tests/test_update_query.py
+++ b/tests/test_update_query.py
@@ -470,3 +470,41 @@ def test_extend_query_with_non_ascii_same_key() -> None:
         "&%F0%9D%95%A6=%F0%9D%95%A6&%F0%9D%95%A6=%F0%9D%95%A6"
     )
     assert url.extend_query({"𝕦": "𝕦"}) == expected
+
+
+def test_extend_query_strips_leading_ampersand() -> None:
+    """A user-supplied string starting with '&' is normalised, not joined verbatim.
+
+    Otherwise `extend_query('&b=2')` would produce a double-'&' join
+    (`a=1&&b=2`), and `URL('http://example.com/').extend_query('&a=1')`
+    would produce a literal '&' at the start of the query (`?&a=1`).
+    """
+    # Leading '&' on an empty query: previously produced '?&a=1'
+    url = URL("http://example.com/")
+    assert str(url.extend_query("&a=1")) == "http://example.com/?a=1"
+
+    # Leading '&' on a populated query: previously produced a=1&&b=2
+    url = URL("http://example.com/?a=1")
+    assert str(url.extend_query("&b=2")) == "http://example.com/?a=1&b=2"
+
+    # Chained extend_query where the second argument carries a leading '&'
+    url = URL("http://example.com/?a=1")
+    assert (
+        str(url.extend_query("b=2").extend_query("&c=3"))
+        == "http://example.com/?a=1&b=2&c=3"
+    )
+
+    # A bare '&' is a no-op (just an empty separator)
+    url = URL("http://example.com/?a=1")
+    assert url.extend_query("&") == url
+
+
+def test_extend_query_leading_ampersand_does_not_break_kwargs_or_dicts() -> None:
+    """The lstrip only applies to the str branch — kwargs / dicts are untouched."""
+    url = URL("http://example.com/?a=1")
+    # kwargs path
+    assert str(url.extend_query(b=2)) == "http://example.com/?a=1&b=2"
+    # dict path
+    assert str(url.extend_query({"b": 2})) == "http://example.com/?a=1&b=2"
+    # str path with no leading '&' — no regression
+    assert str(url.extend_query("b=2")) == "http://example.com/?a=1&b=2"

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1259,6 +1259,14 @@ class URL:
         """
         if not (new_query := get_str_query(*args, **kwargs)):
             return self
+        # A user-supplied string may start with "&" (e.g. "extend_query('&a=1')"
+        # or the result of a manual `URL.query_string` round-trip). Strip it so
+        # the join below never produces a literal "&" at the start of the query
+        # ("?&a=1") or a double "&" at the boundary ("a=1&&b=2").
+        if new_query[:1] == "&":
+            new_query = new_query.lstrip("&")
+            if not new_query:
+                return self
         if query := self._query:
             # both strings are already encoded so we can use a simple
             # string join


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix :meth:`yarl.URL.extend_query` letting a user-supplied query
string starting with `&` produce a literal `&` in the result.
Two failure modes:

- `URL("http://example.com/").extend_query("&a=1")` returned
  `"?&a=1"` (extra `?` in front of the leading `&`).
- `URL("http://example.com/?a=1").extend_query("a=2").extend_query("&b=3")`
  returned `"a=1&&b=3"` (double `&` at the boundary).

The fix strips a leading `&` from `new_query` before joining.
It is a pure pre-processing step that does not change the public
surface — the same string is returned for any input that did not
start with `&` — and the joined result is still byte-identical
to what `query + "&" + new_query` would produce for well-formed
input.

## Are there changes in behavior for the user?

Yes — for inputs that previously went through the leading-`&`
path. The only inputs affected are strings starting with `&`,
which were never valid query strings on their own. The dict and
kwargs paths (which never produce a leading `&`) are unchanged.

## Is it a substantial burden for the maintainers to support this?

No. The change is one line in the public method, the new
behaviour is documented in the test additions, and the fix is
the kind of input validation the API clearly intended from the
start. No API surface is added or removed.

## Related issue number

None; opportunistic bug found while auditing the URL builder
methods.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A — the method
  docstring already documents the new-query contract; no
  narrative doc change is needed)
- [ ] If you provide code modification, please add yourself to
  `CONTRIBUTORS.txt` (N/A — there is no `CONTRIBUTORS.txt` in
  this repo)
- [x] Add a new news fragment into the `CHANGES/` folder
  * name: `1763.bugfix.rst`
  * category: `bugfix`

Drafted with Zo Bot (Claude Opus 4.7); reviewed by @HrachShah.