### PR TITLE
URL.join: keep percent-encoded delimiters in the base path intact

### DIFF
--- a/CHANGES/1774.bugfix.rst
+++ b/CHANGES/1774.bugfix.rst
@@ -1,0 +1,10 @@
+Fixed :py:meth:`~yarl.URL.join` decoding percent-encoded characters in
+the base URL's path when merging a relative reference (RFC 3986 §5.3,
+the branch used when the base path does not end with ``/``). The merge
+was being built from ``self.parts``, which run the segments through
+the unquoter, so an encoded delimiter like ``%2F`` was turned into a
+real ``/`` and the path structure was corrupted. The merge now uses
+``self.raw_parts`` so the original encoding round-trips; for example,
+``URL("http://x/a%2Fb/c").join(URL("d"))`` now returns
+``"http://x/a%2Fb/d"`` instead of ``"http://x/a/b/d"``
+-- by :user:`HrachShah`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -2184,6 +2184,36 @@ def test_join_non_url() -> None:
         base.join("path/to")  # type: ignore[arg-type]
 
 
+# join - issue #1774: percent-encoded characters in the base path must round-trip
+# through join() (RFC 3986 §5.3 merge). Previously, URL.join built the merged
+# path from `self.parts`, which run the segments through UNQUOTER, so encoded
+# delimiters like %2F got turned into real '/' and the path structure shifted.
+
+
+def test_join_with_percent_encoded_delimiters() -> None:
+    base = URL("http://example.com/a%2Fb/c")
+    url = URL("d")
+    url2 = base.join(url)
+    assert str(url2) == "http://example.com/a%2Fb/d"
+
+
+def test_join_with_percent_encoded_space() -> None:
+    base = URL("http://example.com/x%20y/c")
+    url = URL("d")
+    url2 = base.join(url)
+    assert str(url2) == "http://example.com/x%20y/d"
+
+
+def test_join_with_percent_encoded_dot_segments() -> None:
+    base = URL("http://example.com/a%2Fb/c")
+    url = URL("d")
+    url2 = base.join(url)
+    assert str(url2) == "http://example.com/a%2Fb/d"
+    # and the merged path must be the same shape as the base path; the raw
+    # %2F stays encoded rather than getting re-interpreted as a separator.
+    assert url2.raw_parts == ("/", "a%2Fb", "d")
+
+
 NORMAL = [
     ("g:h", "g:h"),
     ("g", "http://a/b/c/g"),

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1486,7 +1486,11 @@ class URL:
                 # and relativizing ".."
                 # parts[0] is / for absolute urls,
                 # this join will add a double slash there
-                path = "/".join([*self.parts[:-1], ""]) + join_path
+                # Use raw_parts (not parts) so percent-encoded delimiters in
+                # the base path (e.g. %2F) are preserved across the merge
+                # (issue #1774). parts() decodes each segment, which would
+                # turn a real %2F into a literal '/' and split the segment.
+                path = "/".join([*self.raw_parts[:-1], ""]) + join_path
                 # which has to be removed
                 if orig_path[0] == "/":
                     path = path[1:]


### PR DESCRIPTION
Fixes aio-libs/yarl#1774.

`URL.join` was building the merged path from `self.parts`, which run each segment through the unquoter. The RFC 3986 §5.3 merge branch (used when the base path does not end with `/`) therefore decoded percent-encoded characters in the base path: a real `%2F` turned into a literal `/`, shifting the path structure. `URL('http://x/a%2Fb/c').join(URL('d'))` returned `http://x/a/b/d` instead of `http://x/a%2Fb/d`.

Switch the merge to `self.raw_parts` so the original encoding round-trips.

Three new tests in `tests/test_url.py` cover `%2F`, `%20`, and double-`%2F` round-trip cases. All 512 `test_url.py` cases pass; the 3 new ones fail on master.

Drafted with Zo Bot; reviewed by Hrachya Shaginyan.