### PR TITLE
Release 1.24.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,28 @@ Changelog
 
 .. towncrier release notes start
 
+v1.24.4
+=======
+
+*(2026-07-19)*
+
+
+Packaging updates and notes for downstreams
+-------------------------------------------
+
+- Stopped installing ``hypothesis`` in the wheel-build test environment. The
+  property-based quoting tests that need it are skipped there already, and
+  building it from source on architectures without a prebuilt wheel (such as
+  ``armv7l`` musllinux, where the build pulls in a Rust toolchain) was failing
+  the wheel jobs -- by :user:`bdraco`.
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`1804`.
+
+
+----
+
+
 v1.24.3
 =======
 

--- a/CHANGES/1804.packaging.rst
+++ b/CHANGES/1804.packaging.rst
@@ -1,5 +1,0 @@
-Stopped installing ``hypothesis`` in the wheel-build test environment. The
-property-based quoting tests that need it are skipped there already, and
-building it from source on architectures without a prebuilt wheel (such as
-``armv7l`` musllinux, where the build pulls in a Rust toolchain) was failing
-the wheel jobs -- by :user:`bdraco`.

--- a/yarl/__init__.py
+++ b/yarl/__init__.py
@@ -1,7 +1,7 @@
 from ._query import Query, QueryVariable, SimpleQuery
 from ._url import URL, cache_clear, cache_configure, cache_info
 
-__version__ = "1.24.3"
+__version__ = "1.24.4"
 
 __all__ = (
     "URL",


### PR DESCRIPTION
https://github.com/aio-libs/yarl/actions/runs/29708062952

1.24.3 couldn't ship without fixing https://github.com/aio-libs/yarl/pull/1804 so we get a 1.24.4 now
<img width="703" height="325" alt="Screenshot 2026-07-19 at 1 02 04 PM" src="https://github.com/user-attachments/assets/cc62c1ef-228d-453d-8b35-916ad6f7ec92" />

