### PR TITLE
fix(url): avoid IndexError in host_port_subcomponent for empty host

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -231,6 +231,24 @@ def test_host_port_subcomponent(input: str, result: str) -> None:
     assert url.host_port_subcomponent == result
 
 
+def test_host_port_subcomponent_empty_host_no_index_error() -> None:
+    # Regression: an empty host should not raise IndexError from
+    # trailing-dot stripping (`raw[-1] == "."` on an empty string).
+    url = URL("//user@")
+    assert url.raw_host == ""
+    assert url.host_port_subcomponent == ""
+
+
+def test_host_port_subcomponent_empty_host_with_port() -> None:
+    url = URL("//user@:8080")
+    assert url.host_port_subcomponent == ":8080"
+
+
+def test_host_subcomponent_empty_host_no_index_error() -> None:
+    url = URL("//user@")
+    assert url.host_subcomponent == ""
+
+
 def test_host_subcomponent_return_idna_encoded_host() -> None:
     url = URL("http://оун-упа.укр")
     assert url.host_subcomponent == "xn----8sb1bdhvc.xn--j1amh"

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -902,7 +902,7 @@ class URL:
         """
         if (raw := self.raw_host) is None:
             return None
-        if raw[-1] == ".":
+        if raw[-1:] == ".":
             # Remove all trailing dots from the netloc as while
             # they are valid FQDNs in DNS, TLS validation fails.
             # See https://github.com/aio-libs/aiohttp/issues/3636.


### PR DESCRIPTION
## Problem

`URL("//user@")` parses with an empty `raw_host` (`""`). Reading `host_port_subcomponent` then evaluated `raw[-1] == "."` on an empty string, raising:

```
IndexError: string index out of range
```

The property is documented as returning a host-and-port string or `None`; leaking an `IndexError` forces callers to handle an implementation detail.

## Root cause

In `host_port_subcomponent`, `raw[-1] == "."` indexes the last character of `raw_host`. When `raw_host` is `""`, `raw[-1]` raises `IndexError`.

## Fix

Use the slice `raw[-1:]` instead, which returns `""` for an empty host and safely compares to `"."`. This preserves the trailing-dot stripping behavior for non-empty hosts while handling the empty-host case gracefully.

## Testing

Added three regression tests to `tests/test_url.py`:

- `test_host_port_subcomponent_empty_host_no_index_error` — `URL("//user@")` returns `""`
- `test_host_port_subcomponent_empty_host_with_port` — `URL("//user@:8080")` returns `":8080"`
- `test_host_subcomponent_empty_host_no_index_error` — `host_subcomponent` also handles empty host

All 16 `host_port_subcomponent` / `host_subcomponent` tests pass, including the existing trailing-dot (`http://example.com.`) cases.

Fixes #1821