### PR TITLE
reject non-ascii-digit port in split_netloc

### DIFF
--- a/CHANGES/1817.bugfix.rst
+++ b/CHANGES/1817.bugfix.rst
@@ -1,0 +1,5 @@
+Rejected URLs whose port subcomponent is not made up solely of ASCII
+digits (e.g. ``//host:+80``, ``//host:8_0`` or a port written with
+non-ASCII decimal digits), which :func:`int` previously accepted while
+RFC 3986 section 3.2.3 defines the port as ``*DIGIT``
+-- by :user:`Samin061`.

--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -229,6 +229,21 @@ class TestPort:
         with pytest.raises(ValueError):
             URL("//h:-80/path")
 
+    @pytest.mark.parametrize(
+        "port",
+        [
+            "+80",  # leading sign
+            " 80",  # leading whitespace
+            "80 ",  # trailing whitespace
+            "8_0",  # underscore digit separator
+            "８０",  # fullwidth digits
+            "٨٠",  # arabic-indic digits
+        ],
+    )
+    def test_non_ascii_digit_port(self, port: str) -> None:
+        with pytest.raises(ValueError):
+            URL(f"//h:{port}/path")
+
 
 class TestUserInfo:
     def test_canonical(self) -> None:

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -159,10 +159,13 @@ def split_netloc(
     if not port_str:
         return username or None, password, hostname or None, None
 
-    try:
-        port = int(port_str)
-    except ValueError:
+    # RFC 3986 section 3.2.3 defines the port as *DIGIT, i.e. ASCII digits
+    # only. int() is more permissive and would accept a leading '+',
+    # surrounding whitespace, underscore digit separators and non-ASCII
+    # decimal digits, so reject those before converting.
+    if not (port_str.isascii() and port_str.isdigit()):
         raise ValueError("Invalid URL: port can't be converted to integer")
+    port = int(port_str)
     if not (0 <= port <= 65535):
         raise ValueError("Port out of range 0-65535")
     return username or None, password, hostname or None, port


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`split_netloc` parsed the port with `int(port_str)`, which accepts a
leading `+`, surrounding whitespace, underscore digit separators and
non-ASCII decimal digits. RFC 3986 section 3.2.3 defines the port as
`*DIGIT`, i.e. ASCII digits only, so `//host:+8080`, `//host:8_080` and
ports written with fullwidth or arabic-indic digits were silently
accepted. The port_str is now required to be solely ASCII digits before
the `int()` conversion.

## Are there changes in behavior for the user?

Yes; URLs carrying a non-ASCII-digit port now raise `ValueError` at parse
time instead of resolving to a port `int()` happened to accept.

## Is it a substantial burden for the maintainers to support this?

No; the check lives in the existing port branch of `split_netloc`.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes N/A (parser behavior, no API surface change)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
