### PR TITLE
Validate hosts parsed by URL(str) like the builder APIs do

### DIFF
--- a/CHANGES/1829.bugfix.rst
+++ b/CHANGES/1829.bugfix.rst
@@ -1,0 +1,7 @@
+Validated the host parsed by the ``URL(str)`` constructor the same way the
+builder APIs do: control characters (e.g. NUL), control characters in an IPv6
+zone identifier, and IDNA-normalized URL delimiters (e.g. the fullwidth ``［``,
+which normalizes to ``[``) are now rejected with a ``ValueError`` instead of
+surviving into a ``str(url)`` that yarl itself cannot re-parse. The documented
+permissive acceptance of an empty IPv6 zone identifier is unchanged -- by
+:user:`aryansk`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -2829,3 +2829,53 @@ def test_default_ignorable_covers_idna_stripped() -> None:
         hex(cp) for cp in stripped if not _DEFAULT_IGNORABLE_RE.search(chr(cp))
     )
     assert not uncovered, f"IDNA strips these but the regex misses them: {uncovered}"
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "a\x00b",  # NUL
+        "a\x01b",  # C0 control
+        "a\x1fb",  # unit separator
+        "a\x7fb",  # DEL
+    ],
+    ids=("nul", "c0", "unit-separator", "del"),
+)
+def test_url_parse_rejects_control_characters_in_host(host: str) -> None:
+    """The string parser must reject control characters in a reg-name host.
+
+    Before #1829 the parser encoded with ``validate_host=False``, so a NUL
+    or other C0 control survived into ``.host`` and ``str(url)`` even though
+    ``URL.build(host=...)`` rejected the same value.
+    """
+    with pytest.raises(ValueError, match="cannot contain"):
+        URL(f"http://{host}/")
+
+
+def test_url_parse_rejects_control_characters_in_ipv6_zone() -> None:
+    """Control characters in an IPv6 zone identifier are rejected on parse.
+
+    ``URL.build(host="fe80::1%\x00")`` already rejected them; the parser
+    previously accepted ``[fe80::1%25\x00evil]`` (#1829).
+    """
+    with pytest.raises(ValueError, match="Invalid characters in zone identifier"):
+        URL("http://[fe80::1%25\x00evil]/")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "//\uff3b",  # fullwidth [ -> [
+        "//\uff3d",  # fullwidth ] -> ]
+        "//\uff3c",  # fullwidth \\ -> \\
+    ],
+    ids=("fullwidth-lbracket", "fullwidth-rbracket", "fullwidth-reverse-solidus"),
+)
+def test_url_parse_rejects_idna_normalized_host_delimiters(url: str) -> None:
+    """NFKC/IDNA must not map a host to a URL delimiter.
+
+    Before #1829 the parser accepted e.g. ``//\uff3b`` and serialized it as
+    ``//[``, which yarl itself could not re-parse.
+    """
+    with pytest.raises(ValueError, match="cannot contain"):
+        URL(url)

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -246,7 +246,12 @@ def encode_url(url_str: str) -> "URL":
                 raise ValueError(msg)
             else:
                 host = ""
-        host = _encode_host(host, validate_host=False)
+        # The parser historically encoded without validation, which let
+        # control characters (NUL/C0) and IDNA-normalized delimiters into
+        # the host, producing a ``str(url)`` that yarl cannot re-parse
+        # (#1829). Validate like the builder APIs do, but keep accepting an
+        # empty IPv6 zone identifier, which parsing has always allowed (#998).
+        host = _encode_host(host, validate_host=True, reject_empty_zone=False)
         # Remove brackets as host encoder adds back brackets for IPv6 addresses
         cache["raw_host"] = host[1:-1] if "[" in host else host
         cache["explicit_port"] = port
@@ -1643,7 +1648,9 @@ def _idna_encode(host: str) -> str:
 
 
 @lru_cache(_DEFAULT_ENCODE_SIZE)
-def _encode_host(host: str, validate_host: bool) -> str:
+def _encode_host(
+    host: str, validate_host: bool, *, reject_empty_zone: bool = True
+) -> str:
     """Encode host part of URL."""
     # If the host ends with a digit or contains a colon, its likely
     # an IP address.
@@ -1676,7 +1683,13 @@ def _encode_host(host: str, validate_host: bool) -> str:
         except ValueError:
             pass
         else:
-            if sep and validate_host and (not zone or _ZONE_ID_UNSAFE_RE.search(zone)):
+            if (
+                sep
+                and validate_host
+                and (
+                    (reject_empty_zone and not zone) or _ZONE_ID_UNSAFE_RE.search(zone)
+                )
+            ):
                 raise ValueError("Invalid characters in zone identifier")
             # These checks should not happen in the
             # LRU to keep the cache size small


### PR DESCRIPTION
## What

Fixes #1829 — `URL(str)` now rejects the same invalid hosts the builder APIs (`URL.build`, `URL.with_host`) already reject, so a parsed host can no longer contain control characters or IDNA-normalized URL delimiters, and `str(url)` always re-parses.

## Why

The parser encoded hosts with `validate_host=False`, so three checks that `validate_host=True` performs were skipped on the far more common entry point:

1. **NUL / C0 / DEL control characters** — `URL("http://a\x00b/")` round-tripped the NUL into `.host` and `str(url)`, while `URL.build(host="a\x00b")` raises `ValueError`.
2. **Control characters in an IPv6 zone identifier** — `URL("http://[fe80::1%25\x00evil]/")` parsed, while the builder rejects it.
3. **NFKC/IDNA delimiter injection** — `URL("//［")` serialized as `//[`, which yarl itself could not re-parse.

All three produced a `str(url)` that disagrees with the host the application validated — the same class of problem #1811 addresses for the `URL.build(authority=…)` path, here on the parser.

## How

`encode_url` now calls `_encode_host(host, validate_host=True, reject_empty_zone=False)`. The new keyword-only `reject_empty_zone` parameter keeps the **documented** permissive acceptance of an empty IPv6 zone identifier (`http://[fe80::1%25]/` — #998, RFC 6874) intact for the parser while applying the rest of the strict validation. All other call sites keep their current behavior.

## Tests

- 8 new tests in `tests/test_url.py`: parametrized control chars in reg-name hosts, IPv6 zone controls, and the three fullwidth-delimiter injections — all `ValueError` now, all parse on main.
- The existing empty-zone test (`test_ipv6_zone_empty_zone_parse`) still passes unchanged.
- Full suite: 1509 passed, 104 skipped, 4 xfailed. Ruff check + format clean.

## Changelog

Added `CHANGES/1829.bugfix.rst`.

🤖 Generated with Codebuff
