### PR TITLE
Drop lone surrogates in the Cython quoter

### DIFF
--- a/CHANGES/1799.bugfix.rst
+++ b/CHANGES/1799.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed the Cython quoter preserving lone surrogate characters
+(``U+D800``..``U+DFFF``) instead of dropping them; it now matches the
+pure-Python quoter, which strips them, so both backends produce the
+same output for the same input -- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -17,6 +17,7 @@ aiohttp
 armv
 ascii
 backend
+backends
 boolean
 booleans
 bools
@@ -46,6 +47,7 @@ nightlies
 pre
 pydantic
 pytest
+quoter
 rc
 reStructuredText
 reencoding

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -99,6 +99,16 @@ def test_quote_ignore_broken_unicode(quoter: type[_Quoter]) -> None:
     assert quoter()(s) == s
 
 
+def test_quote_lone_surrogate_only_trigger(quoter: type[_Quoter]) -> None:
+    # A lone surrogate that is the only character needing attention must be
+    # dropped, not preserved. The path quoter keeps ``/`` safe, so without a
+    # fix the C quoter returned the input unchanged (surrogate included) while
+    # the Python quoter dropped it, letting a prefix check diverge from what
+    # is serialised on the wire.
+    s = quoter(safe="/", protected="/")("/\ud800admin")
+    assert s == "/admin"
+
+
 def test_unquote_to_bytes(unquoter: type[_Unquoter]) -> None:
     assert unquoter()("abc%20def") == "abc def"
     assert unquoter()("") == ""

--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -146,7 +146,11 @@ cdef inline int _write_utf8(Writer* writer, Py_UCS4 symbol):
             return -1
         return _write_pct(writer,  <uint8_t>(0x80 | (utf & 0x3f)), True)
     elif 0xD800 <= utf <= 0xDFFF:
-        # surogate pair, ignored
+        # lone surrogate; invalid in UTF-8 so it is dropped, matching the
+        # pure-Python quoter's errors="ignore" encode. Mark the writer as
+        # changed so _do_quote returns the surrogate-free buffer rather than
+        # the untouched input string.
+        writer.changed = True
         return 0
     elif utf < 0x10000:
         if _write_pct(writer, <uint8_t>(0xe0 | (utf >> 12)), True) < 0:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The Cython quoter preserved lone surrogate characters (``U+D800`` through ``U+DFFF``) when a surrogate was the only character that triggered quoting. The surrogate branch of ``_write_utf8`` wrote nothing to the output buffer but never set ``writer.changed``, so ``_do_quote`` returned the original input untouched, surrogate included. The pure-Python quoter encodes with ``errors="ignore"`` and drops surrogates, so the two backends produced different output for the same input. Setting ``writer.changed`` in the surrogate branch makes the Cython quoter return the surrogate-free buffer, matching the pure-Python quoter.

## Are there changes in behavior for the user?

Yes; a lone surrogate that previously survived quoting under the C extension is now dropped, so ``URL("http://h/\ud800admin").path`` is ``/admin`` on both backends instead of only under the pure-Python quoter.

## Is it a substantial burden for the maintainers to support this?

No; it aligns the two quoters and adds a regression test that runs against both.

## Related issue number

Reported by @bytejmp in GHSA-r78m-9xmv-6rcq; thanks for the report. Fixing in the open as a quoter parity bug.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes N/A (internal quoting behavior, no public API doc)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
