### PR TITLE
fix(parse): reject bracketed authority ending in @ with ValueError

### DIFF
--- a/tests/test_url_parsing.py
+++ b/tests/test_url_parsing.py
@@ -184,6 +184,20 @@ class TestHost:
         assert u.query_string == ""
         assert u.fragment == ""
 
+    @pytest.mark.parametrize(
+        "value",
+        (
+            "http://[::1]@",
+            "//[]@",
+            "//a[b]c@",
+        ),
+    )
+    def test_bracketed_authority_ending_in_at_rejected(self, value: str) -> None:
+        # Regression: malformed authorities ending in "@" used to leak
+        # IndexError from `hostinfo[0]` on an empty `hostinfo` string.
+        with pytest.raises(ValueError):
+            URL(value)
+
 
 class TestPort:
     def test_canonical(self) -> None:

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -79,7 +79,12 @@ def split_url(url: str) -> SplitURLType:
             # host subcomponent (e.g. 'http://[:localhost[]].google:80'),
             # which would otherwise resolve to an unintended host.
             hostinfo = netloc.rpartition("@")[2]
-            if not hostinfo or hostinfo[0] != "[" or hostinfo.count("[") > 1 or hostinfo.count("]") > 1:
+            if (
+                not hostinfo
+                or hostinfo[0] != "["
+                or hostinfo.count("[") > 1
+                or hostinfo.count("]") > 1
+            ):
                 raise ValueError("Invalid IPv6 URL")
             bracketed_host, _, after_bracket = hostinfo[1:].partition("]")
             # Per RFC 3986 §3.2.2, after the closing ']' of an IP-literal

--- a/yarl/_parse.py
+++ b/yarl/_parse.py
@@ -79,7 +79,7 @@ def split_url(url: str) -> SplitURLType:
             # host subcomponent (e.g. 'http://[:localhost[]].google:80'),
             # which would otherwise resolve to an unintended host.
             hostinfo = netloc.rpartition("@")[2]
-            if hostinfo[0] != "[" or hostinfo.count("[") > 1 or hostinfo.count("]") > 1:
+            if not hostinfo or hostinfo[0] != "[" or hostinfo.count("[") > 1 or hostinfo.count("]") > 1:
                 raise ValueError("Invalid IPv6 URL")
             bracketed_host, _, after_bracket = hostinfo[1:].partition("]")
             # Per RFC 3986 §3.2.2, after the closing ']' of an IP-literal


### PR DESCRIPTION
## Problem

Malformed authorities that contain brackets and end in `@` used to raise `IndexError`:

```
'http://[::1]@' IndexError string index out of range
'//[]@' IndexError string index out of range
'//a[b]c@' IndexError string index out of range
```

Callers had to handle an implementation detail rather than a URL validation result.

## Root cause

In `split_url`, `hostinfo = netloc.rpartition("@")[2]` produces an empty string when the authority ends in `@`. The subsequent `hostinfo[0] != "["` then indexes an empty string, raising `IndexError: string index out of range`.

## Fix

Guard the bracket host validation with an emptiness check (`not hostinfo`) so these malformed authorities are rejected with `ValueError` consistent with other invalid bracketed hosts.

## Testing

Added a parametrized regression test `test_bracketed_authority_ending_in_at_rejected` to `TestHost` in `tests/test_url_parsing.py` covering all three reported cases (`http://[::1]@`, `//[]@`, `//a[b]c@`). All 3 variants pass.

Fixes #1822