### PR TITLE
Reject builder hosts that normalize to a URL delimiter

### DIFF
--- a/CHANGES/1800.bugfix.rst
+++ b/CHANGES/1800.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed :meth:`URL.build() <yarl.URL.build>` and
+:meth:`~yarl.URL.with_host` accepting hosts that expand to a URL
+delimiter (``/``, ``?`` or ``#``) under IDNA normalization; such hosts
+are now rejected, so the builder APIs agree with the parser
+-- by :user:`bdraco`.

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -181,6 +181,23 @@ def test_build_with_invalid_host(host: str, is_authority: bool) -> None:
         URL.build(host=host)
 
 
+@pytest.mark.parametrize(
+    "host",
+    [
+        "127.0.0.1／allowed.example",
+        "127.0.0.1？allowed.example",
+        "127.0.0.1＃allowed.example",
+    ],
+    ids=["fullwidth-solidus", "fullwidth-question", "fullwidth-number-sign"],
+)
+def test_build_with_host_delimiter_from_normalization(host: str) -> None:
+    # A non-ascii character that expands to a URL delimiter under IDNA/NFKC
+    # normalization must be rejected, matching the parser's _check_netloc.
+    match = r"cannot contain '[/?#]' after IDNA normalization to "
+    with pytest.raises(ValueError, match=match):
+        URL.build(host=host)
+
+
 def test_build_with_authority() -> None:
     url = URL.build(scheme="http", authority="степан:bar@host.com:8000", path="/path")
     assert (

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -206,6 +206,24 @@ def test_with_invalid_host(host: str, is_authority: bool) -> None:
         url.with_host(host=host)
 
 
+@pytest.mark.parametrize(
+    "host",
+    [
+        "127.0.0.1／allowed.example",
+        "127.0.0.1？allowed.example",
+        "127.0.0.1＃allowed.example",
+    ],
+    ids=["fullwidth-solidus", "fullwidth-question", "fullwidth-number-sign"],
+)
+def test_with_host_delimiter_from_normalization(host: str) -> None:
+    # A non-ascii character that expands to a URL delimiter under IDNA/NFKC
+    # normalization must be rejected, matching the parser's _check_netloc.
+    url = URL("http://example.com:123")
+    match = r"cannot contain '[/?#]' after IDNA normalization to "
+    with pytest.raises(ValueError, match=match):
+        url.with_host(host)
+
+
 def test_with_host_percent_encoded() -> None:
     url = URL("http://%25cf%2580%cf%80:%25cf%2580%cf%80@example.com:123")
     url2 = url.with_host("%cf%80.org")

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1651,7 +1651,18 @@ def _encode_host(host: str, validate_host: bool) -> str:
             ) from None
         return host
 
-    return _idna_encode(host)
+    encoded = _idna_encode(host)
+    # IDNA uses NFKC equivalence, so normalization can expand a non-ascii
+    # character into an ASCII delimiter (e.g. the fullwidth solidus U+FF0F
+    # becomes '/'). The ascii branch above rejects such delimiters directly;
+    # apply the same check to the IDNA output so the builder APIs agree with
+    # the parser's _check_netloc.
+    if validate_host and (invalid := NOT_REG_NAME.search(encoded)):
+        raise ValueError(
+            f"Host {host!r} cannot contain {invalid.group()!r} "
+            f"after IDNA normalization to {encoded!r}"
+        ) from None
+    return encoded
 
 
 @rewrite_module


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

``URL.build(host=...)`` and ``URL.with_host(...)`` route through ``_encode_host``, whose non-ascii branch handed the host to IDNA encoding without checking the result for delimiters. IDNA uses NFKC equivalence, so a character such as the fullwidth solidus ``U+FF0F`` normalizes to ``/``, producing a host like ``127.0.0.1/allowed.example``. The parser already rejects that shape in ``_check_netloc``; this validates the IDNA-encoded output against ``NOT_REG_NAME`` so the builder APIs agree with the parser.

## Are there changes in behavior for the user?

Yes; a host that normalizes to ``/``, ``?`` or ``#`` under IDNA is now rejected with ``ValueError`` from ``URL.build`` and ``URL.with_host``, instead of being accepted and exposed through ``.host``.

## Is it a substantial burden for the maintainers to support this?

No; the check runs only on the non-ascii branch, after the IDNA encode that already dominates that path, and the ascii hot path is untouched.

## Related issue number

Reported by @mauriceng98; thanks for the report.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes N/A (behavior fix, no public API surface change)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
