### PR TITLE
Skip Pydantic 1 integration tests

### DIFF
--- a/CHANGES/1872.contrib.rst
+++ b/CHANGES/1872.contrib.rst
@@ -1,0 +1,2 @@
+Skipped the Pydantic integration tests when only Pydantic 1 is installed
+-- by :user:`ryux1`.

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -7,7 +7,7 @@ from yarl import URL
 if TYPE_CHECKING:
     import pydantic
 else:
-    pydantic = pytest.importorskip("pydantic")
+    pydantic = pytest.importorskip("pydantic", minversion="2.0")
 
 
 class TstModel(pydantic.BaseModel):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Require Pydantic 2 or newer before collecting the optional Pydantic integration tests. This skips tests for APIs that do not exist in Pydantic 1 and matches the integration test requirement.

## Are there changes in behavior for the user?

No. This only changes test collection when an unsupported Pydantic version is installed.

## Is it a substantial burden for the maintainers to support this?

No. The version gate is local to the optional integration test module.

## Related issue number

Fixes #1872

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes: N/A, test-only change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`: N/A, this repository has no such file
- [x] Add a new news fragment into the `CHANGES/` folder

Drafted with OpenAI Codex; personal review by the contributor remains required before the PR is marked ready.

<details>
<summary>Agent run details</summary>

- Pydantic 1.10.20: integration module skipped
- Pydantic 2.13.5: 6 integration tests passed
- Full suite: 1,623 passed, 4 expected xfails, 99.72% coverage
- Pre-commit source checks passed; its MyPy report wrapper stopped because `lxml` is missing from the hook environment
- Hosted CI: all 57 checks passed on the submitted commit

</details>
