### PR TITLE
fix: handle empty hostinfo after '@' in bracketed authority parsing

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -441,6 +441,9 @@ def test_ipfuture_brackets_not_allowed() -> None:
         "http://[:evil.com[]].bank.com:443",
         "http://[:127.0.0.1[]]:80",
         "http://[v1.:attacker[]].bank.com:80",
+        "http://[::1]@",
+        "//[]@",
+        "//a[b]c@",
     ),
     ids=(
         "host-confusion-with-port",
@@ -449,6 +452,9 @@ def test_ipfuture_brackets_not_allowed() -> None:
         "domain-allowlist-bypass",
         "private-ip-injection",
         "ipvfuture-bracket-abuse",
+        "bracketed-authority-ending-at-sign",
+        "empty-bracketed-authority-at-sign",
+        "bracket-in-middle-authority-at-sign",
     ),
 )
 def test_malformed_bracketed_host_rejected(url: str) -> None:

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -79,7 +79,12 @@ def split_url(url: str) -> SplitURLType:
             # host subcomponent (e.g. 'http://[:localhost[]].google:80'),
             # which would otherwise resolve to an unintended host.
             hostinfo = netloc.rpartition("@")[2]
-            if hostinfo[0] != "[" or hostinfo.count("[") > 1 or hostinfo.count("]") > 1:
+            if (
+                not hostinfo
+                or hostinfo[0] != "["
+                or hostinfo.count("[") > 1
+                or hostinfo.count("]") > 1
+            ):
                 raise ValueError("Invalid IPv6 URL")
             bracketed_host, _, after_bracket = hostinfo[1:].partition("]")
             # Per RFC 3986 §3.2.2, after the closing ']' of an IP-literal


### PR DESCRIPTION
## Summary

Fixes `IndexError` when constructing a `URL` from a malformed authority containing brackets but ending in `@` (empty host after `@`).

**Root cause:** `split_url()` accesses `hostinfo[0]` without checking if `hostinfo` is empty. When a URL like `http://[::1]@` is parsed, `rpartition("@")[2]` returns `""`, and `""[0]` raises `IndexError`.

**Fix:** Added `not hostinfo` guard to the existing bracket validation check, so empty hostinfo is rejected with `ValueError("Invalid IPv6 URL")` — consistent with other invalid bracket configurations.

**Test cases added:** Three new parametrized cases in `test_malformed_bracketed_host_rejected`:
- `http://[::1]@` — bracketed authority ending at sign
- `//[]@` — empty bracketed authority at sign  
- `//a[b]c@` — bracket in middle authority at sign

All 529 existing tests pass.

Closes #1822
