### PR TITLE
validate the authority host subcomponent in URL.build

### DIFF
--- a/CHANGES/1811.bugfix.rst
+++ b/CHANGES/1811.bugfix.rst
@@ -1,0 +1,5 @@
+Validated the host subcomponent of ``authority`` in :meth:`yarl.URL.build`
+as an :rfc:`3986` ``reg-name``, the same way the ``host`` argument already
+was. A delimiter such as ``/``, ``?``, ``#`` or CRLF previously survived
+into the ``netloc``, so parsing ``str(url)`` back gave a different host than
+:attr:`yarl.URL.host` reported -- by :user:`Samin061`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -608,6 +608,13 @@ section generates a new :class:`URL` instance.
       Only one of ``query`` or ``query_string`` should be passed then ValueError
       will be raised.
 
+   .. note::
+
+      Unless ``encoded=True`` is passed, the host subcomponent of ``authority``
+      is validated as a :rfc:`3986` *reg-name*, the same way ``host`` is, and a
+      :exc:`ValueError` is raised when it holds a character that would change
+      how the serialized URL parses.
+
 .. method:: URL.with_scheme(scheme)
 
    Return a new URL with *scheme* replaced:

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -140,15 +140,35 @@ def test_url_build_ipv6_zone_id_non_ascii_not_ascii_encodable() -> None:
         bytes(u)
 
 
-def test_url_build_ipv6_zone_id_empty_authority_not_validated() -> None:
-    """``authority=`` bypasses the empty-zone rejection of ``host=``.
+def test_url_build_ipv6_zone_id_empty_authority() -> None:
+    """``authority=`` rejects an empty zone just like ``host=``.
 
-    The authority path uses ``validate_host=False``; documents the
-    asymmetry with ``test_url_build_ipv6_zone_id_empty`` (#998).
+    Matches ``test_url_build_ipv6_zone_id_empty`` (#998).
     """
-    u = URL.build(scheme="http", authority="[fe80::1%25]")
-    assert str(u) == "http://[fe80::1%25]"
-    assert u.host == "fe80::1%"
+    with pytest.raises(ValueError, match="Invalid characters in zone identifier"):
+        URL.build(scheme="http", authority="[fe80::1%25]")
+
+
+@pytest.mark.parametrize(
+    ("authority", "char"),
+    [
+        ("ex/ample.com", "/"),
+        ("ex?ample.com", "?"),
+        ("ex#ample.com", "#"),
+        ("ex ample.com", " "),
+        ("example.com\r\nx-injected: 1", "\r"),
+        ("user@ex/ample.com", "/"),
+    ],
+    ids=("slash", "question", "hash", "space", "crlf", "userinfo-slash"),
+)
+def test_url_build_authority_rejects_delimiters(authority: str, char: str) -> None:
+    """A delimiter in the authority host must not reach the netloc.
+
+    Left unvalidated it survives into ``str(url)``, which then reparses
+    to a different host than :attr:`URL.host` reports.
+    """
+    with pytest.raises(ValueError, match="cannot contain"):
+        URL.build(scheme="http", authority=authority)
 
 
 def test_build_with_scheme() -> None:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -523,7 +523,11 @@ class URL:
         _host: str | None = None
         if authority:
             user, password, _host, port = split_netloc(authority)
-            _host = _encode_host(_host, validate_host=False) if _host else ""
+            # The authority is user input here, so its host subcomponent gets
+            # the same reg-name validation as the ``host=`` argument. Without
+            # it a delimiter (``/``, ``?``, ``#``, CR, LF, ...) survives into
+            # the netloc and str(url) reparses to a different host.
+            _host = _encode_host(_host, validate_host=True) if _host else ""
         elif host:
             _host = _encode_host(host, validate_host=True)
         else:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`URL.build(authority=...)` hands the host subcomponent to `_encode_host` with `validate_host=False`, so the reg-name check that `host=` gets is skipped on a value that comes straight from the caller. That is safe for the string parser, which shares the flag, because `split_url` has already guaranteed the netloc holds no `/`, `?`, `#`, backslash, CR, LF or tab; nothing makes that guarantee for an `authority` argument. A delimiter therefore survives into `_netloc`, and the URL stops agreeing with itself: `URL.build(scheme="http", authority="ex/ample.com").host` is `ex/ample.com`, while parsing `str(url)` back gives host `ex`, so an application that validates the host it holds and then sends the serialized string reaches a host it never checked. A bare CRLF gets through the same way and lands verbatim in `str(url)`. I noticed it while comparing the two builder entry points, since `host="ex/ample.com"` already raises. Validating in the authority branch closes it, and it keeps the check where the other one lives rather than asking callers to pre-screen the authority.

## Are there changes in behavior for the user?

Yes. `URL.build(authority=...)` now raises `ValueError` for an authority whose host holds a character outside the RFC 3986 reg-name set, matching what `host=` has always done. `encoded=True` is unaffected.

## Is it a substantial burden for the maintainers to support this?

No, it reuses the existing validation path.

## Related issue number

None; found while reading `URL.build`.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Verification</summary>

```
pytest ./tests ./yarl        1622 passed, 2 skipped, 4 xfailed
pre-commit run --files ...   all hooks passed (ruff, flake8, mypy, codespell)
sphinx -b spelling docs      clean
sphinx -b doctest docs       clean
```

The six new parametrized cases in `test_url_build_authority_rejects_delimiters` plus
`test_url_build_ipv6_zone_id_empty_authority` fail on the unpatched tree and pass with
the change.
</details>
