### PR TITLE
Do not install hypothesis in the wheel-build test env

### DIFF
--- a/CHANGES/1804.packaging.rst
+++ b/CHANGES/1804.packaging.rst
@@ -1,0 +1,5 @@
+Stopped installing ``hypothesis`` in the wheel-build test environment. The
+property-based quoting tests that need it are skipped there already, and
+building it from source on architectures without a prebuilt wheel (such as
+``armv7l`` musllinux, where the build pulls in a Rust toolchain) was failing
+the wheel jobs -- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -45,8 +45,10 @@ macOS
 mailto
 manylinux
 multi
+musllinux
 nightlies
 pre
+prebuilt
 pydantic
 pytest
 quoter
@@ -68,6 +70,7 @@ subcomponent
 subdirectory
 subtree
 svetlov
+toolchain
 tox
 uncompiled
 unencoded

--- a/requirements/test-cibuildwheel.txt
+++ b/requirements/test-cibuildwheel.txt
@@ -1,6 +1,5 @@
 -r cython.txt
 covdefaults
-hypothesis>=6.157.0
 idna==3.18
 multidict==6.7.1
 propcache==0.4.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,10 @@
 -r test-cibuildwheel.txt
+# hypothesis is only needed for the property-based tests in
+# tests/test_quoting_hypothesis.py, which the wheel-build test run skips
+# (via -m "not hypothesis" plus an importorskip). Keeping it out of
+# test-cibuildwheel.txt avoids building it from source on arches without a
+# prebuilt wheel (e.g. armv7l musllinux, where the source build needs Rust).
+hypothesis>=6.157.0
 # pydantic-core has no binary wheels for freethreading mode,
 # let's skip testing it during wheels building.
 # The regular test run is sufficient for testing pydantic integration.

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -1,6 +1,4 @@
 import pytest
-from hypothesis import assume, example, given, note
-from hypothesis import strategies as st
 
 import yarl
 from yarl._quoting import NO_EXTENSIONS, _Quoter, _Unquoter
@@ -558,79 +556,3 @@ def test_quoter_path_with_plus(quoter: type[_Quoter]) -> None:
 def test_unquoter_path_with_plus(unquoter: type[_Unquoter]) -> None:
     s = "/test/x+y%2Bz/:+%2B/"
     assert "/test/x+y+z/:++/" == unquoter(unsafe="+")(s)
-
-
-@given(safe=st.text(), protected=st.text(), qs=st.booleans(), requote=st.booleans())
-def test_fuzz__PyQuoter(safe: str, protected: str, qs: bool, requote: bool) -> None:  # type: ignore[misc]
-    """Verify that _PyQuoter can be instantiated with any valid arguments."""
-    _PyQuoter(safe=safe, protected=protected, qs=qs, requote=requote)
-
-
-@given(ignore=st.text(), unsafe=st.text(), qs=st.booleans())
-def test_fuzz__PyUnquoter(ignore: str, unsafe: str, qs: bool) -> None:  # type: ignore[misc]
-    """Verify that _PyUnquoter can be instantiated with any valid arguments."""
-    _PyUnquoter(ignore=ignore, unsafe=unsafe, qs=qs)
-
-
-@example(text_input="0")
-@given(
-    text_input=st.text(
-        alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
-    ),
-)
-@pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
-@pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
-def test_quote_unquote_parameter(  # type: ignore[misc]
-    quoter: type[_PyQuoter],
-    unquoter: type[_PyUnquoter],
-    text_input: str,
-) -> None:
-    quote = quoter()
-    unquote = unquoter()
-    text_quoted = quote(text_input)
-    note(f"text_quoted={text_quoted!r}")
-    text_output = unquote(text_quoted)
-    assert text_input == text_output
-
-
-@example(text_input="0")
-@given(
-    text_input=st.text(
-        alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
-    ),
-)
-@pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
-@pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
-def test_quote_unquote_parameter_requote(  # type: ignore[misc]
-    quoter: type[_PyQuoter],
-    unquoter: type[_PyUnquoter],
-    text_input: str,
-) -> None:
-    quote = quoter(requote=True)
-    unquote = unquoter()
-    text_quoted = quote(text_input)
-    note(f"text_quoted={text_quoted!r}")
-    text_output = unquote(text_quoted)
-    assert text_input == text_output
-
-
-@example(text_input="0")
-@given(
-    text_input=st.text(
-        alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
-    ),
-)
-@pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
-@pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
-def test_quote_unquote_parameter_path_safe(  # type: ignore[misc]
-    quoter: type[_PyQuoter],
-    unquoter: type[_PyUnquoter],
-    text_input: str,
-) -> None:
-    quote = quoter()
-    unquote = unquoter(ignore="/%", unsafe="+")
-    assume("+" not in text_input and "/" not in text_input)
-    text_quoted = quote(text_input)
-    note(f"text_quoted={text_quoted!r}")
-    text_output = unquote(text_quoted)
-    assert text_input == text_output

