### PR TITLE
Require Pydantic 2 to collect Pydantic integration tests (#1872)

### DIFF
--- a/CHANGES/1872.bugfix.rst
+++ b/CHANGES/1872.bugfix.rst
@@ -1,0 +1,2 @@
+Required Pydantic 2 or newer to collect the Pydantic integration tests in :file:`tests/test_pydantic.py`
+-- by :user:`dlowzzxx`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -8,6 +8,7 @@ Deprecations
 GPG
 IPv
 PRs
+Pydantic
 PYX
 Towncrier
 Twitter

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -8,8 +8,8 @@ Deprecations
 GPG
 IPv
 PRs
-Pydantic
 PYX
+Pydantic
 Towncrier
 Twitter
 UTF

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -8,8 +8,8 @@ Deprecations
 GPG
 IPv
 PRs
-PYX
 Pydantic
+PYX
 Towncrier
 Twitter
 UTF

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -7,7 +7,7 @@ from yarl import URL
 if TYPE_CHECKING:
     import pydantic
 else:
-    pydantic = pytest.importorskip("pydantic")
+    pydantic = pytest.importorskip("pydantic", minversion="2.0")
 
 
 class TstModel(pydantic.BaseModel):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Specify minversion="2.0" in pytest.importorskip for Pydantic in tests/test_pydantic.py so environments with Pydantic v1 skip the tests rather than failing during collection.

## Are there changes in behavior for the user?

No; test collection only.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Fixes #1872

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

Drafted with Antigravity; reviewed by dlowzzxx.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests: pytest tests/test_pydantic.py -v passed (6/6). Simulated Pydantic 1.10.20 successfully skipped during pytest collection.
Lint: ruff check tests/test_pydantic.py passed.
</details>
