### PR TITLE
Lowercase ASCII labels in the stdlib IDNA host fallback

### DIFF
--- a/CHANGES/1780.bugfix.rst
+++ b/CHANGES/1780.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed :attr:`~yarl.URL.raw_host` returning ASCII host labels in their
+original case for hosts that combine a non-ASCII label with an ASCII
+label that the strict ``idna`` package rejects (for example an
+underscore ``_dmarc`` label); the mismatched case meant the same URL
+rendered differently when parsed a second time
+-- by :user:`gaoflow`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -264,6 +264,24 @@ def test_host_with_underscore() -> None:
     assert "abc_def.com" == url.host
 
 
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("http://_DMARC.café/", "_dmarc.xn--caf-dma"),
+        ("http://H%EFST.café/", "h%efst.xn--caf-dma"),
+        ("http://ABC.%EF.café/", "abc.%ef.xn--caf-dma"),
+    ],
+)
+def test_idna_fallback_lowercases_ascii_labels(url: str, expected: str) -> None:
+    # A host mixing an IDN label with an ASCII label that the strict idna
+    # package rejects (e.g. an underscore DNS label) takes the stdlib IDNA
+    # fallback, which must still lowercase the ASCII labels to stay canonical
+    # and idempotent (RFC 3986 section 6.2.2.1).
+    url_obj = URL(url)
+    assert url_obj.raw_host == expected
+    assert str(url_obj) == str(URL(str(url_obj)))
+
+
 def test_raw_host_when_port_is_specified() -> None:
     url = URL("http://example.com:8888")
     assert "example.com" == url.raw_host

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1587,7 +1587,11 @@ def _idna_encode(host: str) -> str:
     try:
         return idna.encode(host, uts46=True).decode("ascii")
     except UnicodeError:
-        return host.encode("idna").decode("ascii")
+        # The stdlib IDNA-2003 codec leaves already-ASCII labels untouched, so
+        # lowercase the host first to match the ASCII fast path and the
+        # idna.encode(uts46=True) result above (RFC 3986 section 6.2.2.1).
+        # Non-ASCII labels are case-folded again by the codec's nameprep step.
+        return host.lower().encode("idna").decode("ascii")
 
 
 @lru_cache(_DEFAULT_ENCODE_SIZE)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`_idna_encode()` falls back to the stdlib `"idna"` codec when the strict `idna` package rejects a host (for example a host with an underscore DNS label such as `_dmarc`). The stdlib codec leaves already-ASCII labels untouched, so those labels kept whatever case they were given while the non-ASCII labels were still normalised. The host is now lowercased before the fallback encode, matching both the ASCII fast path and the `idna.encode(..., uts46=True)` result used on the success path.

## Are there changes in behavior for the user?

Yes. A host that mixes a non-ASCII label with an ASCII label the strict `idna` package rejects now has its ASCII labels lowercased, so `raw_host` is canonical and the URL round-trips. For example `URL("http://_DMARC.café/").raw_host` is now `_dmarc.xn--caf-dma` instead of `_DMARC.xn--caf-dma`; the old value changed again on a second parse, so the URL was not idempotent.

## Is it a substantial burden for the maintainers to support this?

No. The change is a single `.lower()` on the fallback path, plus a regression test.

## Related issue number

No linked issue; found while checking host normalisation idempotence.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A: no such file in the repo)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Repro (on `master`):

```pycon
>>> from yarl import URL
>>> URL("http://_DMARC.café/").raw_host
'_DMARC.xn--caf-dma'
>>> URL(str(URL("http://_DMARC.café/"))).raw_host   # not idempotent
'_dmarc.xn--caf-dma'
```

Tests: the new `test_idna_fallback_lowercases_ascii_labels` fails on `master` and passes with the fix. Full suite: 1448 passed, 102 skipped, 4 xfailed.

Lint: `ruff check yarl/_url.py tests/test_url.py` clean.

Spelling: the `CHANGES/` fragment words were checked with enchant against `en_US` plus `docs/spelling_wordlist.txt`; a full `make doc-spelling` docs build was not run in this environment.

Drafted with Claude Code (Claude Opus 4.8); pending review by `@gaoflow` before this is taken out of draft.
</details>
