### PR TITLE
Preserve encoded base path when joining URLs

### DIFF
--- a/CHANGES/1774.bugfix.rst
+++ b/CHANGES/1774.bugfix.rst
@@ -1,0 +1,2 @@
+Preserved URL-encoded characters in base paths when joining relative URLs.
+-- by :user:`utkarshalpha`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -2282,6 +2282,17 @@ def test_join() -> None:
     assert str(url2) == "http://www.cwi.nl/~guido/FAQ.html"
 
 
+@pytest.mark.parametrize(
+    ("base", "expected"),
+    [
+        ("http://x/a%2Fb/c", "http://x/a%2Fb/d"),
+        ("http://x/a%20b/c", "http://x/a%20b/d"),
+    ],
+)
+def test_join_preserves_percent_encoding_in_base_path(base: str, expected: str) -> None:
+    assert str(URL(base).join(URL("d"))) == expected
+
+
 def test_join_absolute() -> None:
     base = URL("http://www.cwi.nl/%7Eguido/Python.html")
     url = URL("//www.python.org/%7Eguido")

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1538,7 +1538,7 @@ class URL:
                 # and relativizing ".."
                 # parts[0] is / for absolute urls,
                 # this join will add a double slash there
-                path = "/".join([*self.parts[:-1], ""]) + join_path
+                path = "/".join([*self.raw_parts[:-1], ""]) + join_path
                 # which has to be removed
                 if orig_path[0] == "/":
                     path = path[1:]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Preserve percent-encoded characters from the base URL path when `URL.join()` merges a relative reference. The merge now uses raw path segments, with regression coverage for encoded delimiters and spaces.

## Are there changes in behavior for the user?

Yes. Joining relative references no longer decodes `%2F` into a path separator or `%20` into a literal space in the base path.

## Is it a substantial burden for the maintainers to support this?

No. The change uses the existing `raw_parts` API in the path merge branch.

## Related issue number

Fixes #1774

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` N/A (no `CONTRIBUTORS.txt` in the repo)
- [x] Add a new news fragment into the `CHANGES/` folder

Drafted with OpenAI Codex; human review pending.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

- Focused join suite: `pytest tests/test_url.py -k join`, 131 passed.
- Full suite: `pytest tests/`, 972 passed, 104 skipped.
- Ruff formatting, Ruff linting, and codespell passed.

</details>
