### PR TITLE
Handle safe percent signs during requoting

### DIFF
--- a/CHANGES/1869.bugfix.rst
+++ b/CHANGES/1869.bugfix.rst
@@ -1,0 +1,2 @@
+Made the C and Python quoting backends agree when percent signs are marked safe
+and requoting is enabled -- by :user:`joaogabriel15`.

--- a/tests/test_quoting.py
+++ b/tests/test_quoting.py
@@ -200,6 +200,23 @@ def test_default_quoting_percent(quoter: type[_Quoter]) -> None:
     assert "%2525" == result
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("%41", "A"),
+        ("%4a", "J"),
+        ("%", "%25"),
+        ("%zz", "%25zz"),
+        ("%25", "%"),
+        ("%2f%2F", "%2F%2F"),
+    ],
+)
+def test_requoting_percent_when_percent_is_safe(
+    value: str, expected: str, quoter: type[_Quoter]
+) -> None:
+    assert quoter(safe="%", requote=True)(value) == expected
+
+
 def test_default_quoting_partial(quoter: type[_Quoter]) -> None:
     partial_quote = "ab[]cd"
     expected = "ab%5B%5Dcd"

--- a/yarl/_quoting_c.pyx
+++ b/yarl/_quoting_c.pyx
@@ -82,6 +82,10 @@ cdef inline void set_bit(uint8_t array[], uint64_t ch) noexcept:
     array[ch >> 3] |= (1 << (ch & 7))
 
 
+cdef inline void unset_bit(uint8_t array[], uint64_t ch) noexcept:
+    array[ch >> 3] &= ~(1 << (ch & 7))
+
+
 memset(ALLOWED_TABLE, 0, sizeof(ALLOWED_TABLE))
 memset(ALLOWED_NOTQS_TABLE, 0, sizeof(ALLOWED_NOTQS_TABLE))
 
@@ -197,6 +201,7 @@ cdef class _Quoter:
 
     cdef uint8_t _safe_table[16]
     cdef uint8_t _protected_table[16]
+    cdef bint _safe_percent
 
     def __init__(
             self, *, str safe='', str protected='', bint qs=False, bint requote=True,
@@ -226,6 +231,12 @@ cdef class _Quoter:
             set_bit(self._safe_table, ch)
             set_bit(self._protected_table, ch)
 
+        self._safe_percent = (
+            self._requote and bit_at(self._safe_table, c'%')
+        )
+        if self._safe_percent:
+            unset_bit(self._safe_table, c'%')
+
     def __call__(self, val):
         if val is None:
             return None
@@ -247,8 +258,9 @@ cdef class _Quoter:
         cdef int kind = PyUnicode_KIND(val)
         cdef const void *data = PyUnicode_DATA(val)
 
-        # If everything in the string is in the safe
-        # table and all ASCII, we can skip quoting
+        # If everything in the string is in the safe table and all ASCII,
+        # we can skip quoting. Percent is removed from the table when it is
+        # safe and requoting is enabled because it may introduce an escape.
         while idx:
             idx -= 1
             ch = PyUnicode_READ(kind, data, idx)
@@ -309,7 +321,10 @@ cdef class _Quoter:
                                 raise
                             continue
 
-                        if bit_at(self._safe_table, ch):
+                        if (
+                            bit_at(self._safe_table, ch)
+                            or (ch == c'%' and self._safe_percent)
+                        ):
                             if _write_char(writer, ch, True) < 0:
                                 raise
                             continue

--- a/yarl/_quoting_py.py
+++ b/yarl/_quoting_py.py
@@ -32,6 +32,7 @@ class _Quoter:
         self._protected = protected
         self._qs = qs
         self._requote = requote
+        self._safe_percent = requote and ("%" in safe or "%" in protected)
 
     @overload
     def __call__(self, val: str) -> str: ...
@@ -52,6 +53,8 @@ class _Quoter:
         if not self._qs:
             safe += "+&=;"
         safe += self._protected
+        if self._safe_percent:
+            safe = safe.replace("%", "")
         bsafe = safe.encode("ascii")
         idx = 0
         while idx < len(bval):
@@ -79,7 +82,7 @@ class _Quoter:
 
                     if unquoted in self._protected:
                         ret.extend(pct)
-                    elif unquoted in safe:
+                    elif unquoted in safe or (unquoted == "%" and self._safe_percent):
                         ret.append(ord(unquoted))
                     else:
                         ret.extend(pct)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Ensure that the C quoting backend processes percent signs when requoting is
enabled, even when percent is included in the safe character set. This keeps
valid escape handling and invalid percent encoding consistent with the pure
Python backend.

## Are there changes in behavior for the user?

Yes. The C and Python quoting backends now return the same result for
``_Quoter(safe="%", requote=True)``. Valid escapes are normalized or decoded
according to the safe set, and invalid escapes are encoded as literal percent
signs.

## Is it a substantial burden for the maintainers to support this?

No. The change only corrects the C backend fast path and adds parity tests. It
does not add a public API or a dependency.

## Related issue number

Fixes #1869

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
