### PR TITLE
Reject hosts with Unicode default-ignorable code points

### DIFF
--- a/CHANGES/1801.bugfix.rst
+++ b/CHANGES/1801.bugfix.rst
@@ -1,0 +1,7 @@
+Fixed host encoding accepting Unicode default-ignorable and format code
+points (such as soft hyphen, zero-width space, and word joiner) that IDNA
+normalization silently drops or otherwise folds into a different host,
+so the parsed host could differ from the input string; such hosts are now
+rejected on both the :class:`~yarl.URL` constructor and the builder APIs
+(:meth:`URL.build() <yarl.URL.build>` and :meth:`~yarl.URL.with_host`)
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -40,6 +40,7 @@ google
 hardcoded
 hostless
 hostnames
+ignorable
 macOS
 mailto
 manylinux

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -4,6 +4,7 @@ from urllib.parse import SplitResult, quote, unquote
 import pytest
 
 from yarl import URL
+from yarl._url import _DEFAULT_IGNORABLE_RE, _idna_encode
 
 _WHATWG_C0_CONTROL_OR_SPACE = (
     "\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f\x10"
@@ -2648,3 +2649,64 @@ def test_url_with_fullwidth_percent_rejected(percent_char: str) -> None:
         ValueError, match="contains invalid characters under NFKC normalization"
     ):
         URL(f"http://evil.com{percent_char}2e.internal/")
+
+
+@pytest.mark.parametrize(
+    "ignorable",
+    [
+        "\u00ad",  # SOFT HYPHEN
+        "\u200b",  # ZERO WIDTH SPACE
+        "\u2060",  # WORD JOINER
+        "\u180e",  # MONGOLIAN VOWEL SEPARATOR
+        "\u1806",  # MONGOLIAN TODO SOFT HYPHEN (nameprep fallback strips it)
+        "\ufeff",  # ZERO WIDTH NO-BREAK SPACE
+        "\U000e0001",  # LANGUAGE TAG
+    ],
+    ids=[
+        "soft-hyphen",
+        "zwsp",
+        "word-joiner",
+        "mvs",
+        "todo-soft-hyphen",
+        "bom",
+        "language-tag",
+    ],
+)
+def test_url_host_with_default_ignorable_rejected(ignorable: str) -> None:
+    """Default-ignorable code points are stripped by IDNA, so reject them.
+
+    Otherwise ``URL("http://e<ZWSP>vil.com").host`` would collapse to
+    ``evil.com``, a different host than the string the caller validated.
+    """
+    with pytest.raises(ValueError, match="cannot contain"):
+        URL(f"http://e{ignorable}vil.com/")
+
+
+def _idna_collapses(code_point: int) -> bool:
+    """True if IDNA encoding silently deletes ``code_point`` from a host."""
+    try:
+        return _idna_encode(f"ab{chr(code_point)}cd.com") == "abcd.com"
+    except UnicodeError:
+        return False
+
+
+def test_default_ignorable_covers_idna_stripped() -> None:
+    """_DEFAULT_IGNORABLE_RE must match every code point IDNA silently deletes.
+
+    This pins the hand-written character class to the installed ``idna`` and
+    Unicode data: if a future version starts deleting a code point the regex
+    does not cover, host confusion returns and this test fails loudly. The
+    ranges cover every plane that holds such code points (the highest is
+    ``U+E0FFF``); the empty planes in between hold none.
+    """
+    stripped = {
+        cp
+        for lo, hi in ((0x00A0, 0x20000), (0xE0000, 0xE1000))
+        for cp in range(lo, hi)
+        if not 0xD800 <= cp <= 0xDFFF and _idna_collapses(cp)
+    }
+    assert stripped, "expected IDNA to strip at least the known default-ignorables"
+    uncovered = sorted(
+        hex(cp) for cp in stripped if not _DEFAULT_IGNORABLE_RE.search(chr(cp))
+    )
+    assert not uncovered, f"IDNA strips these but the regex misses them: {uncovered}"

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -198,6 +198,18 @@ def test_build_with_host_delimiter_from_normalization(host: str) -> None:
         URL.build(host=host)
 
 