--- a/tests/test_quoting_hypothesis.py
+++ b/tests/test_quoting_hypothesis.py
@@ -1,0 +1,114 @@
+"""Property-based quoting tests.
+
+Split out from ``test_quoting.py`` so the wheel-build test run can execute the
+rest of the suite without installing ``hypothesis`` (its tests are excluded
+there via ``-m "not hypothesis"``). ``importorskip`` skips this module when
+``hypothesis`` is not installed.
+"""
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from yarl._quoting import NO_EXTENSIONS
+from yarl._quoting_py import _Quoter as _PyQuoter
+from yarl._quoting_py import _Unquoter as _PyUnquoter
+
+if TYPE_CHECKING:
+    from hypothesis import assume, example, given, note
+    from hypothesis import strategies as st
+else:
+    pytest.importorskip("hypothesis")
+
+    from hypothesis import assume, example, given, note
+    from hypothesis import strategies as st
+
+if not NO_EXTENSIONS:
+    from yarl._quoting_c import _Quoter as _CQuoter  # type: ignore[import-not-found]
+    from yarl._quoting_c import _Unquoter as _CUnquoter
+
+    quoters = [_PyQuoter, _CQuoter]
+    quoter_ids = ["PyQuoter", "CQuoter"]
+    unquoters = [_PyUnquoter, _CUnquoter]
+    unquoter_ids = ["PyUnquoter", "CUnquoter"]
+else:
+    quoters = [_PyQuoter]
+    quoter_ids = ["PyQuoter"]
+    unquoters = [_PyUnquoter]
+    unquoter_ids = ["PyUnquoter"]
+
+
+@given(safe=st.text(), protected=st.text(), qs=st.booleans(), requote=st.booleans())
+def test_fuzz__PyQuoter(safe: str, protected: str, qs: bool, requote: bool) -> None:  # type: ignore[misc]
+    """Verify that _PyQuoter can be instantiated with any valid arguments."""
+    _PyQuoter(safe=safe, protected=protected, qs=qs, requote=requote)
+
+
+@given(ignore=st.text(), unsafe=st.text(), qs=st.booleans())
+def test_fuzz__PyUnquoter(ignore: str, unsafe: str, qs: bool) -> None:  # type: ignore[misc]
+    """Verify that _PyUnquoter can be instantiated with any valid arguments."""
+    _PyUnquoter(ignore=ignore, unsafe=unsafe, qs=qs)
+
+
+@example(text_input="0")
+@given(
+    text_input=st.text(
+        alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
+    ),
+)
+@pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
+@pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
+def test_quote_unquote_parameter(  # type: ignore[misc]
+    quoter: type[_PyQuoter],
+    unquoter: type[_PyUnquoter],
+    text_input: str,
+) -> None:
+    quote = quoter()
+    unquote = unquoter()
+    text_quoted = quote(text_input)
+    note(f"text_quoted={text_quoted!r}")
+    text_output = unquote(text_quoted)
+    assert text_input == text_output
+
+
+@example(text_input="0")
+@given(
+    text_input=st.text(
+        alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
+    ),
+)
+@pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
+@pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
+def test_quote_unquote_parameter_requote(  # type: ignore[misc]
+    quoter: type[_PyQuoter],
+    unquoter: type[_PyUnquoter],
+    text_input: str,
+) -> None:
+    quote = quoter(requote=True)
+    unquote = unquoter()
+    text_quoted = quote(text_input)
+    note(f"text_quoted={text_quoted!r}")
+    text_output = unquote(text_quoted)
+    assert text_input == text_output
+
+
+@example(text_input="0")
+@given(
+    text_input=st.text(
+        alphabet=st.characters(max_codepoint=127, blacklist_characters="%")
+    ),
+)
+@pytest.mark.parametrize("quoter", quoters, ids=quoter_ids)
+@pytest.mark.parametrize("unquoter", unquoters, ids=unquoter_ids)
+def test_quote_unquote_parameter_path_safe(  # type: ignore[misc]
+    quoter: type[_PyQuoter],
+    unquoter: type[_PyUnquoter],
+    text_input: str,
+) -> None:
+    quote = quoter()
+    unquote = unquoter(ignore="/%", unsafe="+")
+    assume("+" not in text_input and "/" not in text_input)
+    text_quoted = quote(text_input)
+    note(f"text_quoted={text_quoted!r}")
+    text_output = unquote(text_quoted)
+    assert text_input == text_output


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The wheel-build test run already skips the property-based quoting tests via ``-m "not hypothesis"``, but ``hypothesis`` was still installed through ``requirements/test-cibuildwheel.txt`` and imported at collection time by ``tests/test_quoting.py``, so it was built from source on every arch. On arches without a prebuilt wheel (``armv7l`` musllinux) that source build pulls in a Rust toolchain and failed the wheel jobs.

This moves the property-based tests into ``tests/test_quoting_hypothesis.py`` behind an ``importorskip`` so the module is skipped when ``hypothesis`` is absent, and moves the ``hypothesis`` requirement from ``test-cibuildwheel.txt`` to ``test.txt`` so the regular test run still installs it while the wheel build does not. This mirrors how ``pydantic`` is already scoped to the regular run only.

## Are there changes in behavior for the user?

No; it only changes the test dependencies and layout. The property-based tests still run in the regular test matrix, and the same wheels are produced.

## Is it a substantial burden for the maintainers to support this?

No; it removes a source build from the wheel test environment and follows the existing ``pydantic`` pattern.

## Related issue number

N/A (fixes the armv7l musllinux wheel job)

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes N/A (test/CI layout change)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
