### PR TITLE
Encode scheme-shaped path colon in relative-path builders

### DIFF
--- a/CHANGES/1802.bugfix.rst
+++ b/CHANGES/1802.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed :meth:`~yarl.URL.build`, :meth:`~yarl.URL.joinpath` (and the ``/``
+operator), :meth:`~yarl.URL.with_name`, and :meth:`~yarl.URL.with_suffix`
+building a URL with no host and no scheme whose serialized string could be
+parsed back as an absolute or executable-scheme URL; a scheme-shaped leading
+colon in a relative path is now percent-encoded, matching the parser and
+:meth:`~yarl.URL.human_repr` -- by :user:`bdraco`.

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -779,3 +779,96 @@ def test_raw_path_drops_lone_surrogate() -> None:
     assert url.raw_path == "/path"
     # raw_path is always percent-encoded ASCII; a retained surrogate is a bug.
     assert url.raw_path.encode("ascii") == b"/path"
+
+
+class TestBuilderSchemeMaterialization:
+    """Regression tests for scheme materialization via relative-path builders.
+
+    ``URL.build(path=...)``, ``joinpath()`` and the ``/`` operator,
+    ``with_name()`` and ``with_suffix()`` can build a hostless, schemeless URL
+    whose serialized form would otherwise reparse as an absolute or
+    executable-scheme URL. The scheme-shaped leading colon must be
+    percent-encoded so ``str(url)`` round-trips as the relative URL it reports
+    itself to be. This is the builder-side counterpart to the parser guard in
+    :class:`TestPercentEncodedSchemeBypass`.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "http://127.0.0.1/internal-secret",
+            "javascript:alert(1)",
+            "data:text/html,xss",
+        ],
+        ids=["http-host", "javascript", "data"],
+    )
+    def test_build_path_does_not_introduce_scheme(self, value: str) -> None:
+        """URL.build(path=...) must not serialize to a scheme-shaped string."""
+        u = URL.build(path=value)
+        assert u.absolute is False
+        assert u.raw_host is None
+        assert u.scheme == ""
+
+        reparsed = URL(str(u))
+        assert reparsed.scheme == ""
+        assert reparsed.raw_host is None
+        assert reparsed.absolute is False
+
+    @pytest.mark.parametrize("encoded", [False, True], ids=["decoded", "encoded"])
+    def test_build_path_encoded_flag_does_not_introduce_scheme(
+        self, encoded: bool
+    ) -> None:
+        """The guard holds for both the decoded and pre-encoded build paths."""
+        u = URL.build(path="http://127.0.0.1/internal-secret", encoded=encoded)
+        assert u.scheme == ""
+        assert URL(str(u)).raw_host is None
+
+    def test_joinpath_does_not_introduce_scheme(self) -> None:
+        """joinpath() onto a relative base must not materialize a host."""
+        u = URL("").joinpath("http://127.0.0.1/internal-secret")
+        assert u.scheme == ""
+        assert u.raw_host is None
+        assert URL(str(u)).raw_host is None
+
+    def test_truediv_does_not_introduce_scheme(self) -> None:
+        """The / operator must not materialize an executable scheme."""
+        u = URL("") / "javascript:alert(1)"
+        assert u.scheme == ""
+        assert URL(str(u)).scheme == ""
+
+    def test_with_name_does_not_introduce_scheme(self) -> None:
+        """with_name() on a relative base must not materialize a scheme."""
+        u = URL("foo").with_name("javascript:alert(1)")
+        assert u.scheme == ""
+        assert URL(str(u)).scheme == ""
+
+    def test_with_suffix_does_not_introduce_scheme(self) -> None:
+        """with_suffix() on a relative base must not materialize a scheme."""
+        # "name" + ".a:b" -> "name.a:b"; ".", letters and digits are all
+        # scheme chars, so the colon would materialize scheme "name.a".
+        u = URL("name").with_suffix(".a:b")
+        assert u.scheme == ""
+        assert URL(str(u)).scheme == ""
+
+    def test_absolute_base_builder_keeps_colon(self) -> None:
+        """With an authority the path colon is not a delimiter and is kept."""
+        u = URL("http://example.com").joinpath("a:b")
+        assert str(u) == "http://example.com/a:b"
+        assert URL(str(u)).raw_host == "example.com"
+
+    def test_colon_after_slash_builder_not_affected(self) -> None:
+        """A colon in a non-leading path position is left literal."""
+        u = URL.build(path="/path/with:colon")
+        assert str(u) == "/path/with:colon"
+        assert URL(str(u)).scheme == ""
+
+    def test_build_path_human_repr_unchanged(self) -> None:
+        """human_repr() already encoded the colon and must be unchanged."""
+        u = URL.build(path="http://127.0.0.1/internal-secret")
+        assert u.human_repr() == "http%3A//127.0.0.1/internal-secret"
+
+    def test_relative_builder_without_colon_unchanged(self) -> None:
+        """A relative path with no colon needs no encoding and is kept as is."""
+        assert str(URL.build(path="req/req/req")) == "req/req/req"
+        assert str(URL("").joinpath("req/req/req")) == "req/req/req"
+        assert str(URL.build(path="req/req", encoded=True)) == "req/req"

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -872,3 +872,33 @@ class TestBuilderSchemeMaterialization:
         assert str(URL.build(path="req/req/req")) == "req/req/req"
         assert str(URL("").joinpath("req/req/req")) == "req/req/req"
         assert str(URL.build(path="req/req", encoded=True)) == "req/req"
+
+    @pytest.mark.parametrize("encoded", [False, True], ids=["decoded", "encoded"])
+    def test_with_path_scheme_shaped_relative(self, encoded: bool) -> None:
+        """with_path() prepends a slash, so a scheme cannot materialize."""
+        u = URL("").with_path("http://127.0.0.1/x", encoded=encoded)
+        assert u.scheme == ""
+        assert u.raw_host is None
+        assert str(u) == "/http://127.0.0.1/x"
+        assert URL(str(u)).raw_host is None
+
+    def test_relative_keeps_colon_after_slash(self) -> None:
+        """relative() on an absolute URL keeps a non-leading path colon."""
+        u = URL("http://example.com/a:b").relative()
+        assert u.scheme == ""
+        assert str(u) == "/a:b"
+        assert URL(str(u)).scheme == ""
+
+    def test_with_query_preserves_encoded_scheme_colon(self) -> None:
+        """A relative URL whose colon was already encoded stays encoded."""
+        u = URL.build(path="javascript:alert(1)").with_query(a="1")
+        assert u.scheme == ""
+        assert str(u) == "javascript%3Aalert(1)?a=1"
+        assert URL(str(u)).scheme == ""
+
+    def test_parent_of_scheme_shaped_relative(self) -> None:
+        """parent derives from an already-encoded path and stays relative."""
+        u = URL.build(path="a:b/c").parent
+        assert u.scheme == ""
+        assert str(u) == "a%3Ab"
+        assert URL(str(u)).scheme == ""

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -280,6 +280,8 @@ def build_pre_encoded_url(
             self._netloc = make_netloc(user, password, host, port)
     else:
         self._netloc = ""
+    if path and not scheme and not self._netloc and ":" in path:
+        path = _encode_relative_scheme_colon(path)
     self._path = path
     self._query = query_string
     self._fragment = fragment
@@ -294,6 +296,8 @@ def from_parts_uncached(
     self = object.__new__(URL)
     self._scheme = scheme
     self._netloc = netloc
+    if path and not scheme and not netloc and ":" in path:
+        path = _encode_relative_scheme_colon(path)
     self._path = path
     self._query = query
     self._fragment = fragment
@@ -500,6 +504,8 @@ class URL:
                 )
                 raise ValueError(msg)
 
+        if path and not self._scheme and not self._netloc and ":" in path:
+            path = _encode_relative_scheme_colon(path)
         self._path = path
         if not query and query_string:
             query_string = QUERY_QUOTER(query_string)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The relative-path builders (`URL.build(path=...)`, `joinpath()` and the `/`
operator, `with_name()`, and `with_suffix()`) could build a URL with no host
and no scheme whose serialized string parsed back as an absolute or
executable-scheme URL. For example `URL.build(path="http://127.0.0.1/x")`
reported `absolute` as `False`, `raw_host` as `None`, and an empty scheme,
yet `str(url)` produced `http://127.0.0.1/x`, which reparses with host
`127.0.0.1`. The parser and `human_repr()` already guard against this via
`_encode_relative_scheme_colon()`; this applies the same guard at the builder
construction sinks, so a scheme-shaped leading colon in a relative path is
percent-encoded and `str(url)` stays consistent with the object's properties.

The guard is placed in `from_parts_uncached` (and its `from_parts` cache
wrapper) plus `URL.build`, so it fires for any hostless, schemeless result of
`from_parts`, which also covers `with_path`, `relative`, `with_query`,
`parent`, and the other methods that funnel through the same sink, not just
the four builders named above. Absolute or scheme-bearing URLs and colon-free
relative paths short-circuit before the helper is called, so the encoding only
runs where a scheme could actually materialize; already-encoded paths carry no
literal colon and are left untouched, so there is no double-encoding.

## Are there changes in behavior for the user?

Yes, narrowly; a relative, hostless URL built with a scheme-shaped leading
path segment now serializes with the colon percent-encoded (`http%3A//...`
rather than `http://...`), matching what the parser and `human_repr()`
already do. URLs with a scheme or authority are unaffected, since the guard
only fires when both are absent.

## Is it a substantial burden for the maintainers to support this?

No; it reuses the existing `_encode_relative_scheme_colon()` helper and adds
two boolean checks that short-circuit for any absolute or scheme-bearing URL.

## Related issue number

No public issue; found while reviewing relative-URL serialization against the
existing parser guard from #1669.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
