### PR TITLE
Reject parsed host that IDNA-normalizes to a URL delimiter

### DIFF
--- a/CHANGES/1847.bugfix.rst
+++ b/CHANGES/1847.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed the :class:`~yarl.URL` string parser accepting a host that IDNA
+normalization expands into a URL delimiter (``[``, ``]`` or ``\``); yarl
+rendered the delimiter into ``str(url)`` but then rejected it on
+re-parsing, so the value did not round-trip. Such hosts are now rejected
+during parsing, matching :meth:`URL.build() <yarl.URL.build>` and
+:meth:`~yarl.URL.with_host` -- by :user:`Samin061`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -2792,6 +2792,22 @@ def test_url_host_with_default_ignorable_rejected(ignorable: str) -> None:
         URL(f"http://e{ignorable}vil.com/")
 
 
+@pytest.mark.parametrize(
+    "delimiter",
+    ["［", "］", "＼"],
+    ids=["fullwidth-left-bracket", "fullwidth-right-bracket", "fullwidth-backslash"],
+)
+def test_url_host_idna_normalizes_to_delimiter_rejected(delimiter: str) -> None:
+    """Reject a parsed host that IDNA-normalizes to a URL delimiter.
+
+    ``_check_netloc`` only screens ``/?#@:%``, so ``[``, ``]`` and ``\\``
+    reach ``_idna_encode`` unchecked. Left unrejected, ``URL("http://exa［mple/")``
+    renders as ``http://exa[mple/``, which yarl itself rejects on re-parse.
+    """
+    with pytest.raises(ValueError, match="after IDNA normalization"):
+        URL(f"http://exa{delimiter}mple/p")
+
+
 def _idna_collapses(code_point: int) -> bool:
     """True if IDNA encoding silently deletes ``code_point`` from a host."""
     try:

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1717,10 +1717,14 @@ def _encode_host(host: str, validate_host: bool) -> str:
     encoded = _idna_encode(host)
     # IDNA uses NFKC equivalence, so normalization can expand a non-ascii
     # character into an ASCII delimiter (e.g. the fullwidth solidus U+FF0F
-    # becomes '/'). The ascii branch above rejects such delimiters directly;
-    # apply the same check to the IDNA output so the builder APIs agree with
-    # the parser's _check_netloc.
-    if validate_host and (invalid := NOT_REG_NAME.search(encoded)):
+    # becomes '/'). split_url's _check_netloc screens '/?#@:%' but not '[',
+    # ']' or '\\', so a host like ``exa［mple`` (fullwidth '[') slips
+    # through the parser and _idna_encode turns it into ``exa[mple``, a netloc
+    # that str(url) then renders but yarl itself rejects on re-parse. Run the
+    # check on every path (like the default-ignorable check above, which also
+    # ignores validate_host) so the parsed host cannot diverge from what the
+    # serialized URL means.
+    if invalid := NOT_REG_NAME.search(encoded):
         raise ValueError(
             f"Host {host!r} cannot contain {invalid.group()!r} "
             f"after IDNA normalization to {encoded!r}"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`_encode_host` runs the post-IDNA reg-name check only when `validate_host=True`, but `URL(str)` parses with `validate_host=False`. `split_url`'s `_check_netloc` screens characters that NFKC-normalize to `/?#@:%`, yet it does not screen the ones that normalize to `[`, `]` or `\`. A host written with a fullwidth bracket such as `exa［mple` therefore slips through the parser, `_idna_encode` turns it into `exa[mple`, and `str(url)` renders `http://exa[mple/` which yarl then rejects on re-parse ("Invalid IPv6 URL"), so the value does not round-trip. Dropping the `validate_host` gate makes the check run on every path, the same way the default-ignorable check just above already does, so the parser rejects these hosts exactly as `URL.build()` and `with_host()` already do. Punycode output never contains a reg-name delimiter, so valid hosts are unaffected.

## Are there changes in behavior for the user?

Yes, narrowly. `URL("http://exa［mple/")` (and the `]`/`\` variants) now raises `ValueError` at parse time instead of building a URL that cannot be re-parsed. Legitimate hosts, including any that encode to punycode, are unchanged.

## Is it a substantial burden for the maintainers to support this?

No; it removes one condition on an existing check and reuses the existing error path.

## Related issue number

Relates to #1829 (the IPv6/IDNA-to-delimiter part of that report).

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: `python -m pytest tests/ yarl/` -> 1504 passed, 104 skipped, 4 xfailed (the new regression fails on master and passes with the fix).
Lint: `ruff check` / `ruff format --check` clean; `sphinx -b spelling` reports no misspellings.

Drafted with Claude Opus 4.8; reviewed by Samin061.
</details>
