### PR TITLE
Preserve percent-encoding in base path when joining relative URLs

### DIFF
--- a/CHANGES/1774.bugfix.rst
+++ b/CHANGES/1774.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed :meth:`URL.join() <yarl.URL.join>` decoding percent-encoded
+characters (such as ``%2F`` or ``%20``) in the base URL's path when
+merging in a relative reference, corrupting the resulting path -- by
+:user:`afonsojanu`.

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -2295,6 +2295,18 @@ def test_join_non_url() -> None:
         base.join("path/to")  # type: ignore[arg-type]
 
 
+def test_join_preserves_percent_encoding_in_base_path() -> None:
+    base = URL("http://x/a%2Fb/c")
+    url2 = base.join(URL("d"))
+    assert str(url2) == "http://x/a%2Fb/d"
+
+
+def test_join_preserves_percent_encoded_space_in_base_path() -> None:
+    base = URL("http://x/a%20b/c")
+    url2 = base.join(URL("d"))
+    assert str(url2) == "http://x/a%20b/d"
+
+
 NORMAL = [
     ("g:h", "g:h"),
     ("g", "http://a/b/c/g"),

--- a/yarl/_url.py
+++ b/yarl/_url.py
@@ -1536,9 +1536,9 @@ class URL:
             else:
                 # …
                 # and relativizing ".."
-                # parts[0] is / for absolute urls,
+                # raw_parts[0] is / for absolute urls,
                 # this join will add a double slash there
-                path = "/".join([*self.parts[:-1], ""]) + join_path
+                path = "/".join([*self.raw_parts[:-1], ""]) + join_path
                 # which has to be removed
                 if orig_path[0] == "/":
                     path = path[1:]


### PR DESCRIPTION
Closes #1774.

`URL.join()` builds the RFC 3986 merge path (the branch used when the base path doesn't end with `/`) from `self.parts`, which are already percent-decoded. Feeding a decoded segment back into the path turns an encoded delimiter like `%2F` into a real `/`, splitting what should stay a single path segment. `%20` is likewise decoded into a literal space.

```python
from yarl import URL

print(URL("http://x/a%2Fb/c").join(URL("d")))   # http://x/a/b/d, should be http://x/a%2Fb/d
print(URL("http://x/a%20b/c").join(URL("d")))   # http://x/a b/d, should be http://x/a%20b/d
```

Switched the merge to build from `self.raw_parts` instead, so the base path's original encoding round-trips through the merge rather than getting unquoted and requoted differently.

Added two regression tests covering the `%2F` and `%20` cases from the issue, alongside the existing `test_join_non_url`. Ran the full test suite (1237 passed, 14 skipped, 2 xfailed) plus `ruff check`/`ruff format` on the touched files, both clean.