### PR TITLE
Revert setuptools constraint bump and restrict dependabot to subdir

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,8 @@ updates:
 
 # Maintain dependencies for Python
 - package-ecosystem: "pip"
-  directory: "/"
+  directories:
+  - "/requirements"
   labels:
   - dependencies
   schedule:

--- a/CHANGES/1764.contrib.rst
+++ b/CHANGES/1764.contrib.rst
@@ -1,0 +1,3 @@
+Dependabot has been restricted to the ``requirements`` subdirectory to
+avoid unintended updates outside dependency requirement files
+-- by :user:`bbhtt`.

--- a/CHANGES/1764.packaging.rst
+++ b/CHANGES/1764.packaging.rst
@@ -1,0 +1,3 @@
+The ``setuptools`` build dependency lower bound has been restored to be
+``>= 47`` after an incorrect automated increase in :pr:`1657`
+-- by :user:`bbhtt`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -26,6 +26,7 @@ codspeed
 config
 de
 decodable
+dependabot
 dev
 dists
 downstreams

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   # NOTE: provisioning of the in-tree build backend located under
   # NOTE: `packaging/pep517_backend/`.
   "expandvars",
-  "setuptools >= 82.0.1",  # Minimum required for `version = attr:`
+  "setuptools >= 47",  # Minimum required for `version = attr:`
   "tomli; python_version < '3.11'",
 ]
 backend-path = ["packaging"]  # requires `pip >= 20` or `pep517 >= 0.6.0`


### PR DESCRIPTION
What do these changes do?

Reverts an unintended setuptools constraint bump in pyproject.toml
and restrict dependabot to subdir to prevent it from happening again.

This is a 'port' of https://github.com/aio-libs/propcache/pull/225

Are there changes in behavior for the user?
None

Related issue number
Ref: https://github.com/aio-libs/yarl/pull/1657#issuecomment-4781060604 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