+@pytest.mark.parametrize(
+    "ignorable",
+    ["\u00ad", "\u200b", "\u2060", "\ufeff"],
+    ids=["soft-hyphen", "zwsp", "word-joiner", "bom"],
+)
+def test_build_with_host_default_ignorable(ignorable: str) -> None:
+    # IDNA strips default-ignorable code points, so the builder must reject a
+    # host containing one instead of collapsing it to a different host.
+    with pytest.raises(ValueError, match="cannot contain"):
+        URL.build(host=f"e{ignorable}vil.com")
+
+
 def test_build_with_authority() -> None:
     url = URL.build(scheme="http", authority="степан:bar@host.com:8000", path="/path")
     assert (

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -224,6 +224,19 @@ def test_with_host_delimiter_from_normalization(host: str) -> None:
         url.with_host(host)
 
 
+@pytest.mark.parametrize(
+    "ignorable",
+    ["\u00ad", "\u200b", "\u2060", "\ufeff"],
+    ids=["soft-hyphen", "zwsp", "word-joiner", "bom"],
+)
+def test_with_host_default_ignorable(ignorable: str) -> None:
+    # IDNA strips default-ignorable code points, so with_host must reject a
+    # host containing one instead of collapsing it to a different host.
+    url = URL("http://example.com:123")
+    with pytest.raises(ValueError, match="cannot contain"):
+        url.with_host(f"e{ignorable}vil.com")
+
+
 def test_with_host_percent_encoded() -> None:
     url = URL("http://%25cf%2580%cf%80:%25cf%2580%cf%80@example.com:123")
     url2 = url.with_host("%cf%80.org")

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -89,6 +89,50 @@ NOT_REG_NAME = re.compile(
     re.VERBOSE,
 )
 
+# Invisible default-ignorable / format code points that must not appear in a
+# host (soft hyphen, zero-width space, word joiner, bidi controls, variation
+# selectors, ...). Depending on the code point IDNA either silently deletes it
+# (so ``e<ZWSP>vil.com`` encodes to ``evil.com``) or folds it into a different
+# punycode host; either way the parsed host differs from the string an
+# application validated. The set is the union of two authoritative sources,
+# matching the two encoders _idna_encode dispatches to:
+#
+# 1. Unicode Default_Ignorable_Code_Point (uts46=True path via the ``idna``
+#    package). Ranges taken from the DerivedCoreProperties data file:
+#    https://www.unicode.org/Public/UCD/latest/ucd/DerivedCoreProperties.txt
+#    (the E0000..E0FFF block is contiguous under this property).
+# 2. RFC 3454 (Stringprep) Table B.1 "commonly mapped to nothing", used by the
+#    stdlib ``str.encode("idna")`` / IDNA2003 nameprep fallback:
+#    https://www.rfc-editor.org/rfc/rfc3454#appendix-B.1
+#    This is the source of U+1806, which is not Default_Ignorable.
+#
+# Coverage is pinned to the installed ``idna``/Unicode data by a sweep test
+# (test_default_ignorable_covers_idna_stripped in tests/test_url.py) that
+# brute-forces every code point through _idna_encode and fails if any point it
+# silently deletes is not matched here.
+_DEFAULT_IGNORABLE_RE = re.compile(
+    "["
+    "\u00ad"  # SOFT HYPHEN
+    "\u034f"  # COMBINING GRAPHEME JOINER
+    "\u061c"  # ARABIC LETTER MARK
+    "\u115f-\u1160"  # HANGUL CHOSEONG/JUNGSEONG FILLER
+    "\u17b4-\u17b5"  # KHMER VOWEL INHERENT AQ/AA
+    "\u1806"  # MONGOLIAN TODO SOFT HYPHEN (nameprep maps to nothing)
+    "\u180b-\u180f"  # MONGOLIAN FVS ONE..FOUR and VOWEL SEPARATOR
+    "\u200b-\u200f"  # ZERO WIDTH SPACE..RIGHT-TO-LEFT MARK
+    "\u202a-\u202e"  # bidi embedding/override controls
+    "\u2060-\u206f"  # WORD JOINER..NOMINAL DIGIT SHAPES
+    "\u3164"  # HANGUL FILLER
+    "\ufe00-\ufe0f"  # VARIATION SELECTOR-1..16
+    "\ufeff"  # ZERO WIDTH NO-BREAK SPACE (BOM)
+    "\uffa0"  # HALFWIDTH HANGUL FILLER
+    "\ufff0-\ufff8"  # reserved default-ignorables
+    "\U0001bca0-\U0001bca3"  # SHORTHAND FORMAT controls
+    "\U0001d173-\U0001d17a"  # MUSICAL SYMBOL begin/end controls
+    "\U000e0000-\U000e0fff"  # tags and VARIATION SELECTOR SUPPLEMENT
+    "]"
+)
+
 # Zone IDs are OS-specific text strings with no format defined by the RFCs:
 # https://datatracker.ietf.org/doc/html/rfc4007#section-11.2
 # RFC 9844 §6.3 recommends rejecting characters inappropriate for the
@@ -1651,6 +1695,17 @@ def _encode_host(host: str, validate_host: bool) -> str:
             ) from None
         return host
 
