### PR TITLE
Fix the docs doctest and spelling checks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -173,6 +173,7 @@ jobs:
         toxenv:
         - pre-commit
         - spellcheck-docs
+        - doctest-docs
         - build-docs
         xfail:
         - false

--- a/CHANGES/1784.contrib.rst
+++ b/CHANGES/1784.contrib.rst
@@ -1,6 +1,6 @@
 Started running the Sphinx ``doctest`` builder in CI through the
-``doctest-docs`` tox environment, which existed but was never enabled
-and could not import the package it documents; the environment now
-installs the package. Also added spelling word list entries so the
-spell check passes with dictionary backends other than the one CI
-uses -- by :user:`rodrigobnogueira`.
+``doctest-docs`` tox environment, which existed but was never wired
+into the lint matrix and never installed the package whose examples it
+runs. Also added spelling word list entries so the spell check passes
+with dictionary backends other than the one CI uses
+-- by :user:`rodrigobnogueira`.

--- a/CHANGES/1784.contrib.rst
+++ b/CHANGES/1784.contrib.rst
@@ -1,0 +1,6 @@
+Started running the Sphinx ``doctest`` builder in CI through the
+``doctest-docs`` tox environment, which existed but was never enabled
+and could not import the package it documents; the environment now
+installs the package. Also added spelling word list entries so the
+spell check passes with dictionary backends other than the one CI
+uses -- by :user:`rodrigobnogueira`.

--- a/CHANGES/1784.doc.rst
+++ b/CHANGES/1784.doc.rst
@@ -1,4 +1,3 @@
 Fixed the stale ``with_name()`` example output in the API reference; the
 apostrophe is a character that :rfc:`3986` allows unencoded in path
-segments. Also added the missing entries to the spelling word list so
-that ``make doc-spelling`` passes again -- by :user:`rodrigobnogueira`.
+segments -- by :user:`rodrigobnogueira`.

--- a/CHANGES/1784.doc.rst
+++ b/CHANGES/1784.doc.rst
@@ -1,0 +1,4 @@
+Fixed the stale ``with_name()`` example output in the API reference; the
+apostrophe is a character that :rfc:`3986` allows unencoded in path
+segments. Also added the missing entries to the spelling word list so
+that ``make doc-spelling`` passes again -- by :user:`rodrigobnogueira`.

--- a/CHANGES/1784.packaging.rst
+++ b/CHANGES/1784.packaging.rst
@@ -1,0 +1,7 @@
+Fixed the in-tree PEP 517 build backend to import Cython at the point
+of use instead of module load time. The build front-ends that serve all
+the build hooks from a single long-running backend process, the way
+``pyproject-api`` under ``tox`` does, import the backend before the
+dynamically declared Cython build dependency is provisioned, so the
+accelerated build used to fail with a ``NameError``
+-- by :user:`rodrigobnogueira`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -895,7 +895,7 @@ section generates a new :class:`URL` instance.
       >>> URL('http://example.com/path/to?arg#frag').with_name('new')
       URL('http://example.com/path/new')
       >>> URL('http://example.com/path/to').with_name("ім'я")
