### PR TITLE
validate the scheme against the RFC 3986 grammar

### DIFF
--- a/CHANGES/1813.bugfix.rst
+++ b/CHANGES/1813.bugfix.rst
@@ -1,0 +1,5 @@
+Validated the scheme passed to :meth:`yarl.URL.build` and
+:meth:`yarl.URL.with_scheme` against the :rfc:`3986#section-3.1` grammar.
+A scheme containing a delimiter (e.g. ``http://evil.example``) was written
+into the URL verbatim, so the rendered string parsed back to a different
+host than :attr:`yarl.URL.host` reported -- by :user:`Samin061`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -608,6 +608,12 @@ section generates a new :class:`URL` instance.
       Only one of ``query`` or ``query_string`` should be passed then ValueError
       will be raised.
 
+   .. note::
+
+      Unless ``encoded=True`` is passed, *scheme* must match the
+      :rfc:`3986#section-3.1` grammar (an ASCII letter followed by letters,
+      digits, ``+``, ``-`` or ``.``); ``ValueError`` is raised otherwise.
+
 .. method:: URL.with_scheme(scheme)
 
    Return a new URL with *scheme* replaced:
@@ -616,6 +622,9 @@ section generates a new :class:`URL` instance.
 
       >>> URL('http://example.com').with_scheme('https')
       URL('https://example.com')
+
+   *scheme* must match the :rfc:`3986#section-3.1` grammar; ``ValueError`` is
+   raised otherwise.
 
    Returned URL may have a *different* ``port``
    (:ref:`default port substitution <yarl-api-default-ports>`).

--- a/tests/test_url_build.py
+++ b/tests/test_url_build.py
@@ -156,6 +156,23 @@ def test_build_with_scheme() -> None:
     assert str(u) == "blob:path"
 
 
+@pytest.mark.parametrize(
+    "scheme",
+    (
+        "http://evil.example",
+        "//evil.example",
+        "http:",
+        "ht tp",
+        "1http",
+    ),
+    ids=("authority", "slashes", "trailing-colon", "space", "leading-digit"),
+)
+def test_build_with_scheme_outside_rfc3986_grammar(scheme: str) -> None:
+    """A scheme carrying a delimiter would re-point the rendered URL."""
+    with pytest.raises(ValueError, match="cannot contain"):
+        URL.build(scheme=scheme, host="good.example", path="/p")
+
+
 def test_build_with_host() -> None:
     u = URL.build(host="127.0.0.1")
     assert str(u) == "//127.0.0.1"

--- a/tests/test_url_update_netloc.py
+++ b/tests/test_url_update_netloc.py
@@ -40,6 +40,24 @@ def test_with_scheme_for_relative_file_url() -> None:
     assert expected.with_scheme("file") == expected
 
 
+@pytest.mark.parametrize(
+    "scheme",
+    (
+        "http://evil.example",
+        "//evil.example",
+        "http:",
+        "ht tp",
+        "1http",
+    ),
+    ids=("authority", "slashes", "trailing-colon", "space", "leading-digit"),
+)
+def test_with_scheme_outside_rfc3986_grammar(scheme: str) -> None:
+    """A scheme carrying a delimiter would re-point the rendered URL."""
+    url = URL("http://good.example/p")
+    with pytest.raises(ValueError, match="cannot contain"):
+        url.with_scheme(scheme)
+
+
 def test_with_scheme_invalid_type() -> None:
     url = URL("http://example.com")
     with pytest.raises(TypeError):

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -89,6 +89,13 @@ NOT_REG_NAME = re.compile(
     re.VERBOSE,
 )
 
+# scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+# https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
+# This pattern matches the first character that is *not* allowed there, so a
+# scheme carrying a delimiter (most importantly ':' or '/') can be rejected
+# before it is written into the URL.
+NOT_SCHEME = re.compile(r"\A[^a-zA-Z]|[^a-zA-Z0-9+\-.]")
+
 # Invisible default-ignorable / format code points that must not appear in a
 # host (soft hyphen, zero-width space, word joiner, bidi controls, variation
 # selectors, ...). Depending on the code point IDNA either silently deletes it
@@ -209,6 +216,18 @@ class _InternalURLCache(TypedDict, total=False):
 def rewrite_module(obj: _T) -> _T:
     obj.__module__ = "yarl"
     return obj
+
+
+def _validate_scheme(scheme: str) -> None:
+    """Check a scheme against the RFC 3986 grammar.
+
+    An empty scheme is allowed; it stands for a relative URL.
+    """
+    if scheme and (invalid := NOT_SCHEME.search(scheme)):
+        raise ValueError(
+            f"Scheme {scheme!r} cannot contain {invalid.group()!r} "
+            f"(at position {invalid.start()})"
+        )
 
 
 def _encode_relative_scheme_colon(path: str) -> str:
@@ -518,6 +537,7 @@ class URL:
                 fragment,
             )
 
+        _validate_scheme(scheme)
         self = object.__new__(URL)
         self._scheme = scheme
         _host: str | None = None
@@ -1156,6 +1176,7 @@ class URL:
         if not isinstance(scheme, str):
             raise TypeError("Invalid scheme type")
         lower_scheme = scheme.lower()
+        _validate_scheme(lower_scheme)
         netloc = self._netloc
         if not netloc and lower_scheme in SCHEME_REQUIRES_HOST:
             msg = (


### PR DESCRIPTION
## What do these changes do?

`URL.build(scheme=...)` and `URL.with_scheme()` write the caller-supplied scheme into the URL without checking it against the RFC 3986 scheme grammar, and a scheme is never escaped, so a delimiter in it restructures the rendered URL. `URL('http://good.example/p').with_scheme('http://evil.example')` renders as `http://evil.example://good.example/p`, which parses back to host `evil.example` while the object it came from still reports `good.example`; the same holds for `URL.build`. Both entry points now run the scheme through `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )` before it is stored, which is where the host subcomponent is already validated.

## Are there changes in behavior for the user?

Yes. A scheme outside the RFC 3986 grammar now raises `ValueError` instead of producing a URL that renders differently than it parses. An empty scheme still means a relative URL, and `encoded=True` still skips validation, matching how `host` is handled.

## Is it a substantial burden for the maintainers to support this?

No, it is one grammar check shared by the two unencoded entry points.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A, no such file in this repo)
- [x] Add a new news fragment into the `CHANGES/` folder