+    # IDNA/UTS-46 mapping silently deletes default-ignorable code points, which
+    # would turn e.g. ``e<ZWSP>vil.com`` into ``evil.com``, a different host
+    # than the string the caller supplied. Reject them on every path (this runs
+    # regardless of ``validate_host`` since the plain ``URL(str)`` constructor
+    # encodes with ``validate_host=False``) so the parsed host cannot diverge
+    # from the input, matching idna/httpx/urllib3.
+    if invalid := _DEFAULT_IGNORABLE_RE.search(host):
+        raise ValueError(
+            f"Host {host!r} cannot contain {invalid.group()!r} "
+            f"(at position {invalid.start()})"
+        ) from None
     encoded = _idna_encode(host)
     # IDNA uses NFKC equivalence, so normalization can expand a non-ascii
     # character into an ASCII delimiter (e.g. the fullwidth solidus U+FF0F


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Invisible default-ignorable and format code points (soft hyphen, zero-width space, word joiner, bidi controls, variation selectors, and so on) let the parsed host diverge from the string the caller validated. Depending on the code point, IDNA either silently deletes it (so ``e<ZWSP>vil.com`` encoded to ``evil.com``) or folds it into a different punycode host; in both cases ``.host`` and ``str(url)`` no longer matched the input. ``_encode_host`` now rejects any host containing such a code point before IDNA encoding. This runs on every path, including the plain ``URL(str)`` constructor and the builder APIs, so the parsed host cannot diverge from the input. This matches ``idna``, ``httpx`` and ``urllib3``, which all reject these hosts.

The rejected set is the union of two authoritative sources, matching the two encoders ``_idna_encode`` dispatches to: the Unicode ``Default_Ignorable_Code_Point`` property (for the ``idna`` uts46 path) and RFC 3454 Stringprep Table B.1 "commonly mapped to nothing" (for the stdlib ``str.encode("idna")`` fallback). The latter is the source of ``U+1806``, which is not default-ignorable but is still stripped by the fallback.

## Are there changes in behavior for the user?

Yes; a host containing a default-ignorable code point is now rejected with ``ValueError`` instead of being silently collapsed to a different host.

## Is it a substantial burden for the maintainers to support this?

No; the check is a single regex search on the already-slow non-ascii branch of ``_encode_host``, and the ascii hot path is untouched. A sweep test brute-forces every code point through ``_idna_encode`` and fails if any point it silently deletes is not covered by the character class, so the hand-written ranges stay pinned to the installed ``idna``/Unicode data rather than drifting.

## Related issue number

Reported by @bilguunbicktivism; thanks for the report.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes N/A (behavior fix, no public API surface change)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