-      URL('http://example.com/path/%D1%96%D0%BC%27%D1%8F')
+      URL('http://example.com/path/%D1%96%D0%BC'%D1%8F')
 
 .. method:: URL.with_suffix(suffix, *, keep_query=False, keep_fragment=False)
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -4,6 +4,7 @@ CPython
 Changelog
 Codecov
 Cython
+Deprecations
 GPG
 IPv
 PRs
@@ -46,8 +47,10 @@ nightlies
 pre
 pydantic
 pytest
+quoter
 rc
 reStructuredText
+recode
 reencoding
 requote
 requoter
@@ -60,11 +63,13 @@ serializer
 subclass
 subclasses
 subcomponent
+subdirectory
 subtree
 svetlov
 tox
 uncompiled
 unencoded
+unobvious
 unquoter
 v1
 yarl

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -18,6 +18,7 @@ aiohttp
 armv
 ascii
 backend
+backends
 boolean
 booleans
 bools

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -38,16 +38,6 @@ from distutils.dist import (
     DistributionMetadata as _DistutilsDistributionMetadata,
 )
 
-
-with suppress(ImportError):
-    # NOTE: Only available for wheel builds that bundle C-extensions. Declared
-    # NOTE: by `get_requires_for_build_wheel()` and
-    # NOTE: `get_requires_for_build_editable()`, when `pure-python`
-    # NOTE: is not passed.
-    from Cython.Build.Cythonize import (
-        main as _cythonize_cli_cmd,
-    )
-
 from ._compat import chdir_cm
 from ._cython_configuration import (
     get_local_cythonize_config as _get_local_cython_config,
@@ -326,6 +316,18 @@ def maybe_prebuild_c_extensions(
 
         yield
         return
+
+    # NOTE: Cython is declared as a dynamic build dependency by
+    # NOTE: `get_requires_for_build_wheel()` and
+    # NOTE: `get_requires_for_build_editable()` when `pure-python` is not
+    # NOTE: passed, so it may only be provisioned after this module has
+    # NOTE: already been imported. PEP 517 front-ends that serve all the
+    # NOTE: hooks from a single long-running backend process, like
+    # NOTE: `pyproject-api` under tox, would never see a module-level
+    # NOTE: import retried, hence this deferred one.
+    from Cython.Build.Cythonize import (  # noqa: PLC0415
+        main as _cythonize_cli_cmd,
+    )
 
     print(  # noqa: T201, WPS421
         '**********************',

--- a/tox.ini
+++ b/tox.ini
@@ -152,7 +152,6 @@ commands =
 [testenv:doctest-docs]
 description =
   Run the doctests embedded in the documentation
-package = skip
 deps =
   -r requirements/doc.txt
 allowlist_externals =


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix the API reference doctests and start running them in CI.

The `with_name()` example expects the apostrophe to come out percent-encoded, but the path quoter treats `'` as an RFC 3986 sub-delim and leaves it as is, so the Sphinx doctest builder fails on master. It went unnoticed because the `doctest-docs` tox environment, unlike its `spellcheck-docs` and `build-docs` siblings, was never added to the lint matrix in CI; it also could not work standalone, since `package = skip` left the examples with no importable `yarl`. The environment now installs the package and runs as a fourth lint leg.

Enabling that surfaced a latent bug in the in-tree PEP 517 backend: the guarded module-level Cython import binds before `get_requires_for_build_wheel()` provisions Cython whenever a front-end serves all build hooks from one long-running backend process, the way `pyproject-api` does under tox, so any `tox`-driven package build crashed with `NameError: name '_cythonize_cli_cmd' is not defined` (reproducible on master with `tox run -e py --recreate`). The import is now deferred to the point of use, which fixes `tox`-driven builds generally.

The spelling word list additionally gains a few legitimate words (`Deprecations`, `backends`, `quoter`, `recode`, `subdirectory`, `unobvious`) that are reported as misspelled when the enchant backend resolves to a more restrictive dictionary than the one CI uses (observed locally with aspell), so `make doc-spelling` gives contributors the same verdict as CI.

## Are there changes in behavior for the user?

No. Documentation, word list, tox configuration, and CI only.

## Is it a substantial burden for the maintainers to support this?

No. The new CI leg reuses the existing tox environment and the reusable tox workflow; it adds about half a minute of parallel runtime.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A; verified with `tox -e doctest-docs`, `make doctest`, `make doc-spelling` and `make doc`)
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt`` (N/A; no ``CONTRIBUTORS.txt`` in this repo)
- [x] Add a new news fragment into the `CHANGES/` folder
  * name: ``1784.doc.rst``, ``1784.contrib.rst``, ``1784.packaging.rst``
  * category: ``doc``, ``contrib``, ``packaging``
