### PR TITLE
Run the IDNA sweep test only on native Linux x86_64

### DIFF
--- a/CHANGES/1806.contrib.rst
+++ b/CHANGES/1806.contrib.rst
@@ -1,0 +1,5 @@
+Restricted the exhaustive IDNA default-ignorable sweep test to a native
+Linux x86_64 runner. It iterates roughly 140,000 code points and its result
+does not depend on the architecture, so running it under emulated wheel
+builds only added minutes and intermittently crashed the test workers
+-- by :user:`bdraco`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1,3 +1,5 @@
+import platform
+import sys
 from enum import Enum
 from urllib.parse import SplitResult, quote, unquote
 
@@ -2798,6 +2800,15 @@ def _idna_collapses(code_point: int) -> bool:
         return False
 
 
+@pytest.mark.skipif(
+    sys.platform != "linux" or platform.machine() != "x86_64",
+    reason=(
+        "Exhaustive IDNA sweep iterates ~140k code points; its result does not "
+        "depend on the architecture, so it only runs on a native Linux x86_64 "
+        "runner. It is too heavy for QEMU-emulated wheel-build arches, where it "
+        "crashes the test workers."
+    ),
+)
 def test_default_ignorable_covers_idna_stripped() -> None:
     """_DEFAULT_IGNORABLE_RE must match every code point IDNA silently deletes.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

``test_default_ignorable_covers_idna_stripped`` iterates roughly 140,000 code points through ``_idna_encode`` to pin the default-ignorable character class to the installed ``idna`` data. Its result does not depend on the architecture, but running it under the QEMU-emulated wheel-build arches (``s390x``, ``armv7l``, and so on) added minutes and intermittently crashed the ``xdist`` workers. This skips it unless the host is native Linux x86_64, where the regular test matrix already runs it.

## Are there changes in behavior for the user?

No; it only narrows where a heavyweight test runs. The check still runs in the regular test matrix on native Linux x86_64.

## Is it a substantial burden for the maintainers to support this?

No; it is a single ``skipif`` on one test.

## Related issue number

N/A (fixes the emulated odd-arch wheel jobs crashing on this test)

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes N/A (test-only change)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
