### PR TITLE
Strip IPv6 zone IDs from Host header values

### DIFF
--- a/CHANGES/1862.bugfix.rst
+++ b/CHANGES/1862.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed :attr:`~yarl.URL.host_port_subcomponent` to omit IPv6 zone identifiers
+from values used in HTTP Host headers -- by :user:`cananoo`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -244,13 +244,15 @@ There are two kinds of properties: *decoded* and *encoded* (with
       >>> URL('http://[::1]').host_port_subcomponent
       '[::1]'
 
-   .. note::
+   An :rfc:`6874` IPv6 zone identifier is omitted because zone identifiers
+   have local significance only (:rfc:`6874#section-4`) and must not be sent
+   in an outgoing HTTP Host header. Use :attr:`URL.host_subcomponent` when
+   the zone identifier needs to be preserved in a URI.
 
-      An :rfc:`6874` IPv6 zone identifier is included verbatim. Zone
-      identifiers have local significance only
-      (:rfc:`6874#section-4`), so callers that use this value to build
-      outgoing protocol elements such as the HTTP Host header need to
-      strip it first.
+   .. doctest::
+
+      >>> URL('http://[fe80::1%25eth0]/').host_port_subcomponent
+      '[fe80::1]'
 
    .. versionadded:: 1.17
 

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -224,6 +224,8 @@ def test_host_subcomponent(host: str) -> None:
         ("http://example.com:80", "example.com"),
         ("http://example.com:8080", "example.com:8080"),
         ("http://[::1]:8080", "[::1]:8080"),
+        ("http://[fe80::1%25eth0]", "[fe80::1]"),
+        ("http://[fe80::1%eth0]:8080", "[fe80::1]:8080"),
     ],
 )
 def test_host_port_subcomponent(input: str, result: str) -> None:
@@ -497,7 +499,7 @@ def test_ipv6_zone_rfc6874() -> None:
     assert url.raw_host == "fe80::1%251"
     assert url.host == "fe80::1%1"
     assert url.host_subcomponent == "[fe80::1%251]"
-    assert url.host_port_subcomponent == "[fe80::1%251]"
+    assert url.host_port_subcomponent == "[fe80::1]"
     assert url.authority == "fe80::1%1:80"
     assert url.human_repr() == "http://[fe80::1%1]/"
     assert str(url) == "http://[fe80::1%251]/"
@@ -509,6 +511,7 @@ def test_ipv6_zone_rfc6874_named_zone() -> None:
     assert url.raw_host == "fe80::1%25eth0"
     assert url.host == "fe80::1%eth0"
     assert url.host_subcomponent == "[fe80::1%25eth0]"
+    assert url.host_port_subcomponent == "[fe80::1]"
     assert url.authority == "fe80::1%eth0:80"
     assert url.human_repr() == "http://[fe80::1%eth0]/"
     assert str(url) == "http://[fe80::1%25eth0]/"
@@ -520,7 +523,7 @@ def test_ipv6_zone_rfc6874_with_port() -> None:
     assert url.raw_host == "fe80::1%251"
     assert url.host == "fe80::1%1"
     assert url.port == 8080
-    assert url.host_port_subcomponent == "[fe80::1%251]:8080"
+    assert url.host_port_subcomponent == "[fe80::1]:8080"
     assert url.authority == "fe80::1%1:8080"
     assert str(url) == "http://[fe80::1%251]:8080/"
 
@@ -549,7 +552,7 @@ def test_ipv6_zone_bare_percent_parse() -> None:
     assert url.raw_host == "fe80::1%eth0"
     assert url.host == "fe80::1%eth0"
     assert url.host_subcomponent == "[fe80::1%eth0]"
-    assert url.host_port_subcomponent == "[fe80::1%eth0]:8080"
+    assert url.host_port_subcomponent == "[fe80::1]:8080"
     assert url.authority == "fe80::1%eth0:8080"
     assert url.human_repr() == "http://[fe80::1%eth0]:8080/"
     assert str(url) == "http://[fe80::1%eth0]:8080/"

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -884,6 +884,9 @@ class URL:
 
         This value is suitable for use in the Host header of an HTTP request.
 
+        IPv6 zone identifiers are omitted because they have local significance
+        only and must not be sent in an outgoing HTTP Host header.
+
         None for relative URLs.
 
         https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.2
@@ -902,6 +905,10 @@ class URL:
         """
         if (raw := self.raw_host) is None:
             return None
+        if ":" in raw:
+            # RFC 6874 zone identifiers are local to the sending host and
+            # must not be included in outgoing protocol elements.
+            raw = raw.partition("%")[0]
         if raw[-1] == ".":
             # Remove all trailing dots from the netloc as while
             # they are valid FQDNs in DNS, TLS validation fails.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Strip IPv6 zone identifiers from `URL.host_port_subcomponent` so the value is safe for an outgoing HTTP `Host` header. URL serialization, `host`, and `host_subcomponent` continue to preserve the zone identifier.

## Are there changes in behavior for the user?

Yes. `URL("http://[fe80::1%25eth0]/").host_port_subcomponent` now returns `[fe80::1]`, while a non-default port remains included.

## Is it a substantial burden for the maintainers to support this?

No. The change is limited to the existing Host-header helper, its regression coverage, and the API documentation.

## Related issue number

Fixes #1862

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A: this repository has no such file)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details</summary>

- `python -m pytest tests/test_url.py -q --no-cov`: 527 passed, 1 skipped
- `python -m pytest tests --ignore=tests/test_quoting.py -q --no-cov`: 972 passed, 104 skipped
- Sphinx spelling check: passed
- Sphinx doctests: 173 passed
- `ruff check yarl/_url.py tests/test_url.py`: passed
- An aiohttp end-to-end request capture emitted zone-free `Host` headers for both bare and `%25` zone forms.
- The Cython quoter comparison suite was not run because MSVC is unavailable in the local Windows environment.

</details>

Drafted with OpenAI Codex (GPT-5); pending human review.
