### PR TITLE
Cover RFC 6874 IPv6 zone ID handling with tests and docs

### DIFF
--- a/CHANGES/998.doc.rst
+++ b/CHANGES/998.doc.rst
@@ -1,0 +1,4 @@
+Documented how :attr:`~yarl.URL.host` and :attr:`~yarl.URL.raw_host`
+expose :rfc:`6874` IPv6 zone identifiers and that the host subcomponent
+properties include the zone identifier verbatim
+-- by :user:`rodrigobnogueira`.

--- a/CHANGES/998.misc.rst
+++ b/CHANGES/998.misc.rst
@@ -1,0 +1,5 @@
+Expanded the test suite to pin IPv6 zone identifier handling per the
+:rfc:`6874` compatibility research: the ``%25`` and legacy bare ``%``
+separator forms, empty zone and reserved character corner cases,
+``encoded=True`` round-trips, and zone survival through URL mutation
+APIs -- by :user:`rodrigobnogueira`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -171,6 +171,11 @@ There are two kinds of properties: *decoded* and *encoded* (with
    Brackets are stripped for IPv6. Host is converted to lowercase,
    address is validated and converted to compressed form.
 
+   For IPv6 addresses that carry an :rfc:`6874` zone identifier, the
+   ``%25`` zone separator is decoded to ``%``, so the value matches the
+   scoped address format understood by :mod:`socket` and
+   :mod:`ipaddress`.
+
    .. doctest::
 
       >>> URL('http://example.com').host
@@ -181,11 +186,15 @@ There are two kinds of properties: *decoded* and *encoded* (with
       True
       >>> URL('http://[::1]').host
       '::1'
+      >>> URL('http://[fe80::1%25eth0]/').host
+      'fe80::1%eth0'
 
 .. attribute:: URL.raw_host
 
    IDNA decoded *host* part of URL, ``None`` for relative URLs
    (:ref:`yarl-api-relative-urls`).
+
+   An :rfc:`6874` ``%25`` zone identifier separator is kept as-is.
 
    .. doctest::
 
@@ -193,11 +202,15 @@ There are two kinds of properties: *decoded* and *encoded* (with
       'xn--n1agdj.xn--d1acufc'
       >>> URL('http://[::1]').raw_host
       '::1'
+      >>> URL('http://[fe80::1%25eth0]/').raw_host
+      'fe80::1%25eth0'
 
 .. attribute:: URL.host_subcomponent
 
    :rfc:`3986#section-3.2.2` host subcomponent part of URL, ``None`` for relative URLs
    (:ref:`yarl-api-relative-urls`).
+
+   An :rfc:`6874` IPv6 zone identifier, if any, is included verbatim.
 
    .. doctest::
 
@@ -205,6 +218,8 @@ There are two kinds of properties: *decoded* and *encoded* (with
       'xn--n1agdj.xn--d1acufc'
       >>> URL('http://[::1]').host_subcomponent
       '[::1]'
+      >>> URL('http://[fe80::1%25eth0]/').host_subcomponent
+      '[fe80::1%25eth0]'
 
    .. versionadded:: 1.13
 
@@ -228,6 +243,14 @@ There are two kinds of properties: *decoded* and *encoded* (with
       'example.com'
       >>> URL('http://[::1]').host_port_subcomponent
       '[::1]'
+
+   .. note::
+
+      An :rfc:`6874` IPv6 zone identifier is included verbatim. Zone
+      identifiers have local significance only
+      (:rfc:`6874#section-4`), so callers that use this value to build
+      outgoing protocol elements such as the HTTP Host header need to
+      strip it first.
 
    .. versionadded:: 1.17
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -477,6 +477,18 @@ def test_ipv4_zone() -> None:
     assert url.raw_host == SplitResult(*url._val).hostname
 
 
+def test_ipv4_zone_percent25() -> None:
+    """The ``%25`` decode in ``URL.host`` also covers IPv4 hosts.
+
+    Zone identifiers on IPv4 addresses are outside any RFC; this pins
+    the digit-branch behavior of the ``%25`` handling (#998).
+    """
+    url = URL("http://1.2.3.4%25eth0:123/")
+    assert url.raw_host == "1.2.3.4%25eth0"
+    assert url.host == "1.2.3.4%eth0"
+    assert url.port == 123
+
+
 def test_ipv6_zone_rfc6874() -> None:
     url = URL("http://[fe80::1%251]/")
     assert url.raw_host == "fe80::1%251"
@@ -521,6 +533,102 @@ def test_ipv6_zone_rfc6874_pct_encoded_inside_zone() -> None:
     assert url.host_subcomponent == "[fe80::1%25foo%252fbar]"
     assert str(url) == "http://[fe80::1%25foo%252fbar]/"
     assert URL(str(url)) == url
+
+
+def test_ipv6_zone_bare_percent_parse() -> None:
+    """A bare ``%`` zone separator is accepted and preserved verbatim.
+
+    This is the pre-RFC 6874 de-facto form; RFC 6874 §3 suggests
+    (non-normatively) accepting it, and curl/wget/urllib3 all do.
+    yarl does not re-encode it to ``%25``.
+    """
+    url = URL("http://[fe80::1%eth0]:8080/")
+    assert url.raw_host == "fe80::1%eth0"
+    assert url.host == "fe80::1%eth0"
+    assert url.host_subcomponent == "[fe80::1%eth0]"
+    assert url.host_port_subcomponent == "[fe80::1%eth0]:8080"
+    assert url.authority == "fe80::1%eth0:8080"
+    assert url.human_repr() == "http://[fe80::1%eth0]:8080/"
+    assert str(url) == "http://[fe80::1%eth0]:8080/"
+    assert URL(str(url)) == url
+
+
+def test_ipv6_zone_bare_percent_hex_ambiguous() -> None:
+    """A bare ``%`` is accepted even when followed by two hex digits.
+
+    RFC 6874 §3 (non-normative) suggests accepting a bare ``%`` only
+    when it is not followed by two valid hexadecimal characters; like
+    the rest of the ecosystem, yarl accepts it unconditionally, so
+    ``%ee1`` is zone ``ee1`` rather than an error (#998).
+    """
+    url = URL("http://[fe80::a%ee1]/")
+    assert url.raw_host == "fe80::a%ee1"
+    assert url.host == "fe80::a%ee1"
+
+
+def test_ipv6_zone_empty_zone_parse() -> None:
+    """The string-parse path accepts empty zone identifiers.
+
+    ``URL.build(host=...)`` rejects them (RFC 9844 §6.3), but parsing
+    uses ``validate_host=False``; this documents the asymmetry (#998).
+    """
+    url = URL("http://[fe80::1%25]/")
+    assert url.raw_host == "fe80::1%25"
+    assert url.host == "fe80::1%"
+    url = URL("http://[fe80::1%]/")
+    assert url.raw_host == "fe80::1%"
+    assert url.host == "fe80::1%"
+
+
+def test_ipv6_zone_rfc6874_multiple_percent25() -> None:
+    """Only the first ``%25`` is the separator; later ones are zone text."""
+    url = URL("http://[fe80::1%25a%25b]/")
+    assert url.raw_host == "fe80::1%25a%25b"
+    assert url.host == "fe80::1%a%b"
+    assert str(url) == "http://[fe80::1%25a%25b]/"
+    assert URL(str(url)) == url
+
+
+def test_ipv6_zone_rfc6874_encoded_url() -> None:
+    """The ``.host`` zone decode applies to pre-encoded URLs as well."""
+    url = URL("http://[fe80::1%25eth0]/", encoded=True)
+    assert url.raw_host == "fe80::1%25eth0"
+    assert url.host == "fe80::1%eth0"
+    assert str(url) == "http://[fe80::1%25eth0]/"
+
+
+def test_ipv6_zone_separator_spellings_not_equal() -> None:
+    """The two zone separator spellings are distinct URLs.
+
+    yarl performs no normalization between ``%25`` and bare ``%``, so
+    URLs denoting the same scoped address compare unequal even though
+    ``.host`` decodes both to the same value (#998).
+    """
+    encoded = URL("http://[fe80::1%25eth0]/")
+    bare = URL("http://[fe80::1%eth0]/")
+    assert encoded != bare
+    assert encoded.host == bare.host
+
+
+def test_ipv6_zone_rfc6874_global_address() -> None:
+    """Zone identifiers are accepted on non-link-local addresses.
+
+    RFC 6874 §4 restricts zone usage to link-local addresses
+    (fe80::/10); yarl, like curl and urllib3, does not enforce
+    this (#998).
+    """
+    url = URL("http://[2001:db8::1%25eth0]/")
+    assert url.raw_host == "2001:db8::1%25eth0"
+    assert url.host == "2001:db8::1%eth0"
+
+
+def test_ipv6_zone_rfc6874_mutation_apis() -> None:
+    """The encoded zone survives URL mutation APIs byte-for-byte."""
+    url = URL("http://[fe80::1%25eth0]:8080/p?q=1")
+    assert str(url.origin()) == "http://[fe80::1%25eth0]:8080"
+    assert str(url.with_port(9000)) == "http://[fe80::1%25eth0]:9000/p?q=1"
+    assert str(url.with_user("u")) == "http://u@[fe80::1%25eth0]:8080/p?q=1"
+    assert str(url.join(URL("/other"))) == "http://[fe80::1%25eth0]:8080/other"
 
 
 def test_port_for_explicit_port() -> None:

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -78,6 +78,79 @@ def test_url_build_ipv6_zone_id_valid(zone: str) -> None:
     assert URL(str(u)).host == f"::1%{zone}"
 
 
+def test_url_build_ipv6_zone_id_bare_percent_round_trip() -> None:
+    """Programmatic hosts keep the bare ``%`` zone separator.
+
+    ``_encode_host`` falls back to partitioning on ``%`` when no
+    ``%25`` is present so that hosts constructed from RFC 4007 scoped
+    literals keep working; this pins that fallback (#998).
+    """
+    u = URL.build(scheme="http", host="fe80::1%eth0")
+    assert str(u) == "http://[fe80::1%eth0]"
+    assert u.raw_host == "fe80::1%eth0"
+    assert u.host == "fe80::1%eth0"
+    assert URL(str(u)) == u
+
+
+def test_url_build_ipv6_zone_id_numeric_scope_percent25() -> None:
+    """A literal ``%25`` in a programmatic host is read as the separator.
+
+    On Windows, zone identifiers are numeric, so the RFC 4007 literal
+    ``fe80::1%25`` means scope 25 and ``fe80::1%254`` means scope 254.
+    The current heuristic treats the ``%25`` byte sequence as the
+    RFC 6874 encoded separator instead: the first raises for an empty
+    zone and the second is parsed as zone ``4``. Documents current
+    behavior (#998); not an endorsement of it.
+    """
+    with pytest.raises(ValueError, match="Invalid characters in zone identifier"):
+        URL.build(scheme="http", host="fe80::1%25")
+    u = URL.build(scheme="http", host="fe80::1%254")
+    assert str(u) == "http://[fe80::1%254]"
+    assert u.raw_host == "fe80::1%254"
+    assert u.host == "fe80::1%4"
+
+
+@pytest.mark.parametrize(
+    "zone",
+    (
+        "e/h",
+        "a?b",
+        "a#c",
+    ),
+    ids=("slash", "question", "hash"),
+)
+def test_url_build_ipv6_zone_id_reserved_chars_break_round_trip(zone: str) -> None:
+    """Reserved characters in a zone produce URLs yarl cannot re-parse.
+
+    RFC 6874 §2 requires non-unreserved zone characters to be
+    percent-encoded; the liberal RFC 4007 policy emits them raw, so
+    the serialized URL fails yarl's own parser. Documents current
+    behavior (#998).
+    """
+    u = URL.build(scheme="http", host=f"fe80::1%{zone}", path="/x")
+    assert str(u) == f"http://[fe80::1%{zone}]/x"
+    with pytest.raises(ValueError, match="Invalid IPv6 URL"):
+        URL(str(u))
+
+
+def test_url_build_ipv6_zone_id_non_ascii_not_ascii_encodable() -> None:
+    """Non-ASCII zone identifiers make the URL non-ASCII-serializable."""
+    u = URL.build(scheme="http", host="fe80::1%日本語", path="/")
+    with pytest.raises(UnicodeEncodeError):
+        bytes(u)
+
+
+def test_url_build_ipv6_zone_id_empty_authority_not_validated() -> None:
+    """``authority=`` bypasses the empty-zone rejection of ``host=``.
+
+    The authority path uses ``validate_host=False``; documents the
+    asymmetry with ``test_url_build_ipv6_zone_id_empty`` (#998).
+    """
+    u = URL.build(scheme="http", authority="[fe80::1%25]")
+    assert str(u) == "http://[fe80::1%25]"
+    assert u.host == "fe80::1%"
+
+
 def test_build_with_scheme() -> None:
     u = URL.build(scheme="blob", path="path")
     assert str(u) == "blob:path"

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -171,6 +171,14 @@ def test_with_host() -> None:
     assert str(url.with_host("example.org")) == "http://example.org:123"
 
 
+def test_with_host_ipv6_zone_id_bare_percent() -> None:
+    """RFC 4007 scoped literals with a bare ``%`` work in with_host()."""
+    url = URL("http://example.com/x")
+    url2 = url.with_host("fe80::1%1")
+    assert str(url2) == "http://[fe80::1%1]/x"
+    assert url2.host == "fe80::1%1"
+
+
 def test_with_host_empty() -> None:
     url = URL("http://example.com:123")
     with pytest.raises(ValueError):

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -795,8 +795,10 @@ class URL:
         if (raw := self.raw_host) is None:
             return None
         if raw and raw[-1].isdigit() or ":" in raw:
-            # IP addresses are never IDNA encoded; only the RFC 6874
-            # zone separator needs to be decoded.
+            # IP addresses are never IDNA encoded. The replace decodes
+            # every %25 in the raw host, i.e. the RFC 6874 zone
+            # separator and any %25 that percent-encodes a literal %
+            # inside the zone identifier.
             if "%25" in raw:
                 return raw.replace("%25", "%")
             return raw


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add the test coverage requested in #998 for IPv6 zone identifier handling. New tests pin both separator forms (`%25` per RFC 6874 and the legacy bare `%`) across the parse, `URL.build()`, `with_host()` and `encoded=True` paths, plus the corner cases found while researching the issue: empty zones, reserved characters in zones, a literal `%25` in programmatic hosts (Windows numeric scopes), the IPv4 branch of the `%25` decode, separator spelling inequality, and zone survival through the mutation APIs.

The docs for `host`, `raw_host` and the host subcomponent properties now describe the zone identifier behavior, and an understated comment in the `host` property is reworded (the decode applies to every `%25` in the host, not just the separator).

Some tests document current behavior at known rough edges so future fixes show up as explicit test changes; the remaining behavior gaps are listed in the issue.

## Are there changes in behavior for the user?

No. Tests, documentation, and a comment rewording only.

## Is it a substantial burden for the maintainers to support this?

No. The tests pin behavior that already exists on master (from #1653 and #1655).

## Related issue number

Related to #998 (covers the test coverage part; behavior gaps stay tracked in the issue).

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt`` (N/A; no ``CONTRIBUTORS.txt`` in this repo)
- [x] Add a new news fragment into the `CHANGES/` folder
  * name: ``998.misc.rst``, ``998.doc.rst``
  * category: ``misc``, ``doc``
