### PR TITLE
fix: validate host on URL(str) like URL.build (#1829)

### DIFF
--- a/CHANGES/1829.bugfix.rst
+++ b/CHANGES/1829.bugfix.rst
@@ -1,5 +1,6 @@
 Enabled host validation for the plain :class:`~yarl.URL` string constructor
-so it rejects the same invalid hosts as :meth:`~yarl.URL.build` (NUL and other
-C0 controls, unsafe IPv6 zone identifiers, and IDNA/NFKC mappings that inject
-delimiters into the host). Previously these values were accepted by
-``URL(str)`` and could produce non-reparsable serializations.
+so it rejects the same invalid hosts as :meth:`~yarl.URL.build`, including
+NUL and other control characters, unsafe IPv6 zone identifiers, and hosts
+that expand to URL delimiters under IDNA normalization. Previously these
+values were accepted by ``URL(str)`` and could produce strings that yarl
+itself could not parse again.

--- a/CHANGES/1829.bugfix.rst
+++ b/CHANGES/1829.bugfix.rst
@@ -1,0 +1,5 @@
+Enabled host validation for the plain :class:`~yarl.URL` string constructor
+so it rejects the same invalid hosts as :meth:`~yarl.URL.build` (NUL and other
+C0 controls, unsafe IPv6 zone identifiers, and IDNA/NFKC mappings that inject
+delimiters into the host). Previously these values were accepted by
+``URL(str)`` and could produce non-reparsable serializations.

--- a/CHANGES/1829.bugfix.rst
+++ b/CHANGES/1829.bugfix.rst
@@ -1,6 +1,13 @@
-Enabled host validation for the plain :class:`~yarl.URL` string constructor
-so it rejects the same invalid hosts as :meth:`~yarl.URL.build`, including
-NUL and other control characters, unsafe IPv6 zone identifiers, and hosts
-that expand to URL delimiters under IDNA normalization. Previously these
-values were accepted by ``URL(str)`` and could produce strings that yarl
-itself could not parse again.
+Enabled host validation for the plain :class:`~yarl.URL` string
+constructor so it rejects the same invalid hosts as
+:meth:`~yarl.URL.build`, including NUL and other control characters, unsafe
+IPv6 zone identifiers, and hosts that expand to URL delimiters under
+IDNA normalization. Previously these values were accepted by ``URL(str)``
+and could produce strings that yarl itself could not parse again.
+
+URL construction is now roughly 20% slower on the
+``test_empty_path_safe_uncached`` CodSpeed micro-benchmark because
+``_encode_host(..., validate_host=True)`` runs additional IDNA / control-
+character / zone-id checks on every parse. The same path runs for
+``URL.build(host=...)`` already, so this just aligns the two entry
+points; the cost is intentional and matches the security benefit.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -570,17 +570,15 @@ def test_ipv6_zone_bare_percent_hex_ambiguous() -> None:
 
 
 def test_ipv6_zone_empty_zone_parse() -> None:
-    """The string-parse path accepts empty zone identifiers.
+    """Empty zone identifiers are rejected on the string-parse path.
 
-    ``URL.build(host=...)`` rejects them (RFC 9844 §6.3), but parsing
-    uses ``validate_host=False``; this documents the asymmetry (#998).
+    Matches ``URL.build(host=...)`` (RFC 9844 §6.3). Previously the
+    parser used ``validate_host=False`` and accepted these (#998 / #1829).
     """
-    url = URL("http://[fe80::1%25]/")
-    assert url.raw_host == "fe80::1%25"
-    assert url.host == "fe80::1%"
-    url = URL("http://[fe80::1%]/")
-    assert url.raw_host == "fe80::1%"
-    assert url.host == "fe80::1%"
+    with pytest.raises(ValueError, match="Invalid characters in zone identifier"):
+        URL("http://[fe80::1%25]/")
+    with pytest.raises(ValueError, match="Invalid characters in zone identifier"):
+        URL("http://[fe80::1%]/")
 
 
 def test_ipv6_zone_rfc6874_multiple_percent25() -> None:
@@ -2759,6 +2757,74 @@ def test_url_with_fullwidth_percent_rejected(percent_char: str) -> None:
         ValueError, match="contains invalid characters under NFKC normalization"
     ):
         URL(f"http://evil.com{percent_char}2e.internal/")
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "a\x00b",
+        "a\x01b",
+        "a\x1fb",
+        "a\x7fb",
+        "a b",
+    ],
+    ids=["nul", "soh", "us", "del", "space"],
+)
+def test_url_str_rejects_invalid_reg_name_host(host: str) -> None:
+    """``URL(str)`` validates hosts the same way as ``URL.build(host=...)``.
+
+    Before #1829 the parser used ``validate_host=False``, so NUL/C0 controls
+    and other non-reg-name characters survived into ``.host`` /
+    ``host_port_subcomponent`` even though the builder rejected them.
+
+    Note: ``/``, ``?``, and ``#`` never reach host validation on the string
+    path because ``split_url`` treats them as path/query/fragment separators.
+    """
+    with pytest.raises(
+        ValueError, match=r"Host '[^']+' cannot contain '[^']+' \(at position \d+\)"
+    ):
+        URL(f"http://{host}/")
+
+
+@pytest.mark.parametrize(
+    "zone",
+    ("\x00evil", "\x01", "\x7f"),
+    ids=("null-byte", "soh", "del"),
+)
+def test_url_str_rejects_ipv6_zone_control_chars(zone: str) -> None:
+    """IPv6 zone identifiers with CTL characters are rejected when parsing.
+
+    CR/LF/TAB never reach this check: the parser strips them earlier
+    (WHATWG C0 removal), so they are covered separately.
+    """
+    with pytest.raises(
+        ValueError, match="Invalid characters in zone identifier"
+    ) as ctx:
+        URL(f"http://[fe80::1%25{zone}]/")
+    error = str(ctx.value)
+    assert zone not in error
+    assert repr(zone) not in error
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "［",  # U+FF3B FULLWIDTH LEFT SQUARE BRACKET -> '['
+        "］",  # U+FF3D FULLWIDTH RIGHT SQUARE BRACKET -> ']'
+        "＼",  # U+FF3C FULLWIDTH REVERSE SOLIDUS -> '\\'
+    ],
+    ids=["fw-lbracket", "fw-rbracket", "fw-backslash"],
+)
+def test_url_str_rejects_idna_delimiter_injection(host: str) -> None:
+    """IDNA/NFKC must not inject delimiters into a parsed host (#1829).
+
+    Without validation, ``str(URL(...))`` could become non-reparsable
+    (e.g. fullwidth brackets encode to ``[`` / ``]``). Fullwidth solidus
+    and similar ``/?#`` mappings are already rejected earlier by
+    ``_check_netloc``; these cases specifically need ``validate_host``.
+    """
+    with pytest.raises(ValueError, match="cannot contain"):
+        URL(f"//{host}")
 
 
 @pytest.mark.parametrize(

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -246,7 +246,10 @@ def encode_url(url_str: str) -> "URL":
                 raise ValueError(msg)
             else:
                 host = ""
-        host = _encode_host(host, validate_host=False)
+        # Same host validation as URL.build(host=...): reject NUL/C0 controls,
+        # unsafe IPv6 zone identifiers, and IDNA/NFKC mappings that inject
+        # delimiters into the host (see #1829).
+        host = _encode_host(host, validate_host=True)
         # Remove brackets as host encoder adds back brackets for IPv6 addresses
         cache["raw_host"] = host[1:-1] if "[" in host else host
         cache["explicit_port"] = port
@@ -1706,9 +1709,8 @@ def _encode_host(host: str, validate_host: bool) -> str:
     # IDNA/UTS-46 mapping silently deletes default-ignorable code points, which
     # would turn e.g. ``e<ZWSP>vil.com`` into ``evil.com``, a different host
     # than the string the caller supplied. Reject them on every path (this runs
-    # regardless of ``validate_host`` since the plain ``URL(str)`` constructor
-    # encodes with ``validate_host=False``) so the parsed host cannot diverge
-    # from the input, matching idna/httpx/urllib3.
+    # regardless of ``validate_host``) so the parsed host cannot diverge from
+    # the input, matching idna/httpx/urllib3.
     if invalid := _DEFAULT_IGNORABLE_RE.search(host):
         raise ValueError(
             f"Host {host!r} cannot contain {invalid.group()!r} "


### PR DESCRIPTION
## What do these changes do?

`URL(str)` encoded the host with `validate_host=False`, while `URL.build(host=...)` / `with_host()` use `validate_host=True`. That meant the common parse path accepted hosts the builder already rejects:

1. **NUL / C0 controls** in a regular host (`http://a\x00b/` → host `'a\x00b'`)
2. **CTL characters in an IPv6 zone id** (`http://[fe80::1%25\x00evil]/`)
3. **IDNA/NFKC delimiter injection** (fullwidth `［］＼` → non-reparsable `str(url)`)

The same `_encode_host(..., validate_host=True)` path used by the builder now runs for the string constructor, so parser and builder agree on which hosts are valid. Empty IPv6 zone identifiers are also rejected on parse (RFC 9844 §6.3), matching `URL.build(host=...)`.

## Are there changes in behavior for the user?

Yes — intentionally, for invalid hosts only:

- `URL("http://a\\x00b/")` and similar non-reg-name hosts now raise `ValueError` instead of accepting them
- `URL("http://[fe80::1%25]/")` / empty zone now raises (previously accepted; builder already rejected)
- Fullwidth bracket/backslash hosts that used to serialize to non-reparsable URLs now raise

Valid hosts (ASCII, IDNA, IPv4/IPv6 with legitimate zones) are unchanged. `encoded=True` is unaffected.

## Related issue number

Fixes #1829

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes (CHANGES fragment; behavior aligned with existing builder docs)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Verification</summary>

```
pytest tests/ -m "not hypothesis"   1512 passed, 104 skipped, 4 xfailed
```

New coverage:
- `test_url_str_rejects_invalid_reg_name_host` (NUL/C0/space)
- `test_url_str_rejects_ipv6_zone_control_chars`
- `test_url_str_rejects_idna_delimiter_injection`
- `test_ipv6_zone_empty_zone_parse` updated to expect rejection
</details>